### PR TITLE
feat(authFiles): support customizing headers for auth files

### DIFF
--- a/src/features/authFiles/components/AuthFilesPrefixProxyEditorModal.tsx
+++ b/src/features/authFiles/components/AuthFilesPrefixProxyEditorModal.tsx
@@ -138,6 +138,18 @@ export function AuthFilesPrefixProxyEditorModal(props: AuthFilesPrefixProxyEdito
                   />
                   <div className="hint">{t('auth_files.excluded_models_hint')}</div>
                 </div>
+                <div className="form-group">
+                  <label>{t('auth_files.headers_label')}</label>
+                  <textarea
+                    className="input"
+                    value={editor.headersText}
+                    placeholder='{"X-Custom-Header": "value"}'
+                    rows={4}
+                    disabled={disableControls || editor.saving || !editor.json}
+                    onChange={(e) => onChange('headersText', e.target.value)}
+                  />
+                  <div className="hint">{t('auth_files.headers_hint')}</div>
+                </div>
                 <Input
                   label={t('auth_files.disable_cooling_label')}
                   value={editor.disableCooling}

--- a/src/features/authFiles/components/AuthFilesPrefixProxyEditorModal.tsx
+++ b/src/features/authFiles/components/AuthFilesPrefixProxyEditorModal.tsx
@@ -143,7 +143,7 @@ export function AuthFilesPrefixProxyEditorModal(props: AuthFilesPrefixProxyEdito
                   <textarea
                     className="input"
                     value={editor.headersText}
-                    placeholder='{"X-Custom-Header": "value"}'
+                    placeholder={t('auth_files.headers_placeholder')}
                     rows={4}
                     disabled={disableControls || editor.saving || !editor.json}
                     onChange={(e) => onChange('headersText', e.target.value)}

--- a/src/features/authFiles/hooks/useAuthFilesPrefixProxyEditor.ts
+++ b/src/features/authFiles/hooks/useAuthFilesPrefixProxyEditor.ts
@@ -107,11 +107,16 @@ const buildPrefixProxyUpdatedText = (editor: PrefixProxyEditorState | null): str
   }
 
   if (editor.headersText.trim()) {
+    let parsedHeaders;
     try {
-      next.headers = JSON.parse(editor.headersText);
+      parsedHeaders = JSON.parse(editor.headersText);
     } catch {
-      // ignore or handle error
+      throw new Error('Invalid JSON format for Custom Headers. Must be an object.');
     }
+    if (!parsedHeaders || typeof parsedHeaders !== 'object' || Array.isArray(parsedHeaders)) {
+      throw new Error('Invalid JSON format for Custom Headers. Must be an object.');
+    }
+    next.headers = parsedHeaders;
   } else {
     delete next.headers;
   }
@@ -130,11 +135,17 @@ export function useAuthFilesPrefixProxyEditor(
 
   const [prefixProxyEditor, setPrefixProxyEditor] = useState<PrefixProxyEditorState | null>(null);
 
-  const prefixProxyUpdatedText = buildPrefixProxyUpdatedText(prefixProxyEditor);
+  let prefixProxyUpdatedText = '';
+  try {
+    prefixProxyUpdatedText = buildPrefixProxyUpdatedText(prefixProxyEditor);
+  } catch {
+    // Catch JSON parsing errors during render so the UI doesn't crash.
+  }
+
   const prefixProxyDirty =
     Boolean(prefixProxyEditor?.json) &&
     Boolean(prefixProxyEditor?.originalText) &&
-    prefixProxyUpdatedText !== prefixProxyEditor?.originalText;
+    (prefixProxyUpdatedText === '' || prefixProxyUpdatedText !== prefixProxyEditor?.originalText);
 
   const closePrefixProxyEditor = () => {
     setPrefixProxyEditor(null);
@@ -285,7 +296,15 @@ export function useAuthFilesPrefixProxyEditor(
     if (!prefixProxyDirty) return;
 
     const name = prefixProxyEditor.fileName;
-    const payload = prefixProxyUpdatedText;
+    let payload = '';
+    try {
+      payload = buildPrefixProxyUpdatedText(prefixProxyEditor);
+    } catch (err: unknown) {
+      const errorMessage = err instanceof Error ? err.message : 'Invalid format';
+      showNotification(errorMessage, 'error');
+      return;
+    }
+
     const fileSize = new Blob([payload]).size;
     if (fileSize > MAX_AUTH_FILE_SIZE) {
       showNotification(

--- a/src/features/authFiles/hooks/useAuthFilesPrefixProxyEditor.ts
+++ b/src/features/authFiles/hooks/useAuthFilesPrefixProxyEditor.ts
@@ -21,7 +21,8 @@ export type PrefixProxyEditorField =
   | 'excludedModelsText'
   | 'disableCooling'
   | 'websockets'
-  | 'note';
+  | 'note'
+  | 'headersText';
 
 export type PrefixProxyEditorFieldValue = string | boolean;
 
@@ -43,6 +44,7 @@ export type PrefixProxyEditorState = {
   websockets: boolean;
   note: string;
   noteTouched: boolean;
+  headersText: string;
 };
 
 export type UseAuthFilesPrefixProxyEditorOptions = {
@@ -104,6 +106,16 @@ const buildPrefixProxyUpdatedText = (editor: PrefixProxyEditorState | null): str
     }
   }
 
+  if (editor.headersText.trim()) {
+    try {
+      next.headers = JSON.parse(editor.headersText);
+    } catch {
+      // ignore or handle error
+    }
+  } else {
+    delete next.headers;
+  }
+
   return JSON.stringify(
     editor.isCodexFile ? applyCodexAuthFileWebsockets(next, editor.websockets) : next
   );
@@ -162,6 +174,7 @@ export function useAuthFilesPrefixProxyEditor(
       websockets: false,
       note: '',
       noteTouched: false,
+      headersText: '',
     });
 
     try {
@@ -213,6 +226,11 @@ export function useAuthFilesPrefixProxyEditor(
       const disableCoolingValue = parseDisableCoolingValue(json.disable_cooling);
       const websocketsValue = readCodexAuthFileWebsockets(json);
       const note = typeof json.note === 'string' ? json.note : '';
+      const headers = json.headers;
+      let headersText = '';
+      if (headers && typeof headers === 'object') {
+        headersText = JSON.stringify(headers, null, 2);
+      }
 
       setPrefixProxyEditor((prev) => {
         if (!prev || prev.fileName !== name) return prev;
@@ -231,6 +249,7 @@ export function useAuthFilesPrefixProxyEditor(
           websockets: websocketsValue,
           note,
           noteTouched: false,
+          headersText,
           error: null,
         };
       });
@@ -256,6 +275,7 @@ export function useAuthFilesPrefixProxyEditor(
       if (field === 'excludedModelsText') return { ...prev, excludedModelsText: String(value) };
       if (field === 'disableCooling') return { ...prev, disableCooling: String(value) };
       if (field === 'note') return { ...prev, note: String(value), noteTouched: true };
+      if (field === 'headersText') return { ...prev, headersText: String(value) };
       return { ...prev, websockets: Boolean(value) };
     });
   };

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -599,6 +599,7 @@
     "note_display": "Note",
     "headers_label": "Custom Headers (headers)",
     "headers_placeholder": "{\n  \"Header-Name\": \"value\"\n}",
+    "headers_hint": "Enter custom HTTP headers as a JSON object, e.g., {\"X-My-Header\": \"value\"}",
     "prefix_proxy_invalid_json": "This auth file is not a JSON object, so fields cannot be edited.",
     "prefix_proxy_saved_success": "Updated auth file \"{{name}}\" successfully",
     "quota_refresh_success": "Quota refreshed for \"{{name}}\"",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -597,6 +597,8 @@
     "note_placeholder": "Enter a note, e.g.: John's account",
     "note_hint": "Optional. Used to describe the purpose or owner of this credential; leave empty to omit.",
     "note_display": "Note",
+    "headers_label": "Custom Headers (headers)",
+    "headers_placeholder": "{\n  \"Header-Name\": \"value\"\n}",
     "prefix_proxy_invalid_json": "This auth file is not a JSON object, so fields cannot be edited.",
     "prefix_proxy_saved_success": "Updated auth file \"{{name}}\" successfully",
     "quota_refresh_success": "Quota refreshed for \"{{name}}\"",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -599,6 +599,7 @@
     "note_display": "备注",
     "headers_label": "自定义请求头（headers）",
     "headers_placeholder": "{\n  \"Header-Name\": \"value\"\n}",
+    "headers_hint": "以 JSON 对象格式输入自定义 HTTP 请求头，例如：{\"X-My-Header\": \"value\"}",
     "prefix_proxy_invalid_json": "该认证文件不是 JSON 对象，无法编辑字段。",
     "prefix_proxy_saved_success": "已更新认证文件 \"{{name}}\"",
     "quota_refresh_success": "已刷新 \"{{name}}\" 的额度",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -597,6 +597,8 @@
     "note_placeholder": "输入备注信息，例如：张三的账号",
     "note_hint": "可选，用于标记凭证用途或归属；留空则不写入。",
     "note_display": "备注",
+    "headers_label": "自定义请求头（headers）",
+    "headers_placeholder": "{\n  \"Header-Name\": \"value\"\n}",
     "prefix_proxy_invalid_json": "该认证文件不是 JSON 对象，无法编辑字段。",
     "prefix_proxy_saved_success": "已更新认证文件 \"{{name}}\"",
     "quota_refresh_success": "已刷新 \"{{name}}\" 的额度",


### PR DESCRIPTION
## Description

Adds a new UI field in the Auth Files editor to customize `headers`.
This brings the frontend management center in line with the backend changes introduced in CLIProxyAPI#2457 (https://github.com/router-for-me/CLIProxyAPI/issues/2457).

Users can now specify custom HTTP Headers in JSON format.

## Changes
- Updated `useAuthFilesPrefixProxyEditor.ts` to parse and serialize the `headers` object.
- Added `headersText` TextArea inside `AuthFilesPrefixProxyEditorModal.tsx`.
- Provided translations for the new fields in both English and Simplified Chinese.
