### PR TITLE
feat: add missing English translations for Gemini API keys and other UI elements

### DIFF
--- a/app.js
+++ b/app.js
@@ -773,7 +773,7 @@ class CLIProxyManager {
             // 更新按钮提示文本
             const toggleBtn = document.getElementById('sidebar-toggle-btn-desktop');
             if (toggleBtn) {
-                toggleBtn.setAttribute('title', isCollapsed ? '展开侧边栏' : '收起侧边栏');
+                toggleBtn.setAttribute('title', isCollapsed ? t('sidebar.expand') : t('sidebar.collapse'));
             }
         }
     }
@@ -794,7 +794,7 @@ class CLIProxyManager {
                     // 更新按钮提示文本
                     const toggleBtn = document.getElementById('sidebar-toggle-btn-desktop');
                     if (toggleBtn) {
-                        toggleBtn.setAttribute('title', '展开侧边栏');
+                        toggleBtn.setAttribute('title', t('sidebar.expand'));
                     }
                 }
             }
@@ -1564,14 +1564,14 @@ class CLIProxyManager {
         const modalBody = document.getElementById('modal-body');
 
         modalBody.innerHTML = `
-            <h3>添加Gemini API密钥</h3>
+            <h3>\${t('gemini.add_modal_title')}</h3>
             <div class="form-group">
-                <label for="new-gemini-key">API密钥:</label>
-                <input type="text" id="new-gemini-key" placeholder="请输入Gemini API密钥">
+                <label for="new-gemini-key">\${t('gemini.add_modal_key_label')}</label>
+                <input type="text" id="new-gemini-key" placeholder="\${t('gemini.add_modal_key_placeholder')}">
             </div>
             <div class="modal-actions">
-                <button class="btn btn-secondary" onclick="manager.closeModal()">取消</button>
-                <button class="btn btn-primary" onclick="manager.addGeminiKey()">添加</button>
+                <button class="btn btn-secondary" onclick="manager.closeModal()">\${t('gemini.add_modal_cancel')}</button>
+                <button class="btn btn-primary" onclick="manager.addGeminiKey()">\${t('gemini.add_modal_add')}</button>
             </div>
         `;
 
@@ -1583,7 +1583,7 @@ class CLIProxyManager {
         const newKey = document.getElementById('new-gemini-key').value.trim();
 
         if (!newKey) {
-            this.showNotification('请输入Gemini API密钥', 'error');
+            this.showNotification(t('gemini.add_modal_key_placeholder'), 'error');
             return;
         }
 
@@ -1600,9 +1600,9 @@ class CLIProxyManager {
             this.clearCache(); // 清除缓存
             this.closeModal();
             this.loadGeminiKeys();
-            this.showNotification('Gemini密钥添加成功', 'success');
+            this.showNotification(t('gemini.key_added_success'), 'success');
         } catch (error) {
-            this.showNotification(`添加Gemini密钥失败: ${error.message}`, 'error');
+            this.showNotification(t('gemini.key_add_failed', { message: error.message }), 'error');
         }
     }
 
@@ -1612,14 +1612,14 @@ class CLIProxyManager {
         const modalBody = document.getElementById('modal-body');
 
         modalBody.innerHTML = `
-            <h3>编辑Gemini API密钥</h3>
+            <h3>\${t('gemini.edit_modal_title')}</h3>
             <div class="form-group">
-                <label for="edit-gemini-key">API密钥:</label>
-                <input type="text" id="edit-gemini-key" value="${currentKey}">
+                <label for="edit-gemini-key">\${t('gemini.add_modal_key_label')}</label>
+                <input type="text" id="edit-gemini-key" value="\${currentKey}">
             </div>
             <div class="modal-actions">
-                <button class="btn btn-secondary" onclick="manager.closeModal()">取消</button>
-                <button class="btn btn-primary" onclick="manager.updateGeminiKey('${currentKey}')">更新</button>
+                <button class="btn btn-secondary" onclick="manager.closeModal()">\${t('gemini.add_modal_cancel')}</button>
+                <button class="btn btn-primary" onclick="manager.updateGeminiKey('\${currentKey}')">\${t('gemini.edit_modal_update')}</button>
             </div>
         `;
 
@@ -1631,7 +1631,7 @@ class CLIProxyManager {
         const newKey = document.getElementById('edit-gemini-key').value.trim();
 
         if (!newKey) {
-            this.showNotification('请输入Gemini API密钥', 'error');
+            this.showNotification(t('gemini.edit_modal_key_placeholder'), 'error');
             return;
         }
 
@@ -1644,9 +1644,9 @@ class CLIProxyManager {
             this.clearCache(); // 清除缓存
             this.closeModal();
             this.loadGeminiKeys();
-            this.showNotification('Gemini密钥更新成功', 'success');
+            this.showNotification(t('gemini.key_updated_success'), 'success');
         } catch (error) {
-            this.showNotification(`更新Gemini密钥失败: ${error.message}`, 'error');
+            this.showNotification(t('gemini.key_update_failed', { message: error.message }), 'error');
         }
     }
 
@@ -1658,9 +1658,9 @@ class CLIProxyManager {
             await this.makeRequest(`/generative-language-api-key?value=${encodeURIComponent(key)}`, { method: 'DELETE' });
             this.clearCache(); // 清除缓存
             this.loadGeminiKeys();
-            this.showNotification('Gemini密钥删除成功', 'success');
+            this.showNotification(t('gemini.key_deleted_success'), 'success');
         } catch (error) {
-            this.showNotification(`删除Gemini密钥失败: ${error.message}`, 'error');
+            this.showNotification(t('gemini.key_delete_failed', { message: error.message }), 'error');
         }
     }
 
@@ -2437,26 +2437,26 @@ class CLIProxyManager {
         const inlineLabel = document.getElementById('gemini-web-label-input');
         const modalBody = document.getElementById('modal-body');
         modalBody.innerHTML = `
-            <h3>${i18n.t('auth_login.gemini_web_button')}</h3>
+            <h3>\${i18n.t('auth_login.gemini_web_button')}</h3>
             <div class="gemini-web-form">
                 <div class="form-group">
-                    <label for="modal-secure-1psid">${i18n.t('auth_login.secure_1psid_label')}</label>
-                    <input type="text" id="modal-secure-1psid" placeholder="${i18n.t('auth_login.secure_1psid_placeholder')}" required>
-                    <div class="form-hint">从浏览器开发者工具 → Application → Cookies 中获取</div>
+                    <label for="modal-secure-1psid">\${i18n.t('auth_login.secure_1psid_label')}</label>
+                    <input type="text" id="modal-secure-1psid" placeholder="\${i18n.t('auth_login.secure_1psid_placeholder')}" required>
+                    <div class="form-hint">\${t('gemini.form_hint_cookies')}</div>
                 </div>
                 <div class="form-group">
-                    <label for="modal-secure-1psidts">${i18n.t('auth_login.secure_1psidts_label')}</label>
-                    <input type="text" id="modal-secure-1psidts" placeholder="${i18n.t('auth_login.secure_1psidts_placeholder')}" required>
-                    <div class="form-hint">从浏览器开发者工具 → Application → Cookies 中获取</div>
+                    <label for="modal-secure-1psidts">\${i18n.t('auth_login.secure_1psidts_label')}</label>
+                    <input type="text" id="modal-secure-1psidts" placeholder="\${i18n.t('auth_login.secure_1psidts_placeholder')}" required>
+                    <div class="form-hint">\${t('gemini.form_hint_cookies')}</div>
                 </div>
                 <div class="form-group">
-                    <label for="modal-gemini-web-label">${i18n.t('auth_login.gemini_web_label_label')}</label>
-                    <input type="text" id="modal-gemini-web-label" placeholder="${i18n.t('auth_login.gemini_web_label_placeholder')}">
-                    <div class="form-hint">为此认证文件设置一个标签名称（可选）</div>
+                    <label for="modal-gemini-web-label">\${i18n.t('auth_login.gemini_web_label_label')}</label>
+                    <input type="text" id="modal-gemini-web-label" placeholder="\${i18n.t('auth_login.gemini_web_label_placeholder')}">
+                    <div class="form-hint">\${t('gemini.form_hint_label')}</div>
                 </div>
                 <div class="modal-actions">
-                    <button class="btn btn-secondary" onclick="manager.closeModal()">${i18n.t('common.cancel')}</button>
-                    <button class="btn btn-primary" onclick="manager.saveGeminiWebToken()">${i18n.t('common.save')}</button>
+                    <button class="btn btn-secondary" onclick="manager.closeModal()">\${i18n.t('common.cancel')}</button>
+                    <button class="btn btn-primary" onclick="manager.saveGeminiWebToken()">\${i18n.t('common.save')}</button>
                 </div>
             </div>
         `;
@@ -2488,7 +2488,7 @@ class CLIProxyManager {
         const label = document.getElementById('modal-gemini-web-label').value.trim();
 
         if (!secure1psid || !secure1psidts) {
-            this.showNotification('请填写完整的 Cookie 信息', 'error');
+            this.showNotification(t('gemini.full_cookie_required'), 'error');
             return;
         }
 
@@ -2527,7 +2527,7 @@ class CLIProxyManager {
             }
             this.showNotification(`${i18n.t('auth_login.gemini_web_saved')}: ${response.file}`, 'success');
         } catch (error) {
-            this.showNotification(`保存失败: ${error.message}`, 'error');
+            this.showNotification(`${i18n.t('common.error')}: ${error.message}`, 'error');
         }
     }
 
@@ -2589,12 +2589,12 @@ class CLIProxyManager {
         if (urlInput && urlInput.value) {
             try {
                 await navigator.clipboard.writeText(urlInput.value);
-                this.showNotification('链接已复制到剪贴板', 'success');
+                this.showNotification(t('gemini.link_copied'), 'success');
             } catch (error) {
                 // 降级方案：使用传统的复制方法
                 urlInput.select();
                 document.execCommand('copy');
-                this.showNotification('链接已复制到剪贴板', 'success');
+                this.showNotification(t('gemini.link_copied'), 'success');
             }
         }
     }
@@ -2734,12 +2734,12 @@ class CLIProxyManager {
         if (urlInput && urlInput.value) {
             try {
                 await navigator.clipboard.writeText(urlInput.value);
-                this.showNotification('链接已复制到剪贴板', 'success');
+                this.showNotification(t('gemini.link_copied'), 'success');
             } catch (error) {
                 // 降级方案：使用传统的复制方法
                 urlInput.select();
                 document.execCommand('copy');
-                this.showNotification('链接已复制到剪贴板', 'success');
+                this.showNotification(t('gemini.link_copied'), 'success');
             }
         }
     }
@@ -2888,12 +2888,12 @@ class CLIProxyManager {
         if (urlInput && urlInput.value) {
             try {
                 await navigator.clipboard.writeText(urlInput.value);
-                this.showNotification('链接已复制到剪贴板', 'success');
+                this.showNotification(t('gemini.link_copied'), 'success');
             } catch (error) {
                 // 降级方案：使用传统的复制方法
                 urlInput.select();
                 document.execCommand('copy');
-                this.showNotification('链接已复制到剪贴板', 'success');
+                this.showNotification(t('gemini.link_copied'), 'success');
             }
         }
     }
@@ -3033,12 +3033,12 @@ class CLIProxyManager {
         if (urlInput && urlInput.value) {
             try {
                 await navigator.clipboard.writeText(urlInput.value);
-                this.showNotification('链接已复制到剪贴板', 'success');
+                this.showNotification(t('gemini.link_copied'), 'success');
             } catch (error) {
                 // 降级方案：使用传统的复制方法
                 urlInput.select();
                 document.execCommand('copy');
-                this.showNotification('链接已复制到剪贴板', 'success');
+                this.showNotification(t('gemini.link_copied'), 'success');
             }
         }
     }
@@ -3178,12 +3178,12 @@ class CLIProxyManager {
         if (urlInput && urlInput.value) {
             try {
                 await navigator.clipboard.writeText(urlInput.value);
-                this.showNotification('链接已复制到剪贴板', 'success');
+                this.showNotification(t('gemini.link_copied'), 'success');
             } catch (error) {
                 // 降级方案：使用传统的复制方法
                 urlInput.select();
                 document.execCommand('copy');
-                this.showNotification('链接已复制到剪贴板', 'success');
+                this.showNotification(t('gemini.link_copied'), 'success');
             }
         }
     }
@@ -3591,7 +3591,7 @@ class CLIProxyManager {
                     modelsHtml += `
                         <div class="model-item">
                             <span class="model-name">${modelName}</span>
-                            <span>${modelRequests} 请求 / ${modelTokens} tokens</span>
+                            <span>\${t('usage_stats.requests_tokens', { requests: modelRequests, tokens: modelTokens })}</span>
                         </div>
                     `;
                 });

