### PR TITLE
fix(auth): clear usage stats store on logout

### DIFF
--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -10,6 +10,7 @@ import { STORAGE_KEY_AUTH } from '@/utils/constants';
 import { secureStorage } from '@/services/storage/secureStorage';
 import { apiClient } from '@/services/api/client';
 import { useConfigStore } from './useConfigStore';
+import { useUsageStatsStore } from './useUsageStatsStore';
 import { detectApiBaseFromLocation, normalizeApiBase } from '@/utils/connection';
 
 interface AuthStoreState extends AuthState {
@@ -136,6 +137,7 @@ export const useAuthStore = create<AuthStoreState>()(
       logout: () => {
         restoreSessionPromise = null;
         useConfigStore.getState().clearCache();
+        useUsageStatsStore.getState().clearUsageStats();
         set({
           isAuthenticated: false,
           apiBase: '',


### PR DESCRIPTION
### Motivation
- Prevent sensitive usage snapshots and details cached in the shared `useUsageStatsStore` from remaining accessible in memory after a user logs out.

### Description
- Add an import for `useUsageStatsStore` and invoke `useUsageStatsStore.getState().clearUsageStats()` inside `logout()` in `src/stores/useAuthStore.ts` so the global usage cache is wiped on sign-out.

### Testing
- Ran `npm run type-check`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ae570723008332a444a0c641e3f347)