### PR TITLE
Fix OpenAI test endpoint to preserve /v1 base path

### DIFF
--- a/src/components/providers/utils.ts
+++ b/src/components/providers/utils.ts
@@ -55,9 +55,6 @@ export const buildOpenAIChatCompletionsEndpoint = (baseUrl: string): string => {
   if (trimmed.endsWith('/chat/completions')) {
     return trimmed;
   }
-  if (trimmed.endsWith('/v1')) {
-    return `${trimmed.slice(0, -3)}/chat/completions`;
-  }
   return `${trimmed}/chat/completions`;
 };
 


### PR DESCRIPTION
### Motivation
- The OpenAI provider test logic removed a trailing `/v1` from the configured Base URL, which caused test requests to target the wrong path and return 404 instead of appending the request path to the user-provided URL.

### Description
- Removed the special-case branch in `buildOpenAIChatCompletionsEndpoint` so it no longer strips `/v1` and now always appends `/chat/completions` to the normalized base URL in `src/components/providers/utils.ts`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697b4a27a38c8327a83b5958ef68469d)