--- a/app.js
+++ b/app.js
@@ -1612,16 +1612,19 @@ class CLIProxyManager {
         const modalBody = document.getElementById('modal-body');
 
         modalBody.innerHTML = `
-            <h3>\${t('gemini.edit_modal_title')}</h3>
+            <h3>${t('gemini.edit_modal_title')}</h3>
             <div class="form-group">
-                <label for="edit-gemini-key">\${t('gemini.add_modal_key_label')}</label>
-                <input type="text" id="edit-gemini-key" value="\${currentKey}">
+                <label for="edit-gemini-key">${t('gemini.add_modal_key_label')}</label>
+                <input type="text" id="edit-gemini-key" value="${this.escapeHtml(currentKey)}">
             </div>
             <div class="modal-actions">
-                <button class="btn btn-secondary" onclick="manager.closeModal()">\${t('gemini.add_modal_cancel')}</button>
-                <button class="btn btn-primary" onclick="manager.updateGeminiKey('\${currentKey}')">\${t('gemini.edit_modal_update')}</button>
+                <button class="btn btn-secondary" id="edit-gemini-cancel-btn">${t('gemini.add_modal_cancel')}</button>
+                <button class="btn btn-primary" id="edit-gemini-update-btn">${t('gemini.edit_modal_update')}</button>
             </div>
         `;
+        
+        modal.querySelector('#edit-gemini-cancel-btn').onclick = () => this.closeModal();
+        modal.querySelector('#edit-gemini-update-btn').onclick = () => this.updateGeminiKey(currentKey);
 
         modal.style.display = 'block';
     }
@@ -2437,26 +2440,26 @@ class CLIProxyManager {
         const inlineLabel = document.getElementById('gemini-web-label-input');
         const modalBody = document.getElementById('modal-body');
         modalBody.innerHTML = `
-            <h3>\${i18n.t('auth_login.gemini_web_button')}</h3>
+            <h3>\${t('auth_login.gemini_web_button')}</h3>
             <div class="gemini-web-form">
                 <div class="form-group">
-                    <label for="modal-secure-1psid">\${i18n.t('auth_login.secure_1psid_label')}</label>
-                    <input type="text" id="modal-secure-1psid" placeholder="\${i18n.t('auth_login.secure_1psid_placeholder')}" required>
+                    <label for="modal-secure-1psid">\${t('auth_login.secure_1psid_label')}</label>
+                    <input type="text" id="modal-secure-1psid" placeholder="\${t('auth_login.secure_1psid_placeholder')}" required>
                     <div class="form-hint">\${t('gemini.form_hint_cookies')}</div>
                 </div>
                 <div class="form-group">
-                    <label for="modal-secure-1psidts">\${i18n.t('auth_login.secure_1psidts_label')}</label>
-                    <input type="text" id="modal-secure-1psidts" placeholder="\${i18n.t('auth_login.secure_1psidts_placeholder')}" required>
+                    <label for="modal-secure-1psidts">\${t('auth_login.secure_1psidts_label')}</label>
+                    <input type="text" id="modal-secure-1psidts" placeholder="\${t('auth_login.secure_1psidts_placeholder')}" required>
                     <div class="form-hint">\${t('gemini.form_hint_cookies')}</div>
                 </div>
                 <div class="form-group">
-                    <label for="modal-gemini-web-label">\${i18n.t('auth_login.gemini_web_label_label')}</label>
-                    <input type="text" id="modal-gemini-web-label" placeholder="\${i18n.t('auth_login.gemini_web_label_placeholder')}">
+                    <label for="modal-gemini-web-label">\${t('auth_login.gemini_web_label_label')}</label>
+                    <input type="text" id="modal-gemini-web-label" placeholder="\${t('auth_login.gemini_web_label_placeholder')}">
                     <div class="form-hint">\${t('gemini.form_hint_label')}</div>
                 </div>
                 <div class="modal-actions">
-                    <button class="btn btn-secondary" onclick="manager.closeModal()">\${i18n.t('common.cancel')}</button>
-                    <button class="btn btn-primary" onclick="manager.saveGeminiWebToken()">\${i18n.t('common.save')}</button>
+                    <button class="btn btn-secondary" onclick="manager.closeModal()">\${t('common.cancel')}</button>
+                    <button class="btn btn-primary" onclick="manager.saveGeminiWebToken()">\${t('common.save')}</button>
                 </div>
             </div>
         `;
@@ -2589,12 +2592,12 @@ class CLIProxyManager {
         if (urlInput && urlInput.value) {
             try {
                 await navigator.clipboard.writeText(urlInput.value);
-                this.showNotification(t('gemini.link_copied'), 'success');
+                this.showNotification(t('common.link_copied'), 'success');
             } catch (error) {
                 // 降级方案：使用传统的复制方法
                 urlInput.select();
                 document.execCommand('copy');
-                this.showNotification(t('gemini.link_copied'), 'success');
+                this.showNotification(t('common.link_copied'), 'success');
             }
         }
     }
@@ -2734,12 +2737,12 @@ class CLIProxyManager {
         if (urlInput && urlInput.value) {
             try {
                 await navigator.clipboard.writeText(urlInput.value);
-                this.showNotification(t('gemini.link_copied'), 'success');
+                this.showNotification(t('common.link_copied'), 'success');
             } catch (error) {
                 // 降级方案：使用传统的复制方法
                 urlInput.select();
                 document.execCommand('copy');
-                this.showNotification(t('gemini.link_copied'), 'success');
+                this.showNotification(t('common.link_copied'), 'success');
             }
         }
     }
@@ -2888,12 +2891,12 @@ class CLIProxyManager {
         if (urlInput && urlInput.value) {
             try {
                 await navigator.clipboard.writeText(urlInput.value);
-                this.showNotification(t('gemini.link_copied'), 'success');
+                this.showNotification(t('common.link_copied'), 'success');
             } catch (error) {
                 // 降级方案：使用传统的复制方法
                 urlInput.select();
                 document.execCommand('copy');
-                this.showNotification(t('gemini.link_copied'), 'success');
+                this.showNotification(t('common.link_copied'), 'success');
             }
         }
     }
@@ -3033,12 +3036,12 @@ class CLIProxyManager {
         if (urlInput && urlInput.value) {
             try {
                 await navigator.clipboard.writeText(urlInput.value);
-                this.showNotification(t('gemini.link_copied'), 'success');
+                this.showNotification(t('common.link_copied'), 'success');
             } catch (error) {
                 // 降级方案：使用传统的复制方法
                 urlInput.select();
                 document.execCommand('copy');
-                this.showNotification(t('gemini.link_copied'), 'success');
+                this.showNotification(t('common.link_copied'), 'success');
             }
         }
     }
@@ -3178,12 +3181,12 @@ class CLIProxyManager {
         if (urlInput && urlInput.value) {
             try {
                 await navigator.clipboard.writeText(urlInput.value);
-                this.showNotification(t('gemini.link_copied'), 'success');
+                this.showNotification(t('common.link_copied'), 'success');
             } catch (error) {
                 // 降级方案：使用传统的复制方法
                 urlInput.select();
                 document.execCommand('copy');
-                this.showNotification(t('gemini.link_copied'), 'success');
+                this.showNotification(t('common.link_copied'), 'success');
             }
         }
     }
@@ -3591,7 +3594,7 @@ class CLIProxyManager {
                     modelsHtml += `
                         <div class="model-item">
                             <span class="model-name">${modelName}</span>
-                            <span>\${t('usage_stats.requests_tokens', { requests: modelRequests, tokens: modelTokens })}</span>
+                            <span>${t('usage_stats.requests_tokens', { requests: modelRequests, tokens: modelTokens })}</span>
                         </div>
                     `;
                 });

