### PR TITLE
feat: add per-account excluded_models & priority UI to auth file editor

### DIFF
--- a/src/pages/AuthFilesPage.tsx
+++ b/src/pages/AuthFilesPage.tsx
@@ -421,7 +421,7 @@ export function AuthFilesPage() {
       .split('\n')
       .map(s => s.trim())
       .filter(Boolean);
-    if ('excluded_models' in next || excludedLines.length > 0) {
+    if (excludedLines.length > 0) {
       next.excluded_models = excludedLines;
     } else {
       delete next.excluded_models;
@@ -934,10 +934,7 @@ export function AuthFilesPage() {
   const handlePrefixProxyChange = (field: 'prefix' | 'proxyUrl' | 'excludedModels' | 'priority', value: string) => {
     setPrefixProxyEditor((prev) => {
       if (!prev) return prev;
-      if (field === 'prefix') return { ...prev, prefix: value };
-      if (field === 'proxyUrl') return { ...prev, proxyUrl: value };
-      if (field === 'excludedModels') return { ...prev, excludedModels: value };
-      return { ...prev, priority: value };
+      return { ...prev, [field]: value };
     });
   };
 


### PR DESCRIPTION
# PR: Add Per-Account `excluded_models` and `priority` to Auth File Editor

## Summary

This PR adds two new per-account configuration fields to the prefix/proxy_url editor modal in the Auth Files management page:

1. **Excluded Models** (`excluded_models`) — A textarea allowing users to specify model names (one per line) that should be excluded from this specific auth file.
2. **Priority** (`priority`) — A numeric input for setting the priority of the auth file (higher value = higher priority, default: 0).

## Changes

### File Modified
- `src/pages/AuthFilesPage.tsx`

### What Changed

#### 1. `PrefixProxyEditorState` Interface
Added two new fields:
- `excludedModels: string` — newline-separated model names for UI binding
- `priority: string` — priority number as string for input binding

#### 2. State Initialization (`openPrefixProxyEditor`)
- Empty state now initializes `excludedModels: ''` and `priority: ''`
- JSON parsing extracts `excluded_models` (array → newline-joined string) and `priority` (number → string)

#### 3. JSON Serialization (`prefixProxyUpdatedText` useMemo)
- Builds `excluded_models` array from newline-separated textarea value; omits field when empty
- Builds `priority` as integer from string input; omits field when empty
- Added `excludedModels` and `priority` to the useMemo dependency array

#### 4. Change Handler (`handlePrefixProxyChange`)
Extended type signature to accept `'excludedModels' | 'priority'` in addition to existing fields.

#### 5. Modal UI
Added after the existing prefix/proxy_url inputs:
- A `<textarea>` for entering excluded model names (one per line), using existing `styles.prefixProxyTextarea` CSS class
- An `<Input type="number">` for setting priority

## Behavior

| Field | Empty Value | Populated Value |
|-------|------------|-----------------|
| `excluded_models` | Omitted from JSON | Serialized as `string[]` |
| `priority` | Omitted from JSON | Serialized as `number` (integer) |

## Labels
- English hardcoded strings (i18n-ready for future localization)
- No new CSS classes needed (reuses existing `prefixProxyFields`, `prefixProxyLabel`, `prefixProxyTextarea` styles)

## Testing Checklist
- [ ] Empty `excluded_models` → field omitted from saved JSON
- [ ] Populated `excluded_models` → saved as `["model-a", "model-b"]`
- [ ] Empty `priority` → field omitted from saved JSON
- [ ] Populated `priority` → saved as integer (e.g., `5`)
- [ ] Existing JSON fields preserved after save
- [ ] Dirty detection works correctly with new fields
- [ ] Fields properly disabled when not connected / saving / invalid JSON
