### PR TITLE
fix(quota): detect Claude Team organizations instead of marking Free

### DIFF
--- a/src/components/quota/quotaConfigs.ts
+++ b/src/components/quota/quotaConfigs.ts
@@ -974,6 +974,13 @@ const resolveClaudePlanType = (profile: ClaudeProfileResponse | null): string | 
   const hasClaudePro = normalizeFlagValue(profile.account?.has_claude_pro);
   if (hasClaudePro) return 'plan_pro';
 
+  const organizationType = normalizeStringValue(profile.organization?.organization_type)?.toLowerCase();
+  const subscriptionStatus = normalizeStringValue(profile.organization?.subscription_status)?.toLowerCase();
+
+  if (organizationType === 'claude_team' && subscriptionStatus === 'active') {
+    return 'plan_team';
+  }
+
   if (hasClaudeMax === false && hasClaudePro === false) return 'plan_free';
 
   return null;

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -645,7 +645,8 @@
     "plan_pro": "Pro",
     "plan_max": "Max",
     "plan_max5": "Max 5x",
-    "plan_max20": "Max 20x"
+    "plan_max20": "Max 20x",
+    "plan_team": "Team"
   },
   "codex_quota": {
     "title": "Codex Quota",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -642,7 +642,8 @@
     "plan_pro": "Pro",
     "plan_max": "Max",
     "plan_max5": "Max 5x",
-    "plan_max20": "Max 20x"
+    "plan_max20": "Max 20x",
+    "plan_team": "Team"
   },
   "codex_quota": {
     "title": "Квота Codex",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -645,7 +645,8 @@
     "plan_pro": "专业版",
     "plan_max": "Max",
     "plan_max5": "Max 5x",
-    "plan_max20": "Max 20x"
+    "plan_max20": "Max 20x",
+    "plan_team": "团队版"
   },
   "codex_quota": {
     "title": "Codex 额度",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -645,7 +645,8 @@
     "plan_pro": "專業版",
     "plan_max": "Max",
     "plan_max5": "Max 5x",
-    "plan_max20": "Max 20x"
+    "plan_max20": "Max 20x",
+    "plan_team": "團隊版"
   },
   "codex_quota": {
     "title": "Codex 配額",


### PR DESCRIPTION
## Summary

- Claude Team accounts report `has_claude_pro=false` and `has_claude_max=false`, so `resolveClaudePlanType` fell through to `plan_free` even though the OAuth profile clearly identifies an active Claude Team organization.
- Inspect `profile.organization.organization_type` and `subscription_status` before falling back to Free. When the org type is `claude_team` and the subscription is `active`, return a new `plan_team` key.
- Add `claude_quota.plan_team` translations for en (`Team`), zh-CN (`团队版`), zh-TW (`團隊版`), and ru (`Team`).

Fixes #222.

## Test plan

- [x] `npm run type-check` passes
- [x] `npm run lint` passes (ESLint: No issues found)
- [x] `npm run build` succeeds (715 modules transformed)
- [x] Logic verification against the issue's redacted payload and 9 edge cases (Max/Pro priority, inactive Team, non-team orgs, null profile, whitespace/mixed case) — all 10 branches return the expected plan key
- [x] Render path confirmed: `quotaConfigs.ts:1060` resolves the plan label via `t(\`claude_quota.${planType}\`)`, so `plan_team` maps directly to the new translation key in each locale
- [ ] Reviewer spot-check in a live Management Center against a real Claude Team / Pro / Max / Free account