### PR TITLE
feat: add GitHub Copilot premium request quota display

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,6 +73,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -480,6 +481,7 @@
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.8.tgz",
       "integrity": "sha512-XcE9fcnkHCbWkjeKyi0lllwXmBLtyYb5dt89dJyx23I9+LSh5vZDIuk7OLG4VM1lgrXZQcY6cxyZyk5WVPRv/A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.5.0",
         "crelt": "^1.0.6",
@@ -1945,6 +1947,7 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2032,6 +2035,7 @@
       "integrity": "sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -2349,6 +2353,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2560,6 +2565,7 @@
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -2824,6 +2830,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3321,6 +3328,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4"
       },
@@ -3691,6 +3699,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3797,6 +3806,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3814,6 +3824,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3922,6 +3933,7 @@
       "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -4110,6 +4122,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4186,6 +4199,7 @@
       "integrity": "sha512-tI2l/nFHC5rLh7+5+o7QjKjSR04ivXDF4jcgV0f/bTQ+OJiITy5S6gaynVsEM+7RqzufMnVbIon6Sr5x1SDYaQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -4315,6 +4329,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -4342,6 +4357,7 @@
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/components/quota/index.ts
+++ b/src/components/quota/index.ts
@@ -5,5 +5,5 @@
 export { QuotaSection } from './QuotaSection';
 export { QuotaCard } from './QuotaCard';
 export { useQuotaLoader } from './useQuotaLoader';
-export { ANTIGRAVITY_CONFIG, CLAUDE_CONFIG, CODEX_CONFIG, GEMINI_CLI_CONFIG, KIMI_CONFIG } from './quotaConfigs';
+export { ANTIGRAVITY_CONFIG, CLAUDE_CONFIG, CODEX_CONFIG, COPILOT_CONFIG, GEMINI_CLI_CONFIG, KIMI_CONFIG } from './quotaConfigs';
 export type { QuotaConfig } from './quotaConfigs';

