### PR TITLE
feat: add GitHub Copilot premium request quota display

### DIFF
--- a/src/components/quota/index.ts
+++ b/src/components/quota/index.ts
@@ -5,5 +5,5 @@
 export { QuotaSection } from './QuotaSection';
 export { QuotaCard } from './QuotaCard';
 export { useQuotaLoader } from './useQuotaLoader';
-export { ANTIGRAVITY_CONFIG, CLAUDE_CONFIG, CODEX_CONFIG, GEMINI_CLI_CONFIG, KIMI_CONFIG } from './quotaConfigs';
+export { ANTIGRAVITY_CONFIG, CLAUDE_CONFIG, CODEX_CONFIG, COPILOT_CONFIG, GEMINI_CLI_CONFIG, KIMI_CONFIG } from './quotaConfigs';
 export type { QuotaConfig } from './quotaConfigs';

--- a/src/components/quota/quotaConfigs.ts
+++ b/src/components/quota/quotaConfigs.ts
@@ -20,6 +20,9 @@ import type {
   CodexUsageWindow,
   CodexQuotaWindow,
   CodexUsagePayload,
+  CopilotQuotaState,
+  CopilotQuotaWindow,
+  CopilotUsageResponse,
   GeminiCliCodeAssistPayload,
   GeminiCliCredits,
   GeminiCliParsedBucket,
@@ -30,6 +33,7 @@ import type {
   KimiQuotaState,
 } from '@/types';
 import { apiCallApi, authFilesApi, getApiCallErrorMessage } from '@/services/api';
+import { apiClient } from '@/services/api/client';
 import { useQuotaStore } from '@/stores';
 import {
   ANTIGRAVITY_QUOTA_URLS,
@@ -70,6 +74,7 @@ import {
   isAntigravityFile,
   isClaudeFile,
   isCodexFile,
+  isCopilotFile,
   isDisabledAuthFile,
   isGeminiCliFile,
   isKimiFile,
@@ -81,7 +86,7 @@ import styles from '@/pages/QuotaPage.module.scss';
 
 type QuotaUpdater<T> = T | ((prev: T) => T);
 
-type QuotaType = 'antigravity' | 'claude' | 'codex' | 'gemini-cli' | 'kimi';
+type QuotaType = 'antigravity' | 'claude' | 'codex' | 'copilot' | 'gemini-cli' | 'kimi';
 
 const DEFAULT_ANTIGRAVITY_PROJECT_ID = 'bamboo-precept-lgxtn';
 const QUOTA_PROGRESS_HIGH_THRESHOLD = 70;
@@ -96,11 +101,13 @@ export interface QuotaStore {
   antigravityQuota: Record<string, AntigravityQuotaState>;
   claudeQuota: Record<string, ClaudeQuotaState>;
   codexQuota: Record<string, CodexQuotaState>;
+  copilotQuota: Record<string, CopilotQuotaState>;
   geminiCliQuota: Record<string, GeminiCliQuotaState>;
   kimiQuota: Record<string, KimiQuotaState>;
   setAntigravityQuota: (updater: QuotaUpdater<Record<string, AntigravityQuotaState>>) => void;
   setClaudeQuota: (updater: QuotaUpdater<Record<string, ClaudeQuotaState>>) => void;
   setCodexQuota: (updater: QuotaUpdater<Record<string, CodexQuotaState>>) => void;
+  setCopilotQuota: (updater: QuotaUpdater<Record<string, CopilotQuotaState>>) => void;
   setGeminiCliQuota: (updater: QuotaUpdater<Record<string, GeminiCliQuotaState>>) => void;
   setKimiQuota: (updater: QuotaUpdater<Record<string, KimiQuotaState>>) => void;
   clearQuotaCache: () => void;
@@ -1341,4 +1348,193 @@ export const KIMI_CONFIG: QuotaConfig<KimiQuotaState, KimiQuotaRow[]> = {
   controlClassName: styles.kimiControl,
   gridClassName: styles.kimiGrid,
   renderQuotaItems: renderKimiItems,
+};
+
+// --- GitHub Copilot Quota ---
+
+const COPILOT_QUOTA_CATEGORIES = [
+  { key: 'premium_interactions', id: 'premium', labelKey: 'copilot_quota.premium_requests' },
+  { key: 'chat', id: 'chat', labelKey: 'copilot_quota.chat' },
+  { key: 'completions', id: 'completions', labelKey: 'copilot_quota.completions' },
+] as const;
+
+const fetchCopilotQuota = async (
+  file: AuthFileItem,
+  t: TFunction
+): Promise<{ windows: CopilotQuotaWindow[]; copilotPlan?: string | null; resetDate?: string | null }> => {
+  const rawAuthIndex = file['auth_index'] ?? file.authIndex;
+  const authIndex = normalizeAuthIndex(rawAuthIndex);
+  if (!authIndex) {
+    throw new Error(t('copilot_quota.missing_auth_index'));
+  }
+
+  let response: CopilotUsageResponse;
+  try {
+    response = await apiClient.get<CopilotUsageResponse>(
+      `/copilot-quota?auth_index=${encodeURIComponent(authIndex)}`
+    );
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : t('common.unknown_error');
+    throw createStatusError(message, getStatusFromError(err));
+  }
+
+  if (!response || !response.quota_snapshots) {
+    throw new Error(t('copilot_quota.empty_data'));
+  }
+
+  const snapshots = response.quota_snapshots;
+  const windows: CopilotQuotaWindow[] = [];
+
+  for (const { key, id, labelKey } of COPILOT_QUOTA_CATEGORIES) {
+    const detail = snapshots[key as keyof typeof snapshots];
+    if (!detail) continue;
+
+    const entitlement = detail.entitlement ?? 0;
+    const rawRemaining = detail.remaining ?? detail.quota_remaining ?? 0;
+    const remaining = entitlement > 0 ? Math.min(Math.max(rawRemaining, 0), entitlement) : 0;
+    const used = entitlement > 0 ? entitlement - remaining : 0;
+    const usedPercent = entitlement > 0 ? Math.max(0, Math.min(100, Math.round((used / entitlement) * 100))) : null;
+
+    windows.push({
+      id,
+      label: t(labelKey),
+      labelKey,
+      entitlement,
+      remaining,
+      used,
+      usedPercent,
+      unlimited: detail.unlimited ?? false,
+    });
+  }
+
+  return {
+    windows,
+    copilotPlan: response.copilot_plan ?? null,
+    resetDate: response.quota_reset_date ?? null,
+  };
+};
+
+const renderCopilotItems = (
+  quota: CopilotQuotaState,
+  t: TFunction,
+  helpers: QuotaRenderHelpers
+): ReactNode => {
+  const { styles: styleMap, QuotaProgressBar } = helpers;
+  const { createElement: h, Fragment } = React;
+  const windows = quota.windows ?? [];
+  const copilotPlan = quota.copilotPlan ?? null;
+  const resetDate = quota.resetDate ?? null;
+  const nodes: ReactNode[] = [];
+
+  if (copilotPlan) {
+    nodes.push(
+      h(
+        'div',
+        { key: 'plan', className: styleMap.copilotPlan },
+        h('span', { className: styleMap.copilotPlanLabel }, t('copilot_quota.plan_label')),
+        h('span', { className: styleMap.copilotPlanValue }, copilotPlan)
+      )
+    );
+  }
+
+  if (resetDate) {
+    const resetLabel = formatQuotaResetTime(resetDate);
+    nodes.push(
+      h(
+        'div',
+        { key: 'reset', className: styleMap.copilotPlan },
+        h('span', { className: styleMap.copilotPlanLabel }, t('copilot_quota.reset_label')),
+        h('span', { className: styleMap.copilotPlanValue }, resetLabel)
+      )
+    );
+  }
+
+  if (windows.length === 0) {
+    nodes.push(
+      h('div', { key: 'empty', className: styleMap.quotaMessage }, t('copilot_quota.empty_data'))
+    );
+    return h(Fragment, null, ...nodes);
+  }
+
+  nodes.push(
+    ...windows.map((window) => {
+      if (window.unlimited) {
+        return h(
+          'div',
+          { key: window.id, className: styleMap.quotaRow },
+          h(
+            'div',
+            { className: styleMap.quotaRowHeader },
+            h('span', { className: styleMap.quotaModel }, window.label),
+            h(
+              'div',
+              { className: styleMap.quotaMeta },
+              h('span', { className: styleMap.quotaPercent }, t('copilot_quota.unlimited'))
+            )
+          ),
+          h(QuotaProgressBar, { percent: 100, highThreshold: QUOTA_PROGRESS_HIGH_THRESHOLD, mediumThreshold: QUOTA_PROGRESS_MEDIUM_THRESHOLD })
+        );
+      }
+
+      const remaining = window.usedPercent === null
+        ? null
+        : Math.max(0, Math.min(100, 100 - window.usedPercent));
+      const percentLabel = remaining === null ? '--' : `${Math.round(remaining)}%`;
+      const amountLabel = `${window.used} / ${window.entitlement}`;
+
+      return h(
+        'div',
+        { key: window.id, className: styleMap.quotaRow },
+        h(
+          'div',
+          { className: styleMap.quotaRowHeader },
+          h('span', { className: styleMap.quotaModel }, window.label),
+          h(
+            'div',
+            { className: styleMap.quotaMeta },
+            h('span', { className: styleMap.quotaPercent }, percentLabel),
+            h('span', { className: styleMap.quotaAmount }, amountLabel)
+          )
+        ),
+        h(QuotaProgressBar, {
+          percent: remaining,
+          highThreshold: QUOTA_PROGRESS_HIGH_THRESHOLD,
+          mediumThreshold: QUOTA_PROGRESS_MEDIUM_THRESHOLD,
+        })
+      );
+    })
+  );
+
+  return h(Fragment, null, ...nodes);
+};
+
+export const COPILOT_CONFIG: QuotaConfig<
+  CopilotQuotaState,
+  { windows: CopilotQuotaWindow[]; copilotPlan?: string | null; resetDate?: string | null }
+> = {
+  type: 'copilot',
+  i18nPrefix: 'copilot_quota',
+  cardIdleMessageKey: 'quota_management.card_idle_hint',
+  filterFn: (file) => isCopilotFile(file) && !isDisabledAuthFile(file),
+  fetchQuota: fetchCopilotQuota,
+  storeSelector: (state) => state.copilotQuota,
+  storeSetter: 'setCopilotQuota',
+  buildLoadingState: () => ({ status: 'loading', windows: [] }),
+  buildSuccessState: (data) => ({
+    status: 'success',
+    windows: data.windows,
+    copilotPlan: data.copilotPlan,
+    resetDate: data.resetDate,
+  }),
+  buildErrorState: (message, status) => ({
+    status: 'error',
+    windows: [],
+    error: message,
+    errorStatus: status,
+  }),
+  cardClassName: styles.copilotCard,
+  controlsClassName: styles.copilotControls,
+  controlClassName: styles.copilotControl,
+  gridClassName: styles.copilotGrid,
+  renderQuotaItems: renderCopilotItems,
 };

--- a/src/components/quota/quotaConfigs.ts
+++ b/src/components/quota/quotaConfigs.ts
@@ -36,6 +36,7 @@ import { apiCallApi, authFilesApi, getApiCallErrorMessage } from '@/services/api
 import { apiClient } from '@/services/api/client';
 import { useQuotaStore } from '@/stores';
 import {
+  COPILOT_QUOTA_ENDPOINT,
   ANTIGRAVITY_QUOTA_URLS,
   ANTIGRAVITY_REQUEST_HEADERS,
   CLAUDE_PROFILE_URL,
@@ -1371,7 +1372,7 @@ const fetchCopilotQuota = async (
   let response: CopilotUsageResponse;
   try {
     response = await apiClient.get<CopilotUsageResponse>(
-      `/copilot-quota?auth_index=${encodeURIComponent(authIndex)}`
+      `${COPILOT_QUOTA_ENDPOINT}?auth_index=${encodeURIComponent(authIndex)}`
     );
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : t('common.unknown_error');

--- a/src/features/authFiles/constants.ts
+++ b/src/features/authFiles/constants.ts
@@ -97,6 +97,19 @@ export const TYPE_COLORS: Record<string, TypeColorSet> = {
     light: { bg: '#e4edfd', text: '#2b5fbc' },
     dark: { bg: '#1a3d80', text: '#89b3f7' },
   },
+  // GitHub Copilot logo: GitHub 蓝 #1A73E8
+  copilot: {
+    light: { bg: '#e8f0fe', text: '#1a73e8' },
+    dark: { bg: '#1a3b5c', text: '#8ab4f8' },
+  },
+  'github-copilot': {
+    light: { bg: '#e8f0fe', text: '#1a73e8' },
+    dark: { bg: '#1a3b5c', text: '#8ab4f8' },
+  },
+  github: {
+    light: { bg: '#e8f0fe', text: '#1a73e8' },
+    dark: { bg: '#1a3b5c', text: '#8ab4f8' },
+  },
   empty: {
     light: { bg: '#f5f5f5', text: '#616161' },
     dark: { bg: '#424242', text: '#bdbdbd' },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -704,6 +704,24 @@
     "limit_index": "Limit #{{index}}",
     "reset_hint": "resets in {{hint}}"
   },
+  "copilot_quota": {
+    "title": "GitHub Copilot Quota",
+    "empty_title": "No GitHub Copilot Auth Files",
+    "empty_desc": "Log in with GitHub Copilot to view remaining premium request quota.",
+    "idle": "Click here to refresh quota",
+    "loading": "Loading quota...",
+    "load_failed": "Failed to load quota: {{message}}",
+    "missing_auth_index": "Auth file missing auth_index",
+    "empty_data": "No quota data available",
+    "refresh_button": "Refresh Quota",
+    "fetch_all": "Fetch All",
+    "premium_requests": "Premium Requests",
+    "chat": "Chat",
+    "completions": "Completions",
+    "plan_label": "Plan:",
+    "reset_label": "Resets:",
+    "unlimited": "Unlimited"
+  },
   "vertex_import": {
     "title": "Vertex JSON Login",
     "description": "Upload a Google service account JSON to store it as auth-dir/vertex-<project>.json using the same rules as the CLI vertex-import helper.",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -707,6 +707,24 @@
     "limit_index": "Лимит #{{index}}",
     "reset_hint": "сброс через {{hint}}"
   },
+  "copilot_quota": {
+    "title": "Квота GitHub Copilot",
+    "empty_title": "Нет аутентификации GitHub Copilot",
+    "empty_desc": "Войдите через GitHub Copilot, чтобы увидеть оставшуюся квоту премиум-запросов.",
+    "idle": "Нажмите для обновления квоты",
+    "loading": "Загрузка квоты...",
+    "load_failed": "Не удалось загрузить квоту: {{message}}",
+    "missing_auth_index": "В файле аутентификации отсутствует auth_index",
+    "empty_data": "Нет данных о квоте",
+    "refresh_button": "Обновить квоту",
+    "fetch_all": "Получить все",
+    "premium_requests": "Премиум-запросы",
+    "chat": "Чат",
+    "completions": "Автодополнение",
+    "plan_label": "План:",
+    "reset_label": "Сброс:",
+    "unlimited": "Безлимитно"
+  },
   "vertex_import": {
     "title": "Вход с Vertex JSON",
     "description": "Загрузите JSON ключа сервисного аккаунта Google, чтобы сохранить его как auth-dir/vertex-<project>.json по тем же правилам, что и помощник CLI vertex-import.",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -704,6 +704,24 @@
     "limit_index": "限额 #{{index}}",
     "reset_hint": "{{hint}} 后重置"
   },
+  "copilot_quota": {
+    "title": "GitHub Copilot 额度",
+    "empty_title": "暂无 GitHub Copilot 认证",
+    "empty_desc": "使用 GitHub Copilot 登录后即可查看高级请求额度。",
+    "idle": "点击此处刷新额度",
+    "loading": "正在加载额度...",
+    "load_failed": "额度获取失败：{{message}}",
+    "missing_auth_index": "认证文件缺少 auth_index",
+    "empty_data": "暂无额度数据",
+    "refresh_button": "刷新额度",
+    "fetch_all": "获取全部",
+    "premium_requests": "高级请求",
+    "chat": "聊天",
+    "completions": "补全",
+    "plan_label": "套餐：",
+    "reset_label": "重置时间：",
+    "unlimited": "无限制"
+  },
   "vertex_import": {
     "title": "Vertex JSON 登录",
     "description": "上传 Google 服务账号 JSON，使用 CLI vertex-import 同步规则写入 auth-dir/vertex-<project>.json。",

--- a/src/pages/QuotaPage.module.scss
+++ b/src/pages/QuotaPage.module.scss
@@ -113,6 +113,7 @@
 .antigravityGrid,
 .claudeGrid,
 .codexGrid,
+.copilotGrid,
 .geminiCliGrid,
 .kimiGrid {
   display: grid;
@@ -127,6 +128,7 @@
 .antigravityControls,
 .claudeControls,
 .codexControls,
+.copilotControls,
 .geminiCliControls,
 .kimiControls {
   display: flex;
@@ -139,6 +141,7 @@
 .antigravityControl,
 .claudeControl,
 .codexControl,
+.copilotControl,
 .geminiCliControl,
 .kimiControl {
   display: flex;
@@ -256,6 +259,12 @@
   background-image: linear-gradient(180deg,
       rgba(224, 247, 250, 0.12),
       rgba(224, 247, 250, 0));
+}
+
+.copilotCard {
+  background-image: linear-gradient(180deg,
+      rgba(232, 240, 254, 0.2),
+      rgba(232, 240, 254, 0));
 }
 
 .codexCard {
@@ -413,7 +422,8 @@
   padding: $spacing-xs $spacing-sm;
 }
 
-.codexPlan {
+.codexPlan,
+.copilotPlan {
   display: flex;
   align-items: center;
   gap: 6px;
@@ -421,11 +431,13 @@
   color: var(--text-secondary);
 }
 
-.codexPlanLabel {
+.codexPlanLabel,
+.copilotPlanLabel {
   color: var(--text-tertiary);
 }
 
-.codexPlanValue {
+.codexPlanValue,
+.copilotPlanValue {
   font-weight: 600;
   color: var(--text-primary);
   text-transform: capitalize;

--- a/src/pages/QuotaPage.tsx
+++ b/src/pages/QuotaPage.tsx
@@ -12,6 +12,7 @@ import {
   ANTIGRAVITY_CONFIG,
   CLAUDE_CONFIG,
   CODEX_CONFIG,
+  COPILOT_CONFIG,
   GEMINI_CLI_CONFIG,
   KIMI_CONFIG
 } from '@/components/quota';
@@ -73,6 +74,12 @@ export function QuotaPage() {
 
       <QuotaSection
         config={CLAUDE_CONFIG}
+        files={files}
+        loading={loading}
+        disabled={disableControls}
+      />
+      <QuotaSection
+        config={COPILOT_CONFIG}
         files={files}
         loading={loading}
         disabled={disableControls}

--- a/src/stores/useQuotaStore.ts
+++ b/src/stores/useQuotaStore.ts
@@ -3,7 +3,7 @@
  */
 
 import { create } from 'zustand';
-import type { AntigravityQuotaState, ClaudeQuotaState, CodexQuotaState, GeminiCliQuotaState, KimiQuotaState } from '@/types';
+import type { AntigravityQuotaState, ClaudeQuotaState, CodexQuotaState, CopilotQuotaState, GeminiCliQuotaState, KimiQuotaState } from '@/types';
 
 type QuotaUpdater<T> = T | ((prev: T) => T);
 
@@ -11,11 +11,13 @@ interface QuotaStoreState {
   antigravityQuota: Record<string, AntigravityQuotaState>;
   claudeQuota: Record<string, ClaudeQuotaState>;
   codexQuota: Record<string, CodexQuotaState>;
+  copilotQuota: Record<string, CopilotQuotaState>;
   geminiCliQuota: Record<string, GeminiCliQuotaState>;
   kimiQuota: Record<string, KimiQuotaState>;
   setAntigravityQuota: (updater: QuotaUpdater<Record<string, AntigravityQuotaState>>) => void;
   setClaudeQuota: (updater: QuotaUpdater<Record<string, ClaudeQuotaState>>) => void;
   setCodexQuota: (updater: QuotaUpdater<Record<string, CodexQuotaState>>) => void;
+  setCopilotQuota: (updater: QuotaUpdater<Record<string, CopilotQuotaState>>) => void;
   setGeminiCliQuota: (updater: QuotaUpdater<Record<string, GeminiCliQuotaState>>) => void;
   setKimiQuota: (updater: QuotaUpdater<Record<string, KimiQuotaState>>) => void;
   clearQuotaCache: () => void;
@@ -32,6 +34,7 @@ export const useQuotaStore = create<QuotaStoreState>((set) => ({
   antigravityQuota: {},
   claudeQuota: {},
   codexQuota: {},
+  copilotQuota: {},
   geminiCliQuota: {},
   kimiQuota: {},
   setAntigravityQuota: (updater) =>
@@ -46,6 +49,10 @@ export const useQuotaStore = create<QuotaStoreState>((set) => ({
     set((state) => ({
       codexQuota: resolveUpdater(updater, state.codexQuota)
     })),
+  setCopilotQuota: (updater) =>
+    set((state) => ({
+      copilotQuota: resolveUpdater(updater, state.copilotQuota)
+    })),
   setGeminiCliQuota: (updater) =>
     set((state) => ({
       geminiCliQuota: resolveUpdater(updater, state.geminiCliQuota)
@@ -59,6 +66,7 @@ export const useQuotaStore = create<QuotaStoreState>((set) => ({
       antigravityQuota: {},
       claudeQuota: {},
       codexQuota: {},
+      copilotQuota: {},
       geminiCliQuota: {},
       kimiQuota: {}
     })

--- a/src/types/quota.ts
+++ b/src/types/quota.ts
@@ -310,20 +310,20 @@ export interface KimiQuotaState {
 // GitHub Copilot quota types
 
 export interface CopilotQuotaDetail {
-  entitlement: number;
-  overage_count: number;
-  overage_permitted: boolean;
-  percent_remaining: number;
-  quota_id: string;
-  quota_remaining: number;
-  remaining: number;
-  unlimited: boolean;
+  entitlement?: number;
+  overage_count?: number;
+  overage_permitted?: boolean;
+  percent_remaining?: number;
+  quota_id?: string;
+  quota_remaining?: number;
+  remaining?: number;
+  unlimited?: boolean;
 }
 
 export interface CopilotQuotaSnapshots {
-  chat: CopilotQuotaDetail;
-  completions: CopilotQuotaDetail;
-  premium_interactions: CopilotQuotaDetail;
+  chat?: CopilotQuotaDetail;
+  completions?: CopilotQuotaDetail;
+  premium_interactions?: CopilotQuotaDetail;
 }
 
 export interface CopilotUsageResponse {

--- a/src/types/quota.ts
+++ b/src/types/quota.ts
@@ -306,3 +306,49 @@ export interface KimiQuotaState {
   error?: string;
   errorStatus?: number;
 }
+
+// GitHub Copilot quota types
+
+export interface CopilotQuotaDetail {
+  entitlement: number;
+  overage_count: number;
+  overage_permitted: boolean;
+  percent_remaining: number;
+  quota_id: string;
+  quota_remaining: number;
+  remaining: number;
+  unlimited: boolean;
+}
+
+export interface CopilotQuotaSnapshots {
+  chat: CopilotQuotaDetail;
+  completions: CopilotQuotaDetail;
+  premium_interactions: CopilotQuotaDetail;
+}
+
+export interface CopilotUsageResponse {
+  access_type_sku?: string;
+  copilot_plan?: string;
+  quota_reset_date?: string;
+  quota_snapshots?: CopilotQuotaSnapshots;
+}
+
+export interface CopilotQuotaWindow {
+  id: string;
+  label: string;
+  labelKey?: string;
+  entitlement: number;
+  remaining: number;
+  used: number;
+  usedPercent: number | null;
+  unlimited: boolean;
+}
+
+export interface CopilotQuotaState {
+  status: 'idle' | 'loading' | 'success' | 'error';
+  windows: CopilotQuotaWindow[];
+  copilotPlan?: string | null;
+  resetDate?: string | null;
+  error?: string;
+  errorStatus?: number;
+}

--- a/src/utils/quota/constants.ts
+++ b/src/utils/quota/constants.ts
@@ -42,6 +42,18 @@ export const TYPE_COLORS: Record<string, TypeColorSet> = {
     light: { bg: '#e0f7fa', text: '#006064' },
     dark: { bg: '#004d40', text: '#80deea' },
   },
+  copilot: {
+    light: { bg: '#e8f0fe', text: '#1a73e8' },
+    dark: { bg: '#1a3b5c', text: '#8ab4f8' },
+  },
+  'github-copilot': {
+    light: { bg: '#e8f0fe', text: '#1a73e8' },
+    dark: { bg: '#1a3b5c', text: '#8ab4f8' },
+  },
+  github: {
+    light: { bg: '#e8f0fe', text: '#1a73e8' },
+    dark: { bg: '#1a3b5c', text: '#8ab4f8' },
+  },
   iflow: {
     light: { bg: '#f5e3fc', text: '#9025c8' },
     dark: { bg: '#521490', text: '#d49cf5' },

--- a/src/utils/quota/constants.ts
+++ b/src/utils/quota/constants.ts
@@ -204,6 +204,11 @@ export const CODEX_REQUEST_HEADERS = {
   'User-Agent': 'codex_cli_rs/0.76.0 (Debian 13.0.0; x86_64) WindowsTerminal',
 };
 
+// Copilot API configuration
+// Note: Copilot uses a dedicated backend endpoint (not the generic /api-call proxy)
+// because the backend handles the GitHub token → Copilot JWT exchange internally.
+export const COPILOT_QUOTA_ENDPOINT = '/copilot-quota';
+
 // Kimi API configuration
 export const KIMI_USAGE_URL = 'https://api.kimi.com/coding/v1/usages';
 

--- a/src/utils/quota/validators.ts
+++ b/src/utils/quota/validators.ts
@@ -43,6 +43,11 @@ export function isKimiFile(file: AuthFileItem): boolean {
   return resolveAuthProvider(file) === 'kimi';
 }
 
+export function isCopilotFile(file: AuthFileItem): boolean {
+  const provider = resolveAuthProvider(file);
+  return provider === 'copilot' || provider === 'github-copilot' || provider === 'github';
+}
+
 export function isRuntimeOnlyAuthFile(file: AuthFileItem): boolean {
   const raw = file['runtime_only'] ?? file.runtimeOnly;
   if (typeof raw === 'boolean') return raw;


### PR DESCRIPTION
## Summary

- Add Copilot quota section to the QuotaPage displaying premium request usage, chat, and completions quota from the GitHub Copilot API
- Add `CopilotQuotaState`, `CopilotQuotaWindow`, and `CopilotUsageResponse` types
- Add `copilotQuota` field and `setCopilotQuota` setter to Zustand store
- Add `COPILOT_CONFIG` with `fetchCopilotQuota` and `renderCopilotItems` following the existing `QuotaConfig` pattern
- Add `copilot`/`github-copilot`/`github` type colors in auth file constants
- Add `isCopilotFile` validator and `COPILOT_QUOTA_URLS` constants
- Add i18n translations (en/zh-CN/ru) for the `copilot_quota` namespace

> Split from #189 — this PR contains **only** the Copilot quota feature with no unrelated changes.

## Changed files

| Area | Files |
|------|-------|
| Types | `src/types/quota.ts` |
| Store | `src/stores/useQuotaStore.ts` |
| Config | `src/components/quota/quotaConfigs.ts`, `src/components/quota/index.ts` |
| Page | `src/pages/QuotaPage.tsx`, `src/pages/QuotaPage.module.scss` |
| Utils | `src/utils/quota/constants.ts`, `src/utils/quota/validators.ts` |
| Auth | `src/features/authFiles/constants.ts` |
| i18n | `src/i18n/locales/{en,zh-CN,ru}.json` |

## Test plan

- [ ] Verify Copilot quota section renders on QuotaPage when Copilot auth files exist
- [ ] Verify premium requests / chat / completions bars display correct usage
- [ ] Verify error states (missing auth_index, API failure) show appropriate messages
- [ ] Verify non-Copilot quota sections are unaffected