### PR TITLE
fix(authFiles): 统一 Codex 认证文件的 websockets 字段

### DIFF
--- a/src/features/authFiles/components/AuthFilesPrefixProxyEditorModal.tsx
+++ b/src/features/authFiles/components/AuthFilesPrefixProxyEditorModal.tsx
@@ -126,10 +126,10 @@ export function AuthFilesPrefixProxyEditorModal(props: AuthFilesPrefixProxyEdito
                   <div className="form-group">
                     <label>{t('ai_providers.codex_websockets_label')}</label>
                     <ToggleSwitch
-                      checked={Boolean(editor.websocket)}
+                      checked={Boolean(editor.websockets)}
                       disabled={disableControls || editor.saving || !editor.json}
                       ariaLabel={t('ai_providers.codex_websockets_label')}
-                      onChange={(value) => onChange('websocket', value)}
+                      onChange={(value) => onChange('websockets', value)}
                     />
                     <div className="hint">{t('ai_providers.codex_websockets_hint')}</div>
                   </div>

--- a/src/features/authFiles/constants.ts
+++ b/src/features/authFiles/constants.ts
@@ -160,6 +160,19 @@ export const parseDisableCoolingValue = (value: unknown): boolean | undefined =>
   return undefined;
 };
 
+export const readCodexAuthFileWebsockets = (value: Record<string, unknown>): boolean =>
+  parseDisableCoolingValue(value.websockets) ?? false;
+
+export const applyCodexAuthFileWebsockets = (
+  value: Record<string, unknown>,
+  websockets: boolean
+): Record<string, unknown> => {
+  const next = { ...value };
+  delete next.websocket;
+  next.websockets = websockets;
+  return next;
+};
+
 export function isRuntimeOnlyAuthFile(file: AuthFileItem): boolean {
   const raw = file['runtime_only'] ?? file.runtimeOnly;
   if (typeof raw === 'boolean') return raw;

--- a/src/features/authFiles/hooks/useAuthFilesPrefixProxyEditor.ts
+++ b/src/features/authFiles/hooks/useAuthFilesPrefixProxyEditor.ts
@@ -6,10 +6,12 @@ import { useNotificationStore } from '@/stores';
 import { formatFileSize } from '@/utils/format';
 import { MAX_AUTH_FILE_SIZE } from '@/utils/constants';
 import {
+  applyCodexAuthFileWebsockets,
   normalizeExcludedModels,
   parseDisableCoolingValue,
   parseExcludedModelsText,
   parsePriorityValue,
+  readCodexAuthFileWebsockets,
 } from '@/features/authFiles/constants';
 
 export type PrefixProxyEditorField =
@@ -18,7 +20,7 @@ export type PrefixProxyEditorField =
   | 'priority'
   | 'excludedModelsText'
   | 'disableCooling'
-  | 'websocket'
+  | 'websockets'
   | 'note';
 
 export type PrefixProxyEditorFieldValue = string | boolean;
@@ -37,7 +39,7 @@ export type PrefixProxyEditorState = {
   priority: string;
   excludedModelsText: string;
   disableCooling: string;
-  websocket: boolean;
+  websockets: boolean;
   note: string;
   noteTouched: boolean;
 };
@@ -92,10 +94,6 @@ const buildPrefixProxyUpdatedText = (editor: PrefixProxyEditorState | null): str
     delete next.disable_cooling;
   }
 
-  if (editor.isCodexFile) {
-    next.websocket = editor.websocket;
-  }
-
   if (editor.noteTouched) {
     const noteValue = editor.note.trim();
     if (noteValue) {
@@ -105,7 +103,9 @@ const buildPrefixProxyUpdatedText = (editor: PrefixProxyEditorState | null): str
     }
   }
 