--- a/src/components/quota/quotaConfigs.ts
+++ b/src/components/quota/quotaConfigs.ts
@@ -20,6 +20,9 @@ import type {
   CodexUsageWindow,
   CodexQuotaWindow,
   CodexUsagePayload,
+  CopilotQuotaState,
+  CopilotQuotaWindow,
+  CopilotUsageResponse,
   GeminiCliCodeAssistPayload,
   GeminiCliCredits,
   GeminiCliParsedBucket,
@@ -30,6 +33,7 @@ import type {
   KimiQuotaState,
 } from '@/types';
 import { apiCallApi, authFilesApi, getApiCallErrorMessage } from '@/services/api';
+import { apiClient } from '@/services/api/client';
 import { useQuotaStore } from '@/stores';
 import {
   ANTIGRAVITY_QUOTA_URLS,
@@ -70,6 +74,7 @@ import {
   isAntigravityFile,
   isClaudeFile,
   isCodexFile,
+  isCopilotFile,
   isDisabledAuthFile,
   isGeminiCliFile,
   isKimiFile,
@@ -81,7 +86,7 @@ import styles from '@/pages/QuotaPage.module.scss';
 
 type QuotaUpdater<T> = T | ((prev: T) => T);
 
-type QuotaType = 'antigravity' | 'claude' | 'codex' | 'gemini-cli' | 'kimi';
+type QuotaType = 'antigravity' | 'claude' | 'codex' | 'copilot' | 'gemini-cli' | 'kimi';
 
 const DEFAULT_ANTIGRAVITY_PROJECT_ID = 'bamboo-precept-lgxtn';
 const QUOTA_PROGRESS_HIGH_THRESHOLD = 70;
@@ -96,11 +101,13 @@ export interface QuotaStore {
   antigravityQuota: Record<string, AntigravityQuotaState>;
   claudeQuota: Record<string, ClaudeQuotaState>;
   codexQuota: Record<string, CodexQuotaState>;
+  copilotQuota: Record<string, CopilotQuotaState>;
   geminiCliQuota: Record<string, GeminiCliQuotaState>;
   kimiQuota: Record<string, KimiQuotaState>;
   setAntigravityQuota: (updater: QuotaUpdater<Record<string, AntigravityQuotaState>>) => void;
   setClaudeQuota: (updater: QuotaUpdater<Record<string, ClaudeQuotaState>>) => void;
   setCodexQuota: (updater: QuotaUpdater<Record<string, CodexQuotaState>>) => void;
+  setCopilotQuota: (updater: QuotaUpdater<Record<string, CopilotQuotaState>>) => void;
   setGeminiCliQuota: (updater: QuotaUpdater<Record<string, GeminiCliQuotaState>>) => void;
   setKimiQuota: (updater: QuotaUpdater<Record<string, KimiQuotaState>>) => void;
   clearQuotaCache: () => void;
@@ -1341,4 +1348,193 @@ export const KIMI_CONFIG: QuotaConfig<KimiQuotaState, KimiQuotaRow[]> = {
   controlClassName: styles.kimiControl,
   gridClassName: styles.kimiGrid,
   renderQuotaItems: renderKimiItems,
+};
+
+// --- GitHub Copilot Quota ---
+
+const COPILOT_QUOTA_CATEGORIES = [
+  { key: 'premium_interactions', id: 'premium', labelKey: 'copilot_quota.premium_requests' },
+  { key: 'chat', id: 'chat', labelKey: 'copilot_quota.chat' },
+  { key: 'completions', id: 'completions', labelKey: 'copilot_quota.completions' },
+] as const;
+
+const fetchCopilotQuota = async (
+  file: AuthFileItem,
+  t: TFunction
+): Promise<{ windows: CopilotQuotaWindow[]; copilotPlan?: string | null; resetDate?: string | null }> => {
+  const rawAuthIndex = file['auth_index'] ?? file.authIndex;
+  const authIndex = normalizeAuthIndex(rawAuthIndex);
+  if (!authIndex) {
+    throw new Error(t('copilot_quota.missing_auth_index'));
+  }
+
+  let response: CopilotUsageResponse;
+  try {
+    response = await apiClient.get<CopilotUsageResponse>(
+      `/copilot-quota?auth_index=${encodeURIComponent(authIndex)}`
+    );
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : t('common.unknown_error');
+    throw createStatusError(message, getStatusFromError(err));
+  }
+
+  if (!response || !response.quota_snapshots) {
+    throw new Error(t('copilot_quota.empty_data'));
+  }
+
+  const snapshots = response.quota_snapshots;
+  const windows: CopilotQuotaWindow[] = [];
+
+  for (const { key, id, labelKey } of COPILOT_QUOTA_CATEGORIES) {
+    const detail = snapshots[key as keyof typeof snapshots];
+    if (!detail) continue;
+
+    const entitlement = detail.entitlement ?? 0;
+    const rawRemaining = detail.remaining ?? detail.quota_remaining ?? 0;
+    const remaining = entitlement > 0 ? Math.min(Math.max(rawRemaining, 0), entitlement) : 0;
+    const used = entitlement > 0 ? entitlement - remaining : 0;
+    const usedPercent = entitlement > 0 ? Math.max(0, Math.min(100, Math.round((used / entitlement) * 100))) : null;
+
+    windows.push({
+      id,
+      label: t(labelKey),
+      labelKey,
+      entitlement,
+      remaining,
+      used,
+      usedPercent,
+      unlimited: detail.unlimited ?? false,
+    });
+  }
+
+  return {
+    windows,
+    copilotPlan: response.copilot_plan ?? null,
+    resetDate: response.quota_reset_date ?? null,
+  };
+};
+
+const renderCopilotItems = (
+  quota: CopilotQuotaState,
+  t: TFunction,
+  helpers: QuotaRenderHelpers
+): ReactNode => {
+  const { styles: styleMap, QuotaProgressBar } = helpers;
+  const { createElement: h, Fragment } = React;
+  const windows = quota.windows ?? [];
+  const copilotPlan = quota.copilotPlan ?? null;
+  const resetDate = quota.resetDate ?? null;
+  const nodes: ReactNode[] = [];
+
+  if (copilotPlan) {
+    nodes.push(
+      h(
+        'div',
+        { key: 'plan', className: styleMap.copilotPlan },
+        h('span', { className: styleMap.copilotPlanLabel }, t('copilot_quota.plan_label')),
+        h('span', { className: styleMap.copilotPlanValue }, copilotPlan)
+      )
+    );
+  }
+
+  if (resetDate) {
+    const resetLabel = formatQuotaResetTime(resetDate);
+    nodes.push(
+      h(
+        'div',
+        { key: 'reset', className: styleMap.copilotPlan },
+        h('span', { className: styleMap.copilotPlanLabel }, t('copilot_quota.reset_label')),
+        h('span', { className: styleMap.copilotPlanValue }, resetLabel)
+      )
+    );
+  }
+
+  if (windows.length === 0) {
+    nodes.push(
+      h('div', { key: 'empty', className: styleMap.quotaMessage }, t('copilot_quota.empty_data'))
+    );
+    return h(Fragment, null, ...nodes);
+  }
+
+  nodes.push(
+    ...windows.map((window) => {
+      if (window.unlimited) {
+        return h(
+          'div',
+          { key: window.id, className: styleMap.quotaRow },
+          h(
+            'div',
+            { className: styleMap.quotaRowHeader },
+            h('span', { className: styleMap.quotaModel }, window.label),
+            h(
+              'div',
+              { className: styleMap.quotaMeta },
+              h('span', { className: styleMap.quotaPercent }, t('copilot_quota.unlimited'))
+            )
+          ),
+          h(QuotaProgressBar, { percent: 100, highThreshold: QUOTA_PROGRESS_HIGH_THRESHOLD, mediumThreshold: QUOTA_PROGRESS_MEDIUM_THRESHOLD })
+        );
+      }
+
+      const remaining = window.usedPercent === null
+        ? null
+        : Math.max(0, Math.min(100, 100 - window.usedPercent));
+      const percentLabel = remaining === null ? '--' : `${Math.round(remaining)}%`;
+      const amountLabel = `${window.used} / ${window.entitlement}`;
+
+      return h(
+        'div',
+        { key: window.id, className: styleMap.quotaRow },
+        h(
+          'div',
+          { className: styleMap.quotaRowHeader },
+          h('span', { className: styleMap.quotaModel }, window.label),
+          h(
+            'div',
+            { className: styleMap.quotaMeta },
+            h('span', { className: styleMap.quotaPercent }, percentLabel),
+            h('span', { className: styleMap.quotaAmount }, amountLabel)
+          )
+        ),
+        h(QuotaProgressBar, {
+          percent: remaining,
+          highThreshold: QUOTA_PROGRESS_HIGH_THRESHOLD,
+          mediumThreshold: QUOTA_PROGRESS_MEDIUM_THRESHOLD,
+        })
+      );
+    })
+  );
+
+  return h(Fragment, null, ...nodes);
+};
+
+export const COPILOT_CONFIG: QuotaConfig<
+  CopilotQuotaState,
+  { windows: CopilotQuotaWindow[]; copilotPlan?: string | null; resetDate?: string | null }
+> = {
+  type: 'copilot',
+  i18nPrefix: 'copilot_quota',
+  cardIdleMessageKey: 'quota_management.card_idle_hint',
+  filterFn: (file) => isCopilotFile(file) && !isDisabledAuthFile(file),
+  fetchQuota: fetchCopilotQuota,
+  storeSelector: (state) => state.copilotQuota,
+  storeSetter: 'setCopilotQuota',
+  buildLoadingState: () => ({ status: 'loading', windows: [] }),
+  buildSuccessState: (data) => ({
+    status: 'success',
+    windows: data.windows,
+    copilotPlan: data.copilotPlan,
+    resetDate: data.resetDate,
+  }),
+  buildErrorState: (message, status) => ({
+    status: 'error',
+    windows: [],
+    error: message,
+    errorStatus: status,
+  }),
+  cardClassName: styles.copilotCard,
+  controlsClassName: styles.copilotControls,
+  controlClassName: styles.copilotControl,
+  gridClassName: styles.copilotGrid,
+  renderQuotaItems: renderCopilotItems,
 };

--- a/src/features/authFiles/constants.ts
+++ b/src/features/authFiles/constants.ts
@@ -97,6 +97,19 @@ export const TYPE_COLORS: Record<string, TypeColorSet> = {
     light: { bg: '#e4edfd', text: '#2b5fbc' },
     dark: { bg: '#1a3d80', text: '#89b3f7' },
   },
+  // GitHub Copilot logo: GitHub 蓝 #1A73E8
+  copilot: {
+    light: { bg: '#e8f0fe', text: '#1a73e8' },
+    dark: { bg: '#1a3b5c', text: '#8ab4f8' },
+  },
+  'github-copilot': {
+    light: { bg: '#e8f0fe', text: '#1a73e8' },
+    dark: { bg: '#1a3b5c', text: '#8ab4f8' },
+  },
+  github: {
+    light: { bg: '#e8f0fe', text: '#1a73e8' },
+    dark: { bg: '#1a3b5c', text: '#8ab4f8' },
+  },
   empty: {
     light: { bg: '#f5f5f5', text: '#616161' },
     dark: { bg: '#424242', text: '#bdbdbd' },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -704,6 +704,24 @@
     "limit_index": "Limit #{{index}}",
     "reset_hint": "resets in {{hint}}"
   },
+  "copilot_quota": {
+    "title": "GitHub Copilot Quota",
+    "empty_title": "No GitHub Copilot Auth Files",
+    "empty_desc": "Log in with GitHub Copilot to view remaining premium request quota.",
+    "idle": "Click here to refresh quota",
+    "loading": "Loading quota...",
+    "load_failed": "Failed to load quota: {{message}}",
+    "missing_auth_index": "Auth file missing auth_index",
+    "empty_data": "No quota data available",
+    "refresh_button": "Refresh Quota",
+    "fetch_all": "Fetch All",
+    "premium_requests": "Premium Requests",
+    "chat": "Chat",
+    "completions": "Completions",
+    "plan_label": "Plan:",
+    "reset_label": "Resets:",
+    "unlimited": "Unlimited"
+  },
   "vertex_import": {
     "title": "Vertex JSON Login",
     "description": "Upload a Google service account JSON to store it as auth-dir/vertex-<project>.json using the same rules as the CLI vertex-import helper.",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -707,6 +707,24 @@
     "limit_index": "Лимит #{{index}}",
     "reset_hint": "сброс через {{hint}}"
   },
+  "copilot_quota": {
+    "title": "Квота GitHub Copilot",
+    "empty_title": "Нет аутентификации GitHub Copilot",
+    "empty_desc": "Войдите через GitHub Copilot, чтобы увидеть оставшуюся квоту премиум-запросов.",
+    "idle": "Нажмите для обновления квоты",
+    "loading": "Загрузка квоты...",
+    "load_failed": "Не удалось загрузить квоту: {{message}}",
+    "missing_auth_index": "В файле аутентификации отсутствует auth_index",
+    "empty_data": "Нет данных о квоте",
+    "refresh_button": "Обновить квоту",
+    "fetch_all": "Получить все",
+    "premium_requests": "Премиум-запросы",
+    "chat": "Чат",
+    "completions": "Автодополнение",
+    "plan_label": "План:",
+    "reset_label": "Сброс:",
+    "unlimited": "Безлимитно"
+  },
   "vertex_import": {
     "title": "Вход с Vertex JSON",
     "description": "Загрузите JSON ключа сервисного аккаунта Google, чтобы сохранить его как auth-dir/vertex-<project>.json по тем же правилам, что и помощник CLI vertex-import.",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -704,6 +704,24 @@
     "limit_index": "限额 #{{index}}",
     "reset_hint": "{{hint}} 后重置"
   },
+  "copilot_quota": {
+    "title": "GitHub Copilot 额度",
+    "empty_title": "暂无 GitHub Copilot 认证",
+    "empty_desc": "使用 GitHub Copilot 登录后即可查看高级请求额度。",
+    "idle": "点击此处刷新额度",
+    "loading": "正在加载额度...",
+    "load_failed": "额度获取失败：{{message}}",
+    "missing_auth_index": "认证文件缺少 auth_index",
+    "empty_data": "暂无额度数据",
+    "refresh_button": "刷新额度",
+    "fetch_all": "获取全部",
+    "premium_requests": "高级请求",
+    "chat": "聊天",
+    "completions": "补全",
+    "plan_label": "套餐：",
+    "reset_label": "重置时间：",
+    "unlimited": "无限制"
+  },
   "vertex_import": {
     "title": "Vertex JSON 登录",
     "description": "上传 Google 服务账号 JSON，使用 CLI vertex-import 同步规则写入 auth-dir/vertex-<project>.json。",

--- a/src/pages/QuotaPage.module.scss
+++ b/src/pages/QuotaPage.module.scss
@@ -113,6 +113,7 @@
 .antigravityGrid,
 .claudeGrid,
 .codexGrid,
+.copilotGrid,
 .geminiCliGrid,
 .kimiGrid {
   display: grid;
@@ -127,6 +128,7 @@
 .antigravityControls,
 .claudeControls,
 .codexControls,
+.copilotControls,
 .geminiCliControls,
 .kimiControls {
   display: flex;
@@ -139,6 +141,7 @@
 .antigravityControl,
 .claudeControl,
 .codexControl,
+.copilotControl,
 .geminiCliControl,
 .kimiControl {
   display: flex;
@@ -256,6 +259,12 @@
   background-image: linear-gradient(180deg,
       rgba(224, 247, 250, 0.12),
       rgba(224, 247, 250, 0));
+}
+
+.copilotCard {
+  background-image: linear-gradient(180deg,
+      rgba(232, 240, 254, 0.2),
+      rgba(232, 240, 254, 0));
 }
 
 .codexCard {
@@ -413,7 +422,8 @@
   padding: $spacing-xs $spacing-sm;
 }
 
-.codexPlan {
+.codexPlan,
+.copilotPlan {
   display: flex;
   align-items: center;
   gap: 6px;
@@ -421,11 +431,13 @@
   color: var(--text-secondary);
 }
 
-.codexPlanLabel {
+.codexPlanLabel,
+.copilotPlanLabel {
   color: var(--text-tertiary);
 }
 
-.codexPlanValue {
+.codexPlanValue,
+.copilotPlanValue {
   font-weight: 600;
   color: var(--text-primary);
   text-transform: capitalize;

--- a/src/pages/QuotaPage.tsx
+++ b/src/pages/QuotaPage.tsx
@@ -12,6 +12,7 @@ import {
   ANTIGRAVITY_CONFIG,
   CLAUDE_CONFIG,
   CODEX_CONFIG,
+  COPILOT_CONFIG,
   GEMINI_CLI_CONFIG,
   KIMI_CONFIG
 } from '@/components/quota';
@@ -73,6 +74,12 @@ export function QuotaPage() {
 
       <QuotaSection
         config={CLAUDE_CONFIG}
+        files={files}
+        loading={loading}
+        disabled={disableControls}
+      />
+      <QuotaSection
+        config={COPILOT_CONFIG}
         files={files}
         loading={loading}
         disabled={disableControls}

--- a/src/stores/useQuotaStore.ts
+++ b/src/stores/useQuotaStore.ts
@@ -3,7 +3,7 @@
  */
 
 import { create } from 'zustand';
-import type { AntigravityQuotaState, ClaudeQuotaState, CodexQuotaState, GeminiCliQuotaState, KimiQuotaState } from '@/types';
+import type { AntigravityQuotaState, ClaudeQuotaState, CodexQuotaState, CopilotQuotaState, GeminiCliQuotaState, KimiQuotaState } from '@/types';
 
 type QuotaUpdater<T> = T | ((prev: T) => T);
 
@@ -11,11 +11,13 @@ interface QuotaStoreState {
   antigravityQuota: Record<string, AntigravityQuotaState>;
   claudeQuota: Record<string, ClaudeQuotaState>;
   codexQuota: Record<string, CodexQuotaState>;
+  copilotQuota: Record<string, CopilotQuotaState>;
   geminiCliQuota: Record<string, GeminiCliQuotaState>;
   kimiQuota: Record<string, KimiQuotaState>;
   setAntigravityQuota: (updater: QuotaUpdater<Record<string, AntigravityQuotaState>>) => void;
   setClaudeQuota: (updater: QuotaUpdater<Record<string, ClaudeQuotaState>>) => void;
   setCodexQuota: (updater: QuotaUpdater<Record<string, CodexQuotaState>>) => void;
+  setCopilotQuota: (updater: QuotaUpdater<Record<string, CopilotQuotaState>>) => void;
   setGeminiCliQuota: (updater: QuotaUpdater<Record<string, GeminiCliQuotaState>>) => void;
   setKimiQuota: (updater: QuotaUpdater<Record<string, KimiQuotaState>>) => void;
   clearQuotaCache: () => void;
@@ -32,6 +34,7 @@ export const useQuotaStore = create<QuotaStoreState>((set) => ({
   antigravityQuota: {},
   claudeQuota: {},
   codexQuota: {},
+  copilotQuota: {},
   geminiCliQuota: {},
   kimiQuota: {},
   setAntigravityQuota: (updater) =>
@@ -46,6 +49,10 @@ export const useQuotaStore = create<QuotaStoreState>((set) => ({
     set((state) => ({
       codexQuota: resolveUpdater(updater, state.codexQuota)
     })),
+  setCopilotQuota: (updater) =>
+    set((state) => ({
+      copilotQuota: resolveUpdater(updater, state.copilotQuota)
+    })),
   setGeminiCliQuota: (updater) =>
     set((state) => ({
       geminiCliQuota: resolveUpdater(updater, state.geminiCliQuota)
@@ -59,6 +66,7 @@ export const useQuotaStore = create<QuotaStoreState>((set) => ({
       antigravityQuota: {},
       claudeQuota: {},
       codexQuota: {},
+      copilotQuota: {},
       geminiCliQuota: {},
       kimiQuota: {}
     })

--- a/src/types/quota.ts
+++ b/src/types/quota.ts
@@ -306,3 +306,49 @@ export interface KimiQuotaState {
   error?: string;
   errorStatus?: number;
 }
+
+// GitHub Copilot quota types
+
+export interface CopilotQuotaDetail {
+  entitlement: number;
+  overage_count: number;
+  overage_permitted: boolean;
+  percent_remaining: number;
+  quota_id: string;
+  quota_remaining: number;
+  remaining: number;
+  unlimited: boolean;
+}
+
+export interface CopilotQuotaSnapshots {
+  chat: CopilotQuotaDetail;
+  completions: CopilotQuotaDetail;
+  premium_interactions: CopilotQuotaDetail;
+}
+
+export interface CopilotUsageResponse {
+  access_type_sku?: string;
+  copilot_plan?: string;
+  quota_reset_date?: string;
+  quota_snapshots?: CopilotQuotaSnapshots;
+}
+
+export interface CopilotQuotaWindow {
+  id: string;
+  label: string;
+  labelKey?: string;
+  entitlement: number;
+  remaining: number;
+  used: number;
+  usedPercent: number | null;
+  unlimited: boolean;
+}
+
+export interface CopilotQuotaState {
+  status: 'idle' | 'loading' | 'success' | 'error';
+  windows: CopilotQuotaWindow[];
+  copilotPlan?: string | null;
+  resetDate?: string | null;
+  error?: string;
+  errorStatus?: number;
+}

--- a/src/utils/quota/constants.ts
+++ b/src/utils/quota/constants.ts
@@ -42,6 +42,18 @@ export const TYPE_COLORS: Record<string, TypeColorSet> = {
     light: { bg: '#e0f7fa', text: '#006064' },
     dark: { bg: '#004d40', text: '#80deea' },
   },
+  copilot: {
+    light: { bg: '#e8f0fe', text: '#1a73e8' },
+    dark: { bg: '#1a3b5c', text: '#8ab4f8' },
+  },
+  'github-copilot': {
+    light: { bg: '#e8f0fe', text: '#1a73e8' },
+    dark: { bg: '#1a3b5c', text: '#8ab4f8' },
+  },
+  github: {
+    light: { bg: '#e8f0fe', text: '#1a73e8' },
+    dark: { bg: '#1a3b5c', text: '#8ab4f8' },
+  },
   iflow: {
     light: { bg: '#f5e3fc', text: '#9025c8' },
     dark: { bg: '#521490', text: '#d49cf5' },

--- a/src/utils/quota/validators.ts
+++ b/src/utils/quota/validators.ts
@@ -43,6 +43,11 @@ export function isKimiFile(file: AuthFileItem): boolean {
   return resolveAuthProvider(file) === 'kimi';
 }
 
+export function isCopilotFile(file: AuthFileItem): boolean {
+  const provider = resolveAuthProvider(file);
+  return provider === 'copilot' || provider === 'github-copilot' || provider === 'github';
+}
+
 export function isRuntimeOnlyAuthFile(file: AuthFileItem): boolean {
   const raw = file['runtime_only'] ?? file.runtimeOnly;
   if (typeof raw === 'boolean') return raw;


### PR DESCRIPTION
## Summary

- Add Copilot quota section to the QuotaPage displaying premium request usage, chat, and completions quota from the GitHub Copilot API
- Add `CopilotQuotaState` and related types (`CopilotQuotaDetail`, `CopilotQuotaSnapshots`, `CopilotUsageResponse`)
- Add `copilotQuota` field and `setCopilotQuota` setter to Zustand store, sync `QuotaStore` interface
- Add `COPILOT_CONFIG` with `fetchCopilotQuota` and `renderCopilotItems` following the existing `QuotaConfig` pattern
- Add `.copilotCard` CSS gradient (blue theme `#e8f0fe`) and `copilotGrid`/`copilotControls`/`copilotControl`/`copilotPlan`/`copilotPlanLabel`/`copilotPlanValue` classes
- Add `isCopilotFile()` validator for auth file filtering (`copilot`/`github-copilot`/`github`)
- Add i18n translations for en, zh-CN, and ru
- Sync `TYPE_COLORS` for copilot/github-copilot/github to `authFiles/constants.ts`
- Use `createStatusError` to preserve HTTP status on fetch errors (not `new Error`)
- Clamp `remaining` to `[0, entitlement]` and `usedPercent` to `[0, 100]`
- Use shared `QUOTA_PROGRESS_HIGH_THRESHOLD`/`QUOTA_PROGRESS_MEDIUM_THRESHOLD` constants
- Use copilot-specific CSS class names instead of reusing codex classes
- Remove trailing spaces from i18n label values (`plan_label`, `reset_label`)

## Dependencies

Requires backend route `GET /copilot-quota` registered in [CLIProxyAPIPlus#485](https://github.com/router-for-me/CLIProxyAPIPlus/pull/485).

## Test plan

- [x] `tsc --noEmit` — zero type errors
- [x] `vite build` — successful single-file HTML output (687 KB gzipped)
- [x] Verified Copilot QuotaSection renders alongside existing providers
- [x] All code review comments addressed and resolved (11/11)