### PR TITLE
fix: improve responsive layout and add collapsible sidebar

### DIFF
--- a/src/components/config/ConfigSection.module.scss
+++ b/src/components/config/ConfigSection.module.scss
@@ -14,6 +14,13 @@
     padding-top: 0;
   }
 
+  @include tablet {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 18px;
+    padding: 22px 0;
+    scroll-margin-top: 88px;
+  }
+
   @include mobile {
     grid-template-columns: minmax(0, 1fr);
     gap: 18px;
@@ -29,6 +36,10 @@
   display: flex;
   flex-direction: column;
   gap: 14px;
+
+  @include tablet {
+    position: static;
+  }
 
   @include mobile {
     position: static;
@@ -94,6 +105,10 @@
   color: var(--text-secondary);
   font-size: 14px;
   line-height: 1.7;
+
+  @include tablet {
+    max-width: none;
+  }
 
   @include mobile {
     max-width: none;

--- a/src/components/config/VisualConfigEditor.module.scss
+++ b/src/components/config/VisualConfigEditor.module.scss
@@ -574,10 +574,14 @@
   display: flex;
   flex-direction: column;
   min-width: 0;
-  padding: clamp(20px, 3vw, 30px);
+  padding: clamp(16px, 3vw, 30px);
   border-radius: 32px;
   border: 1px solid color-mix(in srgb, var(--border-color) 84%, transparent);
   background: color-mix(in srgb, var(--bg-primary) 76%, transparent);
+
+  @include tablet {
+    border-radius: 24px;
+  }
 }
 
 .sectionGrid {
@@ -610,6 +614,11 @@
   border-radius: 18px;
   border: 1px solid color-mix(in srgb, var(--border-color) 82%, transparent);
   background: color-mix(in srgb, var(--bg-primary) 84%, transparent);
+
+  @include tablet {
+    gap: 12px;
+    padding: 14px 16px;
+  }
 
   @include mobile {
     grid-template-columns: minmax(0, 1fr);

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -32,7 +32,7 @@ import {
   useThemeStore,
 } from '@/stores';
 import { triggerHeaderRefresh } from '@/hooks/useHeaderRefresh';
-import { LANGUAGE_LABEL_KEYS, LANGUAGE_ORDER } from '@/utils/constants';
+import { LANGUAGE_LABEL_KEYS, LANGUAGE_ORDER, STORAGE_KEY_SIDEBAR } from '@/utils/constants';
 import { isSupportedLanguage } from '@/utils/language';
 import type { Theme } from '@/types';
 
@@ -221,7 +221,17 @@ export function MainLayout() {
   const setLanguage = useLanguageStore((state) => state.setLanguage);
 
   const [sidebarOpen, setSidebarOpen] = useState(false);
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY_SIDEBAR);
+      if (stored !== null) return stored === 'true';
+    } catch {
+      // localStorage may be unavailable in restricted environments
+    }
+    // Auto-collapse on tablet-to-desktop viewports; preserve mobile drawer UX
+    const w = window.innerWidth;
+    return w > 768 && w <= 1280;
+  });
   const [languageMenuOpen, setLanguageMenuOpen] = useState(false);
   const [themeMenuOpen, setThemeMenuOpen] = useState(false);
   const [brandExpanded, setBrandExpanded] = useState(true);
@@ -360,6 +370,18 @@ export function MainLayout() {
       document.removeEventListener('keydown', handleEscape);
     };
   }, [themeMenuOpen]);
+
+  const toggleSidebarCollapsed = useCallback(() => {
+    setSidebarCollapsed((prev) => {
+      const next = !prev;
+      try {
+        localStorage.setItem(STORAGE_KEY_SIDEBAR, String(next));
+      } catch {
+        // localStorage may be unavailable in restricted environments
+      }
+      return next;
+    });
+  }, []);
 
   const handleBrandClick = useCallback(() => {
     if (!brandExpanded) {
@@ -513,11 +535,11 @@ export function MainLayout() {
         <div className="left">
           <button
             className="sidebar-toggle-header"
-            onClick={() => setSidebarCollapsed((prev) => !prev)}
+            onClick={toggleSidebarCollapsed}
             title={
               sidebarCollapsed
-                ? t('sidebar.expand', { defaultValue: '展开' })
-                : t('sidebar.collapse', { defaultValue: '收起' })
+                ? t('sidebar.toggle_expand')
+                : t('sidebar.toggle_collapse')
             }
           >
             {sidebarCollapsed ? headerIcons.chevronRight : headerIcons.chevronLeft}
@@ -708,6 +730,22 @@ export function MainLayout() {
               </NavLink>
             ))}
           </div>
+          <button
+            className="sidebar-collapse-btn"
+            onClick={toggleSidebarCollapsed}
+            title={
+              sidebarCollapsed
+                ? t('sidebar.toggle_expand')
+                : t('sidebar.toggle_collapse')
+            }
+          >
+            {sidebarCollapsed ? headerIcons.chevronRight : headerIcons.chevronLeft}
+            {!sidebarCollapsed && (
+              <span className="sidebar-collapse-label">
+                {t('sidebar.toggle_collapse')}
+              </span>
+            )}
+          </button>
         </aside>
 
         <div className={`content${isLogsPage ? ' content-logs' : ''}`} ref={contentRef}>

--- a/src/pages/AuthFilesPage.module.scss
+++ b/src/pages/AuthFilesPage.module.scss
@@ -4,7 +4,7 @@
 .container {
   display: flex;
   flex-direction: column;
-  gap: $spacing-lg;
+  gap: $spacing-md;
   padding-bottom: calc(
     var(--auth-files-action-bar-height, 0px) + 16px + env(safe-area-inset-bottom)
   );
@@ -17,10 +17,14 @@
 }
 
 .pageTitle {
-  font-size: 28px;
+  font-size: 26px;
   font-weight: 700;
   color: var(--text-primary);
   margin: 0;
+
+  @include mobile {
+    font-size: 22px;
+  }
 }
 
 .description {
@@ -82,21 +86,21 @@
 .filterSection {
   display: flex;
   flex-direction: column;
-  gap: $spacing-md;
-  margin-bottom: $spacing-lg;
+  gap: $spacing-sm;
+  margin-bottom: $spacing-md;
 }
 
 .filterRail {
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  padding: 12px 14px;
+  gap: 8px;
+  padding: 10px 12px;
   border-radius: 10px;
   border: 1px solid color-mix(in srgb, var(--border-color) 60%, transparent);
   background: color-mix(in srgb, var(--bg-secondary) 60%, transparent);
 
   @include mobile {
-    padding: 10px;
+    padding: 8px;
   }
 }
 
@@ -232,7 +236,7 @@
 }
 
 .filterControlsPanel {
-  padding: 14px;
+  padding: 12px;
   border-radius: 10px;
   border: 1px solid color-mix(in srgb, var(--border-color) 60%, transparent);
   background: color-mix(in srgb, var(--bg-secondary) 50%, transparent);
@@ -240,8 +244,8 @@
 
 .filterControls {
   display: grid;
-  grid-template-columns: minmax(240px, 1.4fr) repeat(2, minmax(120px, 0.72fr)) minmax(220px, auto);
-  gap: $spacing-md;
+  grid-template-columns: minmax(200px, 1.4fr) repeat(2, minmax(100px, 0.7fr)) minmax(180px, auto);
+  gap: $spacing-sm $spacing-md;
   align-items: flex-end;
 
   // 修复 Input 组件在 filterItem 中的嵌套样式
@@ -250,12 +254,12 @@
   }
 
   :global(.input) {
-    height: 40px;
+    height: 36px;
     box-sizing: border-box;
   }
 
   @include tablet {
-    grid-template-columns: minmax(220px, 1fr) repeat(2, minmax(140px, 0.8fr));
+    grid-template-columns: minmax(180px, 1fr) repeat(2, minmax(100px, 0.7fr));
   }
 
   @include mobile {
@@ -281,23 +285,20 @@
 
 .filterToggleItem {
   min-width: 0;
-
-  @include tablet {
-    grid-column: 1 / -1;
-  }
+  grid-column: 1 / -1;
 }
 
 .filterToggleGroup {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 8px;
-  min-height: 40px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  min-height: 36px;
 }
 
 .filterToggleCard {
   display: flex;
   align-items: center;
-  min-height: 40px;
+  min-height: 36px;
   padding: 0 2px;
   border-radius: 8px;
   border: 1px solid color-mix(in srgb, var(--border-color) 60%, transparent);
@@ -307,7 +308,7 @@
 .filterToggle {
   display: flex;
   align-items: center;
-  min-height: 40px;
+  min-height: 36px;
   padding-inline: 2px;
 }
 
@@ -322,14 +323,14 @@
 
 .pageSizeSelect {
   width: 100%;
-  padding: 8px 12px;
+  padding: 6px 12px;
   border: 1px solid color-mix(in srgb, var(--border-color) 70%, transparent);
   border-radius: 8px;
   background-color: var(--bg-secondary);
   color: var(--text-primary);
   font-size: 14px;
   cursor: text;
-  height: 40px;
+  height: 36px;
   box-sizing: border-box;
 
   &:focus {
@@ -343,15 +344,15 @@
 .fileGrid {
   display: grid;
   gap: $spacing-md;
-  grid-template-columns: repeat(auto-fill, minmax(min(100%, 320px), 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 300px), 1fr));
 }
 
 .fileGridQuotaManaged {
-  grid-template-columns: repeat(auto-fill, minmax(min(100%, 340px), 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 320px), 1fr));
 }
 
 .fileGridCompact {
-  grid-template-columns: repeat(auto-fill, minmax(min(100%, 280px), 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 260px), 1fr));
 }
 
 .antigravityGrid {

--- a/src/styles/components.scss
+++ b/src/styles/components.scss
@@ -124,6 +124,10 @@ textarea {
   border-radius: $radius-lg;
   box-shadow: var(--shadow);
   padding: $spacing-lg;
+
+  @media (max-width: $breakpoint-mobile) {
+    padding: $spacing-md;
+  }
 }
 
 .card-header {

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -466,7 +466,7 @@
 }
 
 .sidebar {
-  width: 240px;
+  width: 260px;
   background: var(--bg-primary);
   border-right: 1px solid var(--border-color);
   padding: $spacing-md;
@@ -475,6 +475,7 @@
   gap: $spacing-lg;
   transition:
     width $transition-normal,
+    padding $transition-normal,
     transform $transition-normal;
   overflow-y: auto;
   flex-shrink: 0;
@@ -503,6 +504,7 @@
     border: 1px solid transparent;
     color: var(--text-primary);
     font-weight: 600;
+    font-size: 14px;
     display: flex;
     align-items: center;
     gap: $spacing-sm;
@@ -539,6 +541,7 @@
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
+      transition: opacity $transition-fast;
     }
 
     &:hover {
@@ -564,6 +567,46 @@
     }
   }
 
+  .sidebar-collapse-btn {
+    display: flex;
+    align-items: center;
+    gap: $spacing-sm;
+    width: 100%;
+    padding: 10px 12px;
+    border: 1px solid color-mix(in srgb, var(--border-color) 50%, transparent);
+    border-radius: $radius-md;
+    background: transparent;
+    color: var(--text-tertiary);
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    transition:
+      background $transition-fast,
+      color $transition-fast;
+    flex-shrink: 0;
+
+    &:hover {
+      background: var(--bg-secondary);
+      color: var(--text-primary);
+    }
+
+    svg {
+      flex-shrink: 0;
+    }
+
+    .sidebar-collapse-label {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
+
+  &.collapsed .sidebar-collapse-btn {
+    justify-content: center;
+    padding: 10px;
+    border-color: transparent;
+  }
+
   @media (max-width: $breakpoint-mobile) {
     position: fixed;
     z-index: $z-dropdown;
@@ -575,6 +618,10 @@
 
     &.open {
       transform: translateX(0);
+    }
+
+    .sidebar-collapse-btn {
+      display: none;
     }
   }
 }
@@ -604,7 +651,7 @@
   padding: $spacing-lg;
   display: flex;
   flex-direction: column;
-  gap: $spacing-lg;
+  gap: $spacing-md;
   overflow-x: hidden;
 
   &.main-content-logs {


### PR DESCRIPTION
## Summary

- **Collapsible sidebar**: add bottom collapse/expand button with `localStorage` persistence; auto-collapse on tablet viewports (769–1280px); smooth width/padding transitions
- **Responsive layout**: single-column config grid on tablet, tighter padding for visual editor, improved auth files page spacing

> Split from #192 — this PR contains **only** layout/sidebar changes with no unrelated features. All review feedback from the previous submission has been addressed.

## Fixes from previous review

| Issue | Fix |
|-------|-----|
| `localStorage` access may throw in restricted environments | Wrapped in `try/catch` |
| Hardcoded `'sidebar-collapsed'` key | Uses `STORAGE_KEY_SIDEBAR` from `@/utils/constants` |
| Wrong i18n keys (`sidebar.expand/collapse`) | Changed to `sidebar.toggle_expand/toggle_collapse` |
| Auto-collapse `<= 1280` includes mobile widths | Changed to `769 < w <= 1280` (tablet-only) |
| `.sidebar-collapse-label` styled under `.nav-item` | Moved to `.sidebar-collapse-btn` where the element is rendered |

## Changed files

| Area | Files |
|------|-------|
| Layout | `src/components/layout/MainLayout.tsx` |
| Styles | `src/styles/layout.scss`, `src/styles/components.scss` |
| Config responsive | `src/components/config/ConfigSection.module.scss`, `src/components/config/VisualConfigEditor.module.scss` |
| Auth page | `src/pages/AuthFilesPage.module.scss` |

## Test plan

- [ ] Verify sidebar collapse/expand button works, state persists across refresh
- [ ] Verify auto-collapse fires on tablet (769–1280px) but NOT on mobile (< 769px)
- [ ] Verify ConfigSection switches to single-column on tablet breakpoint
- [ ] Verify i18n labels render correctly in en/zh-CN/ru
- [ ] Verify mobile drawer UX is unaffected (sidebar-collapse-btn hidden)