### PR TITLE
feat: update auth files quota section

### DIFF
--- a/src/features/authFiles/components/AuthFileQuotaSection.tsx
+++ b/src/features/authFiles/components/AuthFileQuotaSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, type ReactNode } from 'react';
+import { useCallback, useEffect, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import {
@@ -16,6 +16,7 @@ import {
   resolveQuotaErrorMessage,
   type QuotaProviderType
 } from '@/features/authFiles/constants';
+import { subscribeAuthFilesQuotaRefresh } from '@/features/authFiles/quotaRefreshEvents';
 import { QuotaProgressBar } from '@/features/authFiles/components/QuotaProgressBar';
 import styles from '@/pages/AuthFilesPage.module.scss';
 
@@ -56,11 +57,12 @@ export function AuthFileQuotaSection(props: AuthFileQuotaSectionProps) {
     return state.setGeminiCliQuota as unknown as (updater: unknown) => void;
   });
 
-  const refreshQuotaForFile = useCallback(async () => {
+  const refreshQuotaForFile = useCallback(async (options?: { silent?: boolean }) => {
     if (disableControls) return;
     if (isRuntimeOnlyAuthFile(file)) return;
     if (file.disabled) return;
     if (quota?.status === 'loading') return;
+    const silent = options?.silent === true;
 
     const config = getQuotaConfig(quotaType) as unknown as {
       i18nPrefix: string;
@@ -82,7 +84,9 @@ export function AuthFileQuotaSection(props: AuthFileQuotaSectionProps) {
         ...prev,
         [file.name]: config.buildSuccessState(data)
       }));
-      showNotification(t('auth_files.quota_refresh_success', { name: file.name }), 'success');
+      if (!silent) {
+        showNotification(t('auth_files.quota_refresh_success', { name: file.name }), 'success');
+      }
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : t('common.unknown_error');
       const status = getStatusFromError(err);
@@ -90,9 +94,21 @@ export function AuthFileQuotaSection(props: AuthFileQuotaSectionProps) {
         ...prev,
         [file.name]: config.buildErrorState(message, status)
       }));
-      showNotification(t('auth_files.quota_refresh_failed', { name: file.name, message }), 'error');
+      if (!silent) {
+        showNotification(t('auth_files.quota_refresh_failed', { name: file.name, message }), 'error');
+      }
     }
   }, [disableControls, file, quota?.status, quotaType, showNotification, t, updateQuotaState]);
+
+  useEffect(() => {
+    const unsubscribe = subscribeAuthFilesQuotaRefresh((detail) => {
+      if (detail.quotaType !== quotaType) return;
+      if (!detail.fileNames.includes(file.name)) return;
+      void refreshQuotaForFile({ silent: true });
+    });
+
+    return unsubscribe;
+  }, [file.name, quotaType, refreshQuotaForFile]);
 
   const config = getQuotaConfig(quotaType) as unknown as {
     i18nPrefix: string;

--- a/src/features/authFiles/quotaRefreshEvents.ts
+++ b/src/features/authFiles/quotaRefreshEvents.ts
@@ -1,0 +1,35 @@
+import type { QuotaProviderType } from '@/features/authFiles/constants';
+
+export const AUTH_FILES_QUOTA_REFRESH_EVENT = 'auth-files:quota-refresh';
+
+export interface AuthFilesQuotaRefreshDetail {
+  quotaType: QuotaProviderType | null;
+  fileNames: string[];
+  reason?: 'header-refresh';
+}
+
+export const triggerAuthFilesQuotaRefresh = (detail: AuthFilesQuotaRefreshDetail) => {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(
+    new CustomEvent<AuthFilesQuotaRefreshDetail>(AUTH_FILES_QUOTA_REFRESH_EVENT, { detail })
+  );
+};
+
+export const subscribeAuthFilesQuotaRefresh = (
+  listener: (detail: AuthFilesQuotaRefreshDetail) => void
+) => {
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  const handler: EventListener = (event) => {
+    const customEvent = event as CustomEvent<AuthFilesQuotaRefreshDetail>;
+    if (!customEvent.detail) return;
+    listener(customEvent.detail);
+  };
+
+  window.addEventListener(AUTH_FILES_QUOTA_REFRESH_EVENT, handler);
+  return () => {
+    window.removeEventListener(AUTH_FILES_QUOTA_REFRESH_EVENT, handler);
+  };
+};

--- a/src/pages/AuthFilesPage.tsx
+++ b/src/pages/AuthFilesPage.tsx
@@ -59,6 +59,7 @@ import {
   type AuthFilesSortMode,
 } from '@/features/authFiles/uiState';
 import { useAuthStore, useNotificationStore, useThemeStore } from '@/stores';
+import { triggerAuthFilesQuotaRefresh } from '@/features/authFiles/quotaRefreshEvents';
 import styles from './AuthFilesPage.module.scss';
 
 const easePower3Out = (progress: number) => 1 - (1 - progress) ** 4;
@@ -323,12 +324,6 @@ export function AuthFilesPage() {
     [loadFiles, sortMode]
   );
 
-  const handleHeaderRefresh = useCallback(async () => {
-    await Promise.all([loadFiles(), refreshKeyStats(), loadExcluded(), loadModelAlias()]);
-  }, [loadFiles, refreshKeyStats, loadExcluded, loadModelAlias]);
-
-  useHeaderRefresh(handleHeaderRefresh);
-
   useEffect(() => {
     if (!isCurrentLayer) return;
     loadFiles();
@@ -423,6 +418,16 @@ export function AuthFilesPage() {
   const currentPage = Math.min(page, totalPages);
   const start = (currentPage - 1) * pageSize;
   const pageItems = sorted.slice(start, start + pageSize);
+  const visibleQuotaFileNames = useMemo(() => {
+    if (!quotaFilterType || compactMode) return [];
+
+    return pageItems
+      .filter((file) => !isRuntimeOnlyAuthFile(file))
+      .filter(
+        (file) => normalizeProviderKey(String(file.provider ?? file.type ?? '')) === quotaFilterType
+      )
+      .map((file) => file.name);
+  }, [compactMode, pageItems, quotaFilterType]);
   const selectablePageItems = useMemo(
     () => pageItems.filter((file) => !isRuntimeOnlyAuthFile(file)),
     [pageItems]
@@ -431,6 +436,28 @@ export function AuthFilesPage() {
     () => sorted.filter((file) => !isRuntimeOnlyAuthFile(file)),
     [sorted]
   );
+  const handleHeaderRefresh = useCallback(async () => {
+    await Promise.all([loadFiles(), refreshKeyStats(), loadExcluded(), loadModelAlias()]);
+
+    if (quotaFilterType && visibleQuotaFileNames.length > 0 && !compactMode) {
+      triggerAuthFilesQuotaRefresh({
+        quotaType: quotaFilterType,
+        fileNames: visibleQuotaFileNames,
+        reason: 'header-refresh',
+      });
+    }
+  }, [
+    compactMode,
+    loadFiles,
+    loadExcluded,
+    loadModelAlias,
+    quotaFilterType,
+    refreshKeyStats,
+    visibleQuotaFileNames,
+  ]);
+
+  useHeaderRefresh(handleHeaderRefresh);
+
   const selectedNames = useMemo(() => Array.from(selectedFiles), [selectedFiles]);
   const selectedHasStatusUpdating = useMemo(
     () => selectedNames.some((name) => statusUpdating[name] === true),


### PR DESCRIPTION
## Summary
This PR improves the Auth Files quota section, with a focus on clearer quota display and more stable refresh behavior.Refreshing the certification document page will simultaneously refresh the remaining balance of the codex credentials within the page.

## Changes
- Refactor quota refresh event handling logic
- Update `AuthFileQuotaSection` rendering and interaction behavior
- Adjust `AuthFilesPage` integration to ensure quota state updates correctly

## Impact
- Better user experience in quota-related operations
- More consistent quota refresh behavior across page interactions
- No breaking API changes

## Verification
- [x] Quota section renders correctly
- [x] Quota refresh works after related actions
- [x] No TypeScript/ESLint errors introduced
