### PR TITLE
Retrospective: frontend release metadata and packaging pipeline

### DIFF
--- a/PROJECT_RELATIONSHIP.md
+++ b/PROJECT_RELATIONSHIP.md
@@ -1,0 +1,23 @@
+# Companion Project Relationship
+
+This repository is the companion Management UI for CLIProxyAPI.
+
+## Primary companion repository
+
+- Service + OpenClaw autonomy fork:
+  - https://github.com/luyuehm/CLIProxyAPI
+
+## Role of this repository
+
+This repository provides the human-facing Management API UI:
+- config editing
+- credentials/auth file handling
+- usage and quota views
+- log viewing
+- interactive troubleshooting
+
+It does **not** provide the OpenClaw autonomy/governance layer by itself.
+
+## If you need automation
+
+For heartbeat, self-heal, cron templates, OpenClaw installation, bootstrap docs, and fork sync maintenance, see the companion repository above.

--- a/PROJECT_RELATIONSHIP.md
+++ b/PROJECT_RELATIONSHIP.md
@@ -21,3 +21,19 @@ It does **not** provide the OpenClaw autonomy/governance layer by itself.
 ## If you need automation
 
 For heartbeat, self-heal, cron templates, OpenClaw installation, bootstrap docs, and fork sync maintenance, see the companion repository above.
+
+
+## Do you need both repositories?
+
+Not always.
+
+### If you only need the UI
+You can use this repository alone for Management API frontend development.
+
+### If you need a real deployable/operator setup
+You should also use the companion repository:
+- https://github.com/luyuehm/CLIProxyAPI
+
+Recommended default:
+- required main repo: `luyuehm/CLIProxyAPI`
+- optional UI companion: `luyuehm/Cli-Proxy-API-Management-Center`

--- a/PROJECT_RELATIONSHIP.md
+++ b/PROJECT_RELATIONSHIP.md
@@ -37,3 +37,8 @@ You should also use the companion repository:
 Recommended default:
 - required main repo: `luyuehm/CLIProxyAPI`
 - optional UI companion: `luyuehm/Cli-Proxy-API-Management-Center`
+
+
+## Repository selection
+
+See `REPO_SELECTION.md` for a scenario-based selection matrix.

--- a/README.md
+++ b/README.md
@@ -157,3 +157,15 @@ Issues and PRs are welcome. Please include:
 ## License
 
 MIT
+
+
+## OpenClaw autonomy companion
+
+If you want the **service fork + OpenClaw autonomy/self-heal/bootstrap layer**, use the companion repository:
+
+- https://github.com/luyuehm/CLIProxyAPI
+
+This repository is the **Management Center UI** only.
+
+See also:
+- `PROJECT_RELATIONSHIP.md`

--- a/README.md
+++ b/README.md
@@ -169,3 +169,14 @@ This repository is the **Management Center UI** only.
 
 See also:
 - `PROJECT_RELATIONSHIP.md`
+
+
+## Do I need both repositories?
+
+Usually:
+- use `luyuehm/CLIProxyAPI` as the main service/OpenClaw repository
+- use this repository only if you also want the browser Management Center UI
+
+So the default answer is:
+- required main repo: `luyuehm/CLIProxyAPI`
+- optional companion UI repo: this repository

--- a/README.md
+++ b/README.md
@@ -180,3 +180,6 @@ Usually:
 So the default answer is:
 - required main repo: `luyuehm/CLIProxyAPI`
 - optional companion UI repo: this repository
+
+
+Need help choosing repositories? See `REPO_SELECTION.md`.

--- a/README_CN.md
+++ b/README_CN.md
@@ -179,3 +179,6 @@ MIT
 所以默认答案是：
 - 必选主仓：`luyuehm/CLIProxyAPI`
 - 可选配套 UI 仓：当前仓库
+
+
+如果你不知道当前仓库是否需要一起用，请看：`REPO_SELECTION.md`。

--- a/README_CN.md
+++ b/README_CN.md
@@ -156,3 +156,15 @@ npm run type-check # tsc --noEmit
 ## 许可证
 
 MIT
+
+
+## OpenClaw 自治配套仓
+
+如果你需要的是：**服务主仓 + OpenClaw 自愈/巡检/接管/bootstrap 能力**，请使用配套仓：
+
+- https://github.com/luyuehm/CLIProxyAPI
+
+当前仓库只负责：**Management Center 管理界面**。
+
+另见：
+- `PROJECT_RELATIONSHIP.md`

--- a/README_CN.md
+++ b/README_CN.md
@@ -168,3 +168,14 @@ MIT
 
 另见：
 - `PROJECT_RELATIONSHIP.md`
+
+
+## 是否两个仓库都要用？
+
+通常建议：
+- 把 `luyuehm/CLIProxyAPI` 当作主仓（服务 + OpenClaw 自治层）
+- 只有在你还需要浏览器管理后台时，再配合当前仓库一起用
+
+所以默认答案是：
+- 必选主仓：`luyuehm/CLIProxyAPI`
+- 可选配套 UI 仓：当前仓库

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,10 +1,10 @@
 # Release Notes
 
 - Name: cli-proxy-webui-react
-- Version: v2026.04.21+8b5c0c0
-- Build Date: 2026-04-21T21:49:33Z
-- Build Stamp: 202604212149
-- Commit: 8b5c0c0
+- Version: v2026.04.21
+- Build Date: 2026-04-21T22:04:26Z
+- Build Stamp: 202604212204
+- Commit: f90c387
 
 ## Included metadata
 - Login page version/build date

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,14 @@
+# Release Notes
+
+- Name: cli-proxy-webui-react
+- Version: d523867
+- Build Date: 2026-04-21T21:47:23Z
+- Build Stamp: 202604212147
+- Commit: d523867
+
+## Included metadata
+- Login page version/build date
+- System page version/build date
+- Header UI version badge
+- Global footer build metadata
+- BUILD_INFO.json embedded in release bundle

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,10 +1,10 @@
 # Release Notes
 
 - Name: cli-proxy-webui-react
-- Version: d523867
-- Build Date: 2026-04-21T21:47:23Z
-- Build Stamp: 202604212147
-- Commit: d523867
+- Version: d15371f
+- Build Date: 2026-04-21T21:49:02Z
+- Build Stamp: 202604212149
+- Commit: d15371f
 
 ## Included metadata
 - Login page version/build date

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,10 +1,10 @@
 # Release Notes
 
 - Name: cli-proxy-webui-react
-- Version: d15371f
-- Build Date: 2026-04-21T21:49:02Z
+- Version: v2026.04.21+8b5c0c0
+- Build Date: 2026-04-21T21:49:33Z
 - Build Stamp: 202604212149
-- Commit: d15371f
+- Commit: 8b5c0c0
 
 ## Included metadata
 - Login page version/build date

--- a/REPO_SELECTION.md
+++ b/REPO_SELECTION.md
@@ -1,0 +1,22 @@
+# Repository Selection Matrix
+
+This repository is optional in most setups.
+
+## Default choice
+
+Start with:
+- `https://github.com/luyuehm/CLIProxyAPI`
+
+Use this repository additionally when you need:
+- a dedicated browser Management Center UI
+- frontend development for the Management API UI itself
+
+## Matrix
+
+| Scenario | Required repo | Optional repo |
+|---|---|---|
+| I want the service/backend fork | `luyuehm/CLIProxyAPI` | — |
+| I want OpenClaw autonomy/self-heal/bootstrap | `luyuehm/CLIProxyAPI` | — |
+| I want the Management UI in browser | `luyuehm/CLIProxyAPI` | `luyuehm/Cli-Proxy-API-Management-Center` |
+| I am only working on the UI project | — | `luyuehm/Cli-Proxy-API-Management-Center` |
+| I want a full operator stack | `luyuehm/CLIProxyAPI` | `luyuehm/Cli-Proxy-API-Management-Center` |

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives",
     "format": "prettier --write \"src/**/*.{ts,tsx,css,scss}\"",
     "type-check": "tsc --noEmit",
-    "build:release": "VERSION=${VERSION:-$(git describe --tags --always 2>/dev/null || echo dev)} BUILD_DATE=${BUILD_DATE:-$(date -u +%Y-%m-%dT%H:%M:%SZ)} GIT_COMMIT_SHORT=${GIT_COMMIT_SHORT:-$(git rev-parse --short HEAD 2>/dev/null || echo local)} npm run build"
+    "build:release": "VERSION=${VERSION:-$(git describe --tags --always 2>/dev/null || echo dev)} BUILD_DATE=${BUILD_DATE:-$(date -u +%Y-%m-%dT%H:%M:%SZ)} GIT_COMMIT_SHORT=${GIT_COMMIT_SHORT:-$(git rev-parse --short HEAD 2>/dev/null || echo local)} npm run build",
+    "build:release:zip": "npm run build:release && LATEST=$(ls -dt dist-* | head -n 1) && rm -f ${LATEST}.zip && /usr/bin/zip -qry ${LATEST}.zip ${LATEST} && echo ${LATEST}.zip"
   },
   "dependencies": {
     "@codemirror/lang-yaml": "^6.1.2",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives",
     "format": "prettier --write \"src/**/*.{ts,tsx,css,scss}\"",
     "type-check": "tsc --noEmit",
-    "build:release": "VERSION=${VERSION:-$(git describe --tags --always 2>/dev/null || echo dev)} BUILD_DATE=${BUILD_DATE:-$(date -u +%Y-%m-%dT%H:%M:%SZ)} GIT_COMMIT_SHORT=${GIT_COMMIT_SHORT:-$(git rev-parse --short HEAD 2>/dev/null || echo local)} npm run build",
-    "build:release:zip": "npm run build:release && LATEST=$(ls -dt dist-* | head -n 1) && rm -f ${LATEST}.zip && /usr/bin/zip -qry ${LATEST}.zip ${LATEST} && echo ${LATEST}.zip",
-    "build:release:archive": "npm run build:release:zip && mkdir -p releases && LATEST_DIR=$(find . -maxdepth 1 -type d -name 'dist-*' | sed 's#^./##' | sort | tail -n 1) && LATEST_ZIP=$(find . -maxdepth 1 -type f -name 'dist-*.zip' | sed 's#^./##' | sort | tail -n 1) && cp -f ${LATEST_ZIP} releases/ && cp -f ${LATEST_DIR}/BUILD_INFO.json releases/${LATEST_DIR}.BUILD_INFO.json && cp -f RELEASE.md releases/${LATEST_DIR}.RELEASE.md && echo releases/${LATEST_ZIP}"
+    "build:release": "VERSION=${VERSION:-v$(date -u +%Y.%m.%d)+$(git rev-parse --short HEAD 2>/dev/null || echo local)} BUILD_DATE=${BUILD_DATE:-$(date -u +%Y-%m-%dT%H:%M:%SZ)} GIT_COMMIT_SHORT=${GIT_COMMIT_SHORT:-$(git rev-parse --short HEAD 2>/dev/null || echo local)} npm run build",
+    "build:release:zip": "npm run build:release && LATEST=$(find . -maxdepth 1 -type d -name 'dist-*' | sed 's#^./##' | sort | tail -n 1) && rm -f ${LATEST}.zip && /usr/bin/zip -qry ${LATEST}.zip ${LATEST} && echo ${LATEST}.zip",
+    "build:release:archive": "npm run build:release:zip && mkdir -p releases && LATEST_DIR=$(find . -maxdepth 1 -type d -name 'dist-*' | sed 's#^./##' | sort | tail -n 1) && LATEST_ZIP=$(find . -maxdepth 1 -type f -name 'dist-*.zip' | sed 's#^./##' | sort | tail -n 1) && cp -f ${LATEST_ZIP} releases/ && cp -f ${LATEST_DIR}/BUILD_INFO.json releases/${LATEST_DIR}.BUILD_INFO.json && cp -f ${LATEST_DIR}/RELEASE.md releases/${LATEST_DIR}.RELEASE.md && echo releases/${LATEST_ZIP}"
   },
   "dependencies": {
     "@codemirror/lang-yaml": "^6.1.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives",
     "format": "prettier --write \"src/**/*.{ts,tsx,css,scss}\"",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "build:release": "VERSION=${VERSION:-$(git describe --tags --always 2>/dev/null || echo dev)} BUILD_DATE=${BUILD_DATE:-$(date -u +%Y-%m-%dT%H:%M:%SZ)} GIT_COMMIT_SHORT=${GIT_COMMIT_SHORT:-$(git rev-parse --short HEAD 2>/dev/null || echo local)} npm run build"
   },
   "dependencies": {
     "@codemirror/lang-yaml": "^6.1.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives",
     "format": "prettier --write \"src/**/*.{ts,tsx,css,scss}\"",
     "type-check": "tsc --noEmit",
-    "build:release": "VERSION=${VERSION:-v$(date -u +%Y.%m.%d)+$(git rev-parse --short HEAD 2>/dev/null || echo local)} BUILD_DATE=${BUILD_DATE:-$(date -u +%Y-%m-%dT%H:%M:%SZ)} GIT_COMMIT_SHORT=${GIT_COMMIT_SHORT:-$(git rev-parse --short HEAD 2>/dev/null || echo local)} npm run build",
+    "build:release": "VERSION=${VERSION:-v$(date -u +%Y.%m.%d)${VERSION_SUFFIX:+-${VERSION_SUFFIX}}} BUILD_DATE=${BUILD_DATE:-$(date -u +%Y-%m-%dT%H:%M:%SZ)} GIT_COMMIT_SHORT=${GIT_COMMIT_SHORT:-$(git rev-parse --short HEAD 2>/dev/null || echo local)} npm run build",
     "build:release:zip": "npm run build:release && LATEST=$(find . -maxdepth 1 -type d -name 'dist-*' | sed 's#^./##' | sort | tail -n 1) && rm -f ${LATEST}.zip && /usr/bin/zip -qry ${LATEST}.zip ${LATEST} && echo ${LATEST}.zip",
     "build:release:archive": "npm run build:release:zip && mkdir -p releases && LATEST_DIR=$(find . -maxdepth 1 -type d -name 'dist-*' | sed 's#^./##' | sort | tail -n 1) && LATEST_ZIP=$(find . -maxdepth 1 -type f -name 'dist-*.zip' | sed 's#^./##' | sort | tail -n 1) && cp -f ${LATEST_ZIP} releases/ && cp -f ${LATEST_DIR}/BUILD_INFO.json releases/${LATEST_DIR}.BUILD_INFO.json && cp -f ${LATEST_DIR}/RELEASE.md releases/${LATEST_DIR}.RELEASE.md && echo releases/${LATEST_ZIP}"
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "format": "prettier --write \"src/**/*.{ts,tsx,css,scss}\"",
     "type-check": "tsc --noEmit",
     "build:release": "VERSION=${VERSION:-$(git describe --tags --always 2>/dev/null || echo dev)} BUILD_DATE=${BUILD_DATE:-$(date -u +%Y-%m-%dT%H:%M:%SZ)} GIT_COMMIT_SHORT=${GIT_COMMIT_SHORT:-$(git rev-parse --short HEAD 2>/dev/null || echo local)} npm run build",
-    "build:release:zip": "npm run build:release && LATEST=$(ls -dt dist-* | head -n 1) && rm -f ${LATEST}.zip && /usr/bin/zip -qry ${LATEST}.zip ${LATEST} && echo ${LATEST}.zip"
+    "build:release:zip": "npm run build:release && LATEST=$(ls -dt dist-* | head -n 1) && rm -f ${LATEST}.zip && /usr/bin/zip -qry ${LATEST}.zip ${LATEST} && echo ${LATEST}.zip",
+    "build:release:archive": "npm run build:release:zip && mkdir -p releases && LATEST_DIR=$(find . -maxdepth 1 -type d -name 'dist-*' | sed 's#^./##' | sort | tail -n 1) && LATEST_ZIP=$(find . -maxdepth 1 -type f -name 'dist-*.zip' | sed 's#^./##' | sort | tail -n 1) && cp -f ${LATEST_ZIP} releases/ && cp -f ${LATEST_DIR}/BUILD_INFO.json releases/${LATEST_DIR}.BUILD_INFO.json && cp -f RELEASE.md releases/${LATEST_DIR}.RELEASE.md && echo releases/${LATEST_ZIP}"
   },
   "dependencies": {
     "@codemirror/lang-yaml": "^6.1.2",

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -244,6 +244,9 @@ export function MainLayout() {
 
   const fullBrandName = 'CLI Proxy API Management Center';
   const uiVersion = __APP_VERSION__ || 'dev';
+  const layoutBuildMeta = typeof __APP_BUILD_DATE__ !== 'undefined' && __APP_BUILD_DATE__
+    ? new Date(__APP_BUILD_DATE__).toLocaleString(language)
+    : 'Unknown';
   const abbrBrandName = t('title.abbr');
   const isLogsPage = location.pathname.startsWith('/logs');
 
@@ -753,6 +756,11 @@ export function MainLayout() {
             />
           </main>
         </div>
+      </div>
+
+      <div className="global-build-footer">
+        <span>UI {uiVersion}</span>
+        <span>{layoutBuildMeta}</span>
       </div>
     </div>
   );

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -243,6 +243,7 @@ export function MainLayout() {
   const headerRef = useRef<HTMLElement | null>(null);
 
   const fullBrandName = 'CLI Proxy API Management Center';
+  const uiVersion = __APP_VERSION__ || 'dev';
   const abbrBrandName = t('title.abbr');
   const isLogsPage = location.pathname.startsWith('/logs');
 
@@ -590,6 +591,7 @@ export function MainLayout() {
               )}
             </span>
             <span className="base">{apiBase || '-'}</span>
+            <span className="header-ui-version">UI {uiVersion}</span>
           </div>
 
           <div className="header-actions">

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -130,7 +130,7 @@ export function Modal({
   const titleId = useId();
   const [isVisible, setIsVisible] = useState(false);
   const [isClosing, setIsClosing] = useState(false);
-  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const closeTimerRef = useRef<number | null>(null);
   const modalRef = useRef<HTMLDivElement | null>(null);
   const closeButtonRef = useRef<HTMLButtonElement | null>(null);
   const previouslyFocusedRef = useRef<HTMLElement | null>(null);

--- a/src/pages/LoginPage.module.scss
+++ b/src/pages/LoginPage.module.scss
@@ -321,3 +321,24 @@
   border-radius: $radius-full;
   animation: splashLoading 1.2s ease-in-out infinite;
 }
+
+
+.buildMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: center;
+  justify-content: center;
+  padding-top: 4px;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.buildVersion {
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.buildDate {
+  opacity: 0.8;
+}

--- a/src/pages/LoginPage.module.scss
+++ b/src/pages/LoginPage.module.scss
@@ -342,3 +342,15 @@
 .buildDate {
   opacity: 0.8;
 }
+
+
+.loginFooter {
+  margin-top: 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  color: var(--text-secondary);
+  font-size: 12px;
+}

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -113,6 +113,11 @@ export function LoginPage() {
     [setLanguage]
   );
 
+
+  useEffect(() => {
+    document.title = `CPAMC ${appVersion}`;
+  }, [appVersion]);
+
   useEffect(() => {
     const init = async () => {
       try {

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -213,6 +213,7 @@ export function LoginPage() {
             </div>
           </div>
         ) : (
+          <>
           /* 登录表单 */
           <div className={styles.formContent}>
             {/* Logo */}
@@ -311,6 +312,11 @@ export function LoginPage() {
               {error && <div className={styles.errorBox}>{error}</div>}
             </div>
           </div>
+          <div className={styles.loginFooter}>
+            <span>UI {appVersion}</span>
+            <span>{appBuildDate}</span>
+          </div>
+          </>
         )}
       </div>
     </div>

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -91,6 +91,10 @@ export function LoginPage() {
   const [error, setError] = useState('');
 
   const detectedBase = useMemo(() => detectApiBaseFromLocation(), []);
+  const appVersion = __APP_VERSION__ || 'dev';
+  const appBuildDate = typeof __APP_BUILD_DATE__ !== 'undefined' && __APP_BUILD_DATE__
+    ? new Date(__APP_BUILD_DATE__).toLocaleString(language)
+    : 'Unknown';
   const languageOptions = useMemo(
     () =>
       LANGUAGE_ORDER.map((lang) => ({
@@ -287,6 +291,12 @@ export function LoginPage() {
                   ariaLabel={t('login.remember_password_label')}
                   label={<span className={styles.toggleLabel}>{t('login.remember_password_label')}</span>}
                 />
+              </div>
+
+
+              <div className={styles.buildMeta}>
+                <span className={styles.buildVersion}>UI {appVersion}</span>
+                <span className={styles.buildDate}>{appBuildDate}</span>
               </div>
 
               <Button fullWidth onClick={handleSubmit} loading={loading}>

--- a/src/pages/SystemPage.tsx
+++ b/src/pages/SystemPage.tsx
@@ -71,6 +71,9 @@ export function SystemPage() {
   const canEditRequestLog = auth.connectionStatus === 'connected' && Boolean(config);
 
   const appVersion = __APP_VERSION__ || t('system_info.version_unknown');
+  const appBuildDate = typeof __APP_BUILD_DATE__ !== 'undefined' && __APP_BUILD_DATE__
+    ? new Date(__APP_BUILD_DATE__).toLocaleString(i18n.language)
+    : t('system_info.version_unknown');
   const apiVersion = auth.serverVersion || t('system_info.version_unknown');
   const buildTime = auth.serverBuildDate
     ? new Date(auth.serverBuildDate).toLocaleString(i18n.language)
@@ -287,6 +290,7 @@ export function SystemPage() {
           >
             <div className={styles.tileLabel}>{t('footer.version')}</div>
             <div className={styles.tileValue}>{appVersion}</div>
+            <div className={styles.tileMeta}>{appBuildDate}</div>
           </button>
 
           <div className={styles.infoTile}>

--- a/src/styles/components.scss
+++ b/src/styles/components.scss
@@ -748,3 +748,32 @@ textarea {
 .hint {
   color: var(--text-secondary);
 }
+
+
+.global-build-footer {
+  position: fixed;
+  right: 16px;
+  bottom: 12px;
+  z-index: 30;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--border-color);
+  background: color-mix(in srgb, var(--bg-primary) 88%, transparent);
+  color: var(--text-secondary);
+  backdrop-filter: blur(10px);
+  box-shadow: var(--shadow-md);
+  font-size: 12px;
+}
+
+@media (max-width: 768px) {
+  .global-build-footer {
+    left: 12px;
+    right: 12px;
+    bottom: 10px;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+}

--- a/src/utils/usage.ts
+++ b/src/utils/usage.ts
@@ -73,6 +73,14 @@ export type UsageTimeRange = '7h' | '24h' | '7d' | 'all';
 
 const TOKENS_PER_PRICE_UNIT = 1_000_000;
 const MODEL_PRICE_STORAGE_KEY = 'cli-proxy-model-prices-v2';
+
+// Official OpenAI API pricing defaults fetched from https://openai.com/api/pricing/
+// Seed only models with explicit published prices; never overwrite user-saved values.
+const DEFAULT_MODEL_PRICES: Record<string, ModelPrice> = {
+  'gpt-5.4': { prompt: 2.5, completion: 15, cache: 0.25 },
+  'gpt-5.4-mini': { prompt: 0.75, completion: 4.5, cache: 0.075 },
+  'gpt-5.4-nano': { prompt: 0.2, completion: 1.25, cache: 0.02 }
+};
 const USAGE_ENDPOINT_METHOD_REGEX = /^(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD)\s+(\S+)/i;
 const USAGE_TIME_RANGE_MS: Record<Exclude<UsageTimeRange, 'all'>, number> = {
   '7h': 7 * 60 * 60 * 1000,
@@ -738,11 +746,11 @@ export function calculateTotalCost(usageData: unknown, modelPrices: Record<strin
 export function loadModelPrices(): Record<string, ModelPrice> {
   try {
     if (typeof localStorage === 'undefined') {
-      return {};
+      return { ...DEFAULT_MODEL_PRICES };
     }
     const raw = localStorage.getItem(MODEL_PRICE_STORAGE_KEY);
     if (!raw) {
-      return {};
+      return { ...DEFAULT_MODEL_PRICES };
     }
     const parsed: unknown = JSON.parse(raw);
     if (!isRecord(parsed)) {
@@ -775,9 +783,9 @@ export function loadModelPrices(): Record<string, ModelPrice> {
         cache
       };
     });
-    return normalized;
+    return { ...DEFAULT_MODEL_PRICES, ...normalized };
   } catch {
-    return {};
+    return { ...DEFAULT_MODEL_PRICES };
   }
 }
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,4 @@
 /// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string;
+declare const __APP_BUILD_DATE__: string;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,3 +2,5 @@
 
 declare const __APP_VERSION__: string;
 declare const __APP_BUILD_DATE__: string;
+
+declare const __APP_BUILD_STAMP__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,6 +35,28 @@ function getVersion(): string {
   return 'dev';
 }
 
+
+function getShortCommit(): string {
+  if (process.env.GIT_COMMIT_SHORT) {
+    return process.env.GIT_COMMIT_SHORT;
+  }
+
+  try {
+    return execSync('git rev-parse --short HEAD 2>/dev/null || echo ""', { encoding: 'utf8' }).trim();
+  } catch {
+    return '';
+  }
+}
+
+function getVersionLabel(): string {
+  const version = getVersion();
+  const shortCommit = getShortCommit();
+  if (!shortCommit || version.includes(shortCommit)) {
+    return version;
+  }
+  return `${version}+${shortCommit}`;
+}
+
 function getBuildDate(): string {
   if (process.env.BUILD_DATE) {
     return process.env.BUILD_DATE;
@@ -51,7 +73,7 @@ export default defineConfig({
     })
   ],
   define: {
-    __APP_VERSION__: JSON.stringify(getVersion()),
+    __APP_VERSION__: JSON.stringify(getVersionLabel()),
     __APP_BUILD_DATE__: JSON.stringify(getBuildDate())
   },
   resolve: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -70,10 +70,32 @@ function getBuildDate(): string {
   return new Date().toISOString();
 }
 
+
+function writeBuildInfoPlugin() {
+  return {
+    name: 'write-build-info',
+    closeBundle() {
+      const version = getVersionLabel();
+      const buildDate = getBuildDate();
+      const buildStamp = getBuildStamp();
+      const outDir = `dist-${version.replace(/[^a-zA-Z0-9._-]/g, '_')}-${buildStamp}`;
+      const payload = {
+        name: 'cli-proxy-webui-react',
+        version,
+        buildDate,
+        buildStamp,
+        commit: getShortCommit() || null
+      };
+      fs.writeFileSync(path.resolve(__dirname, outDir, 'BUILD_INFO.json'), JSON.stringify(payload, null, 2) + '\n');
+    }
+  };
+}
+
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
     react(),
+    writeBuildInfoPlugin(),
     viteSingleFile({
       removeViteModuleLoader: true
     })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,6 +35,13 @@ function getVersion(): string {
   return 'dev';
 }
 
+function getBuildDate(): string {
+  if (process.env.BUILD_DATE) {
+    return process.env.BUILD_DATE;
+  }
+  return new Date().toISOString();
+}
+
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
@@ -44,7 +51,8 @@ export default defineConfig({
     })
   ],
   define: {
-    __APP_VERSION__: JSON.stringify(getVersion())
+    __APP_VERSION__: JSON.stringify(getVersion()),
+    __APP_BUILD_DATE__: JSON.stringify(getBuildDate())
   },
   resolve: {
     alias: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -57,6 +57,12 @@ function getVersionLabel(): string {
   return `${version}+${shortCommit}`;
 }
 
+
+function getBuildStamp(): string {
+  const iso = getBuildDate();
+  return iso.replace(/[-:TZ.]/g, '').slice(0, 12);
+}
+
 function getBuildDate(): string {
   if (process.env.BUILD_DATE) {
     return process.env.BUILD_DATE;
@@ -74,7 +80,8 @@ export default defineConfig({
   ],
   define: {
     __APP_VERSION__: JSON.stringify(getVersionLabel()),
-    __APP_BUILD_DATE__: JSON.stringify(getBuildDate())
+    __APP_BUILD_DATE__: JSON.stringify(getBuildDate()),
+    __APP_BUILD_STAMP__: JSON.stringify(getBuildStamp())
   },
   resolve: {
     alias: {
@@ -94,7 +101,8 @@ export default defineConfig({
   },
   build: {
     target: 'es2020',
-    outDir: 'dist',
+    outDir: `dist-${getVersionLabel().replace(/[^a-zA-Z0-9._-]/g, '_')}-${getBuildStamp()}`,
+    emptyOutDir: true,
     assetsInlineLimit: 100000000,
     chunkSizeWarningLimit: 100000000,
     cssCodeSplit: false,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -59,6 +59,14 @@ function getBuildStamp(): string {
 }
 
 
+
+function getVersionSuffix(): string {
+  const explicit = process.env.VERSION_SUFFIX || process.env.RELEASE_SUFFIX || process.env.BETA_SUFFIX;
+  if (!explicit) return '';
+  const cleaned = explicit.trim().replace(/^[-+]+/, '');
+  return cleaned ? `-${cleaned}` : '';
+}
+
 function formatDateStamp(date: string): string {
   return date.slice(0, 10).replace(/-/g, '.');
 }
@@ -69,8 +77,8 @@ function getReleaseVersion(): string {
   }
   const buildDate = getBuildDate();
   const datePart = formatDateStamp(buildDate);
-  const shortCommit = getShortCommit();
-  return shortCommit ? `v${datePart}+${shortCommit}` : `v${datePart}`;
+  const suffix = getVersionSuffix();
+  return `v${datePart}${suffix}`;
 }
 
 function getBuildDate(): string {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -49,18 +49,28 @@ function getShortCommit(): string {
 }
 
 function getVersionLabel(): string {
-  const version = getVersion();
-  const shortCommit = getShortCommit();
-  if (!shortCommit || version.includes(shortCommit)) {
-    return version;
-  }
-  return `${version}+${shortCommit}`;
+  return getReleaseVersion();
 }
 
 
 function getBuildStamp(): string {
   const iso = getBuildDate();
   return iso.replace(/[-:TZ.]/g, '').slice(0, 12);
+}
+
+
+function formatDateStamp(date: string): string {
+  return date.slice(0, 10).replace(/-/g, '.');
+}
+
+function getReleaseVersion(): string {
+  if (process.env.VERSION) {
+    return process.env.VERSION;
+  }
+  const buildDate = getBuildDate();
+  const datePart = formatDateStamp(buildDate);
+  const shortCommit = getShortCommit();
+  return shortCommit ? `v${datePart}+${shortCommit}` : `v${datePart}`;
 }
 
 function getBuildDate(): string {
@@ -78,7 +88,7 @@ function writeBuildInfoPlugin() {
       const version = getVersionLabel();
       const buildDate = getBuildDate();
       const buildStamp = getBuildStamp();
-      const outDir = `dist-${version.replace(/[^a-zA-Z0-9._-]/g, '_')}-${buildStamp}`;
+      const outDir = `dist-${version.replace(/[^a-zA-Z0-9._-]/g, '_').replace(/\./g, '-')}-${buildStamp}`;
       const payload = {
         name: 'cli-proxy-webui-react',
         version,
@@ -141,7 +151,7 @@ export default defineConfig({
   },
   build: {
     target: 'es2020',
-    outDir: `dist-${getVersionLabel().replace(/[^a-zA-Z0-9._-]/g, '_')}-${getBuildStamp()}`,
+    outDir: `dist-${getVersionLabel().replace(/[^a-zA-Z0-9._-]/g, '_').replace(/\./g, '-')}-${getBuildStamp()}`,
     emptyOutDir: true,
     assetsInlineLimit: 100000000,
     chunkSizeWarningLimit: 100000000,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -86,7 +86,25 @@ function writeBuildInfoPlugin() {
         buildStamp,
         commit: getShortCommit() || null
       };
+      const releaseNotes = [
+        '# Release Notes',
+        '',
+        `- Name: ${payload.name}`,
+        `- Version: ${payload.version}`,
+        `- Build Date: ${payload.buildDate}`,
+        `- Build Stamp: ${payload.buildStamp}`,
+        `- Commit: ${payload.commit || 'unknown'}`,
+        '',
+        '## Included metadata',
+        '- Login page version/build date',
+        '- System page version/build date',
+        '- Header UI version badge',
+        '- Global footer build metadata',
+        '- BUILD_INFO.json embedded in release bundle'
+      ].join('\n') + '\n';
       fs.writeFileSync(path.resolve(__dirname, outDir, 'BUILD_INFO.json'), JSON.stringify(payload, null, 2) + '\n');
+      fs.writeFileSync(path.resolve(__dirname, outDir, 'RELEASE.md'), releaseNotes);
+      fs.writeFileSync(path.resolve(__dirname, 'RELEASE.md'), releaseNotes);
     }
   };
 }


### PR DESCRIPTION
## Summary

This is a retrospective PR submitted to the upstream repository to document and review the frontend release-governance changes that were already validated downstream and released as `v2026.04.21`.

## What changed

### Frontend build metadata and UI surfacing
- Injected UI version / build date / build stamp
- Surfaced metadata on:
  - login page
  - system page
  - header badge
  - global footer
  - document title

### Release naming normalization
- Default version format: `vYYYY.MM.DD`
- Special updates can use suffixes such as `-beta` / `-beta.2`

### Release engineering pipeline
Added scripts:
- `build:release`
- `build:release:zip`
- `build:release:archive`

Added release artifacts:
- zip bundle
- `BUILD_INFO.json`
- `RELEASE.md`
- archived outputs under `releases/`

### Other fixes
- Fixed an existing `Modal.tsx` TypeScript timer typing issue that blocked production builds

## Validation
- `npm run build`
- `npm run build:release`
- `npm run build:release:zip`
- `npm run build:release:archive`
- Verified generated zip / BUILD_INFO / RELEASE.md / releases archive outputs

## Suggested labels
- retrospective
- release
- frontend