--- a/i18n.js
+++ b/i18n.js
@@ -38,6 +38,7 @@ const i18n = {
             'common.base_url': '地址',
             'common.proxy_url': '代理',
             'common.alias': '别名',
+            'common.link_copied': '链接已复制到剪贴板',
 
             // 页面标题
             'title.main': 'CLI Proxy API Management Center',
@@ -153,7 +154,7 @@ const i18n = {
             'sidebar.collapse': '收起侧边栏',
             
             // Usage statistics
-            'usage_stats.requests_tokens': ' requests / {tokens} tokens',
+            'usage_stats.requests_tokens': '{requests} 请求 / {tokens} tokens',
 
             'ai_providers.codex_title': 'Codex API 配置',
             'ai_providers.codex_add_button': '添加配置',
@@ -444,6 +445,7 @@ const i18n = {
             'common.base_url': 'Address',
             'common.proxy_url': 'Proxy',
             'common.alias': 'Alias',
+            'common.link_copied': 'Link copied to clipboard',
 
             // Page titles
             'title.main': 'CLI Proxy API Management Center',

--- a/i18n.js
+++ b/i18n.js
@@ -127,6 +127,33 @@ const i18n = {
             'ai_providers.gemini_edit_modal_title': '编辑Gemini API密钥',
             'ai_providers.gemini_edit_modal_key_label': 'API密钥:',
             'ai_providers.gemini_delete_confirm': '确定要删除这个Gemini密钥吗？',
+            
+            // Gemini API modals and forms
+            'gemini.add_modal_title': '添加Gemini API密钥',
+            'gemini.add_modal_key_label': 'API密钥:',
+            'gemini.add_modal_key_placeholder': '请输入Gemini API密钥',
+            'gemini.add_modal_cancel': '取消',
+            'gemini.add_modal_add': '添加',
+            'gemini.edit_modal_title': '编辑Gemini API密钥',
+            'gemini.edit_modal_update': '更新',
+            'gemini.edit_modal_key_placeholder': '请输入Gemini API密钥',
+            'gemini.form_hint_cookies': '从浏览器开发者工具 → Application → Cookies 中获取',
+            'gemini.form_hint_label': '为此认证文件设置一个标签名称（可选）',
+            'gemini.full_cookie_required': '请填写完整的 Cookie 信息',
+            'gemini.link_copied': '链接已复制到剪贴板',
+            'gemini.key_added_success': 'Gemini密钥添加成功',
+            'gemini.key_add_failed': '添加Gemini密钥失败: {message}',
+            'gemini.key_updated_success': 'Gemini密钥更新成功',
+            'gemini.key_update_failed': '更新Gemini密钥失败: {message}',
+            'gemini.key_deleted_success': 'Gemini密钥删除成功',
+            'gemini.key_delete_failed': '删除Gemini密钥失败: {message}',
+            
+            // Sidebar
+            'sidebar.expand': '展开侧边栏',
+            'sidebar.collapse': '收起侧边栏',
+            
+            // Usage statistics
+            'usage_stats.requests_tokens': ' requests / {tokens} tokens',
 
             'ai_providers.codex_title': 'Codex API 配置',
             'ai_providers.codex_add_button': '添加配置',
@@ -506,6 +533,33 @@ const i18n = {
             'ai_providers.gemini_edit_modal_title': 'Edit Gemini API Key',
             'ai_providers.gemini_edit_modal_key_label': 'API Key:',
             'ai_providers.gemini_delete_confirm': 'Are you sure you want to delete this Gemini key?',
+            
+            // Gemini API modals and forms
+            'gemini.add_modal_title': 'Add Gemini API Key',
+            'gemini.add_modal_key_label': 'API Key:',
+            'gemini.add_modal_key_placeholder': 'Please enter Gemini API key',
+            'gemini.add_modal_cancel': 'Cancel',
+            'gemini.add_modal_add': 'Add',
+            'gemini.edit_modal_title': 'Edit Gemini API Key',
+            'gemini.edit_modal_update': 'Update',
+            'gemini.edit_modal_key_placeholder': 'Please enter Gemini API key',
+            'gemini.form_hint_cookies': 'Obtain from browser developer tools → Application → Cookies',
+            'gemini.form_hint_label': 'Set a label name for this auth file (optional)',
+            'gemini.full_cookie_required': 'Please fill in complete Cookie information',
+            'gemini.link_copied': 'Link copied to clipboard',
+            'gemini.key_added_success': 'Gemini key added successfully',
+            'gemini.key_add_failed': 'Failed to add Gemini key: {message}',
+            'gemini.key_updated_success': 'Gemini key updated successfully',
+            'gemini.key_update_failed': 'Failed to update Gemini key: {message}',
+            'gemini.key_deleted_success': 'Gemini key deleted successfully',
+            'gemini.key_delete_failed': 'Failed to delete Gemini key: {message}',
+            
+            // Sidebar
+            'sidebar.expand': 'Expand sidebar',
+            'sidebar.collapse': 'Collapse sidebar',
+            
+            // Usage statistics
+            'usage_stats.requests_tokens': '{requests} requests / {tokens} tokens',
 
             'ai_providers.codex_title': 'Codex API Configuration',
             'ai_providers.codex_add_button': 'Add Configuration',


### PR DESCRIPTION
This PR adds missing English translations for Gemini API keys and other UI elements that were previously hardcoded in Chinese.

Changes include:
- Add new translation keys for Gemini API modals, forms, and notifications
- Update app.js to use i18n translation keys instead of hardcoded Chinese text
- Add translations for OAuth copy link notifications
- Add translations for sidebar toggle functionality
- Add translations for usage statistics text