### PR TITLE
fix(antigravity): 修复免费账户额度显示问题

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -407,7 +407,8 @@
     "missing_auth_index": "Auth file missing auth_index",
     "empty_models": "No quota data available",
     "refresh_button": "Refresh Quota",
-    "fetch_all": "Fetch All"
+    "fetch_all": "Fetch All",
+    "project_id_fetch_failed": "Failed to fetch Project ID, using default"
   },
   "codex_quota": {
     "title": "Codex Quota",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -407,7 +407,8 @@
     "missing_auth_index": "认证文件缺少 auth_index",
     "empty_models": "暂无额度数据",
     "refresh_button": "刷新额度",
-    "fetch_all": "获取全部"
+    "fetch_all": "获取全部",
+    "project_id_fetch_failed": "获取 Project ID 失败，使用默认值"
   },
   "codex_quota": {
     "title": "Codex 额度",

--- a/src/types/quota.ts
+++ b/src/types/quota.ts
@@ -43,6 +43,23 @@ export interface AntigravityQuotaInfo {
   };
 }
 
+// loadCodeAssist API 响应类型
+export interface AntigravityLoadCodeAssistPayload {
+  cloudaicompanionProject?: string;
+  currentTier?: {
+    id?: string;
+    quotaTier?: string;
+    name?: string;
+    slug?: string;
+  };
+  paidTier?: {
+    id?: string;
+    quotaTier?: string;
+    name?: string;
+    slug?: string;
+  };
+}
+
 export type AntigravityModelsPayload = Record<string, AntigravityQuotaInfo>;
 
 export interface AntigravityQuotaGroupDefinition {

--- a/src/utils/quota/constants.ts
+++ b/src/utils/quota/constants.ts
@@ -65,6 +65,10 @@ export const ANTIGRAVITY_REQUEST_HEADERS = {
   'User-Agent': 'antigravity/1.11.5 windows/amd64'
 };
 
+// Antigravity Project ID 获取端点
+export const ANTIGRAVITY_LOAD_CODE_ASSIST_URL =
+  'https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist';
+
 export const ANTIGRAVITY_QUOTA_GROUPS: AntigravityQuotaGroupDefinition[] = [
   {
     id: 'claude-gpt',

--- a/src/utils/quota/index.ts
+++ b/src/utils/quota/index.ts
@@ -8,3 +8,4 @@ export * from './resolvers';
 export * from './formatters';
 export * from './validators';
 export * from './builders';
+export * from './projectIdCache';

--- a/src/utils/quota/projectIdCache.ts
+++ b/src/utils/quota/projectIdCache.ts
@@ -1,0 +1,61 @@
+/**
+ * Antigravity Project ID 内存缓存
+ * 仅在页面生命周期内有效,刷新后需重新获取
+ */
+
+interface ProjectIdCacheEntry {
+  projectId: string;
+  timestamp: number;
+  authIndex: string;
+}
+
+const cache = new Map<string, ProjectIdCacheEntry>();
+const CACHE_KEY_PREFIX = 'antigravity_project_id';
+const CACHE_DURATION = 24 * 60 * 60 * 1000; // 24小时
+
+function buildCacheKey(authIndex: string): string {
+  return `${CACHE_KEY_PREFIX}_${authIndex}`;
+}
+
+/**
+ * 从缓存获取 project_id
+ */
+export function getProjectId(authIndex: string): string | null {
+  const key = buildCacheKey(authIndex);
+  const entry = cache.get(key);
+
+  if (!entry) return null;
+
+  if (Date.now() - entry.timestamp > CACHE_DURATION) {
+    cache.delete(key);
+    return null;
+  }
+
+  return entry.projectId;
+}
+
+/**
+ * 缓存 project_id
+ */
+export function setProjectId(authIndex: string, projectId: string): void {
+  const key = buildCacheKey(authIndex);
+  cache.set(key, {
+    projectId,
+    timestamp: Date.now(),
+    authIndex
+  });
+}
+
+/**
+ * 清除指定账户的缓存
+ */
+export function clearProjectId(authIndex: string): void {
+  cache.delete(buildCacheKey(authIndex));
+}
+
+/**
+ * 清空所有缓存
+ */
+export function clearAllProjectIds(): void {
+  cache.clear();
+}

--- a/src/utils/quota/resolvers.ts
+++ b/src/utils/quota/resolvers.ts
@@ -110,3 +110,46 @@ export function resolveGeminiCliProjectId(file: AuthFileItem): string | null {
 
   return null;
 }
+
+/**
+ * 从 Antigravity 认证文件中提取 project_id
+ * 支持从 metadata/attributes/project_id 等多个位置读取
+ */
+export function extractAntigravityProjectId(value: unknown): string | null {
+  if (typeof value === 'string' && value.trim()) {
+    return value.trim();
+  }
+  return null;
+}
+
+/**
+ * 解析 Antigravity 认证文件的 project_id
+ */
+export function resolveAntigravityProjectId(file: AuthFileItem): string | null {
+  const metadata =
+    file && typeof file.metadata === 'object' && file.metadata !== null
+      ? (file.metadata as Record<string, unknown>)
+      : null;
+  const attributes =
+    file && typeof file.attributes === 'object' && file.attributes !== null
+      ? (file.attributes as Record<string, unknown>)
+      : null;
+
+  const candidates = [
+    file.project_id,
+    file.projectId,
+    file['project_id'],
+    file['projectId'],
+    metadata?.project_id,
+    metadata?.projectId,
+    attributes?.project_id,
+    attributes?.projectId
+  ];
+
+  for (const candidate of candidates) {
+    const projectId = extractAntigravityProjectId(candidate);
+    if (projectId) return projectId;
+  }
+
+  return null;
+}


### PR DESCRIPTION
实现两步查询流程以正确获取 Antigravity 免费账户额度：

1. 添加 loadCodeAssist API 调用获取 project_id
2. 使用 project_id 作为 payload 查询额度 API
3. 实现 project_id 内存缓存机制（24小时有效期）
4. 添加从认证文件解析 project_id 的工具函数

核心修改：
- 新建 src/utils/quota/projectIdCache.ts 缓存模块
- 重构 fetchAntigravityQuota 函数实现两步查询
- 修改请求体从空对象改为 {project: projectId}
- 添加相关类型定义和翻译文案

参考 Antigravity-Manager 项目的成熟实现方案。