### PR TITLE
Fixing abnormal export

### DIFF
--- a/app.js
+++ b/app.js
@@ -721,4 +721,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
     setupSiteLogo();
     manager = new CLIProxyManager();
+    // Expose manager globally for inline onclick handlers
+    window.manager = manager;
 });


### PR DESCRIPTION
当我使用 npm start 启动到本地后，前端编辑 API 密钥报错

<img width="861" height="283" alt="image" src="https://github.com/user-attachments/assets/b95f91b9-da9c-48fd-8208-a13e0d6255e5" />

应用在 app.js 修复问题被解决

<img width="458" height="197" alt="image" src="https://github.com/user-attachments/assets/ed30b19c-b17b-4468-a691-a3fefc0d7976" />