-  return JSON.stringify(next);
+  return JSON.stringify(
+    editor.isCodexFile ? applyCodexAuthFileWebsockets(next, editor.websockets) : next
+  );
 };
 
 export function useAuthFilesPrefixProxyEditor(
@@ -157,7 +157,7 @@ export function useAuthFilesPrefixProxyEditor(
       priority: '',
       excludedModelsText: '',
       disableCooling: '',
-      websocket: false,
+      websockets: false,
       note: '',
       noteTouched: false,
     });
@@ -199,8 +199,9 @@ export function useAuthFilesPrefixProxyEditor(
 
       const json = { ...(parsed as Record<string, unknown>) };
       if (isCodexFile) {
-        const websocketValue = parseDisableCoolingValue(json.websocket);
-        json.websocket = websocketValue ?? false;
+        const normalizedWebsockets = readCodexAuthFileWebsockets(json);
+        delete json.websocket;
+        json.websockets = normalizedWebsockets;
       }
       const originalText = JSON.stringify(json);
       const prefix = typeof json.prefix === 'string' ? json.prefix : '';
@@ -208,7 +209,7 @@ export function useAuthFilesPrefixProxyEditor(
       const priority = parsePriorityValue(json.priority);
       const excludedModels = normalizeExcludedModels(json.excluded_models);
       const disableCoolingValue = parseDisableCoolingValue(json.disable_cooling);
-      const websocketValue = parseDisableCoolingValue(json.websocket);
+      const websocketsValue = readCodexAuthFileWebsockets(json);
       const note = typeof json.note === 'string' ? json.note : '';
 
       setPrefixProxyEditor((prev) => {
@@ -225,7 +226,7 @@ export function useAuthFilesPrefixProxyEditor(
           excludedModelsText: excludedModels.join('\n'),
           disableCooling:
             disableCoolingValue === undefined ? '' : disableCoolingValue ? 'true' : 'false',
-          websocket: websocketValue ?? false,
+          websockets: websocketsValue,
           note,
           noteTouched: false,
           error: null,
@@ -253,7 +254,7 @@ export function useAuthFilesPrefixProxyEditor(
       if (field === 'excludedModelsText') return { ...prev, excludedModelsText: String(value) };
       if (field === 'disableCooling') return { ...prev, disableCooling: String(value) };
       if (field === 'note') return { ...prev, note: String(value), noteTouched: true };
-      return { ...prev, websocket: Boolean(value) };
+      return { ...prev, websockets: Boolean(value) };
     });
   };
 


### PR DESCRIPTION
## 背景

Auth Files 中的 Codex 认证文件编辑器此前使用的是 `websocket` 单数字段，但 CLIProxyAPI 实际读取的是 `websockets` 复数字段。
这会导致在 Web UI 中编辑 Codex 认证文件时，保存后的字段名与后端实际识别的字段不一致。

## 改动

- 将 Auth Files 中 Codex 认证文件编辑器的内部状态字段从 `websocket` 统一为 `websockets`
- 读取 Codex 认证文件时，仅根据 `websockets` 字段初始化开关状态
- 保存 Codex 认证文件时，只写回 `websockets` 字段
- 写回时移除遗留的 `websocket` 单数字段，避免同一文件中出现两套字段
- 同步更新 Codex 认证文件编辑弹窗中的开关绑定逻辑

## 影响范围

- 仅影响 Auth Files 中 Codex 认证文件的编辑逻辑
- 不涉及 AI Providers 页面中的 `codex-api-key` 配置逻辑
- 不涉及其他认证文件类型的读写逻辑

## 验证

- `npm run type-check`
- `npx eslint src/features/authFiles/constants.ts src/features/authFiles/hooks/useAuthFilesPrefixProxyEditor.ts src/features/authFiles/components/AuthFilesPrefixProxyEditorModal.tsx`

## 注意事项

- 历史上如果认证文件里只存在 `websocket` 单数字段，本次改动后将不再读取该字段
- 如需启用该能力，需要将文件中的配置改为 `websockets: true`，并通过当前 UI 保存