### PR TITLE
Remove blue focus ring from Logs page tabs

### DIFF
--- a/src/pages/LogsPage.module.scss
+++ b/src/pages/LogsPage.module.scss
@@ -44,6 +44,11 @@
   &:hover {
     color: var(--text-primary);
   }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: none;
+  }
 }
 
 .tabActive {


### PR DESCRIPTION
### Motivation
- The focus outline on the Logs page tab buttons produced an unwanted blue ring when switching tabs and should be removed for a cleaner UI.

### Description
- Remove the `:focus-visible` outline and box-shadow on `.tabItem` in `src/pages/LogsPage.module.scss` so tab buttons no longer show the blue focus ring.

### Testing
- Started the dev server with `npm run dev` and ran a Playwright script that opened `/logs` and captured a screenshot to confirm the focus ring is gone, and both steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697b4c55b5d483278a6f95a8bef8180d)