### PR TITLE
Auth Files: revalidate transient Codex cancel warnings before marking auth unhealthy

### DIFF
--- a/src/features/authFiles/components/AuthFileCard.tsx
+++ b/src/features/authFiles/components/AuthFileCard.tsx
@@ -22,6 +22,8 @@ import {
   getAuthFileStatusMessage,
   getTypeColor,
   getTypeLabel,
+  isAuthFileRevalidated,
+  isHealthyAuthFileStatusMessage,
   isRuntimeOnlyAuthFile,
   parsePriorityValue,
   resolveAuthFileStats,
@@ -31,8 +33,6 @@ import {
 import type { AuthFileStatusBarData } from '@/features/authFiles/hooks/useAuthFilesStatusBarCache';
 import { AuthFileQuotaSection } from '@/features/authFiles/components/AuthFileQuotaSection';
 import styles from '@/pages/AuthFilesPage.module.scss';
-
-const HEALTHY_STATUS_MESSAGES = new Set(['ok', 'healthy', 'ready', 'success', 'available']);
 
 export type AuthFileCardProps = {
   file: AuthFileItem;
@@ -110,9 +110,24 @@ export function AuthFileCard(props: AuthFileCardProps) {
   const authIndexKey = normalizeAuthIndex(rawAuthIndex);
   const statusData =
     (authIndexKey && statusBarCache.get(authIndexKey)) || calculateStatusBarData([]);
+  const isRevalidated = isAuthFileRevalidated(file);
   const rawStatusMessage = getAuthFileStatusMessage(file);
+  const displayStatusMessage = isRevalidated
+    ? t('auth_files.health_status_revalidated_message', {
+        defaultValue:
+          'Last request was canceled, but this auth was revalidated: models and quota are reachable.',
+      })
+    : rawStatusMessage;
+  const statusMessageTitle = isRevalidated
+    ? t('auth_files.health_status_revalidated_title', {
+        defaultValue: 'Original status: {{message}}',
+        message: rawStatusMessage || '-',
+      })
+    : rawStatusMessage;
   const hasStatusWarning =
-    Boolean(rawStatusMessage) && !HEALTHY_STATUS_MESSAGES.has(rawStatusMessage.toLowerCase());
+    Boolean(rawStatusMessage) &&
+    !isRevalidated &&
+    !isHealthyAuthFileStatusMessage(rawStatusMessage);
 
   const priorityValue = parsePriorityValue(file.priority ?? file['priority']);
   const noteValue = typeof file.note === 'string' ? file.note.trim() : '';
@@ -120,18 +135,22 @@ export function AuthFileCard(props: AuthFileCardProps) {
     ? t('auth_files.type_virtual') || '虚拟认证文件'
     : file.disabled
       ? t('auth_files.health_status_disabled')
-      : hasStatusWarning
-        ? t('auth_files.health_status_warning')
-        : rawStatusMessage
-          ? t('auth_files.health_status_healthy')
-          : t('auth_files.status_toggle_label');
+      : isRevalidated
+        ? t('auth_files.health_status_revalidated', { defaultValue: 'Revalidated' })
+        : hasStatusWarning
+          ? t('auth_files.health_status_warning')
+          : rawStatusMessage
+            ? t('auth_files.health_status_healthy')
+            : t('auth_files.status_toggle_label');
   const stateBadgeClass = isRuntimeOnly
     ? styles.stateBadgeVirtual
     : file.disabled
       ? styles.stateBadgeDisabled
-      : hasStatusWarning
-        ? styles.stateBadgeWarning
-        : styles.stateBadgeActive;
+      : isRevalidated
+        ? styles.stateBadgeRevalidated
+        : hasStatusWarning
+          ? styles.stateBadgeWarning
+          : styles.stateBadgeActive;
 
   return (
     <div
@@ -214,10 +233,13 @@ export function AuthFileCard(props: AuthFileCardProps) {
             )}
           </div>
 
-          {rawStatusMessage && hasStatusWarning && (
-            <div className={styles.healthStatusMessage} title={rawStatusMessage}>
+          {displayStatusMessage && (hasStatusWarning || isRevalidated) && (
+            <div
+              className={`${styles.healthStatusMessage} ${isRevalidated ? styles.healthStatusMessageRevalidated : ''}`}
+              title={statusMessageTitle}
+            >
               <IconInfo className={styles.messageIcon} size={14} />
-              <span>{rawStatusMessage}</span>
+              <span>{displayStatusMessage}</span>
             </div>
           )}
 

--- a/src/features/authFiles/constants.ts
+++ b/src/features/authFiles/constants.ts
@@ -136,6 +136,23 @@ export const resolveQuotaErrorMessage = (
 
 export const normalizeProviderKey = (value: string) => value.trim().toLowerCase();
 
+const HEALTHY_AUTH_FILE_STATUS_MESSAGES = new Set([
+  'ok',
+  'healthy',
+  'ready',
+  'success',
+  'available',
+]);
+
+const TRANSIENT_AUTH_FILE_STATUS_PATTERNS = [
+  /context\s+cancel/i,
+  /\brequest\s+cancel(?:ed|led)\b/i,
+  /\boperation\s+cancel(?:ed|led)\b/i,
+  /\babort(?:ed)?\b/i,
+  /deadline exceeded/i,
+  /err_aborted/i,
+];
+
 export const getAuthFileStatusMessage = (file: AuthFileItem): string => {
   const raw = file['status_message'] ?? file.statusMessage;
   if (typeof raw === 'string') return raw.trim();
@@ -143,8 +160,26 @@ export const getAuthFileStatusMessage = (file: AuthFileItem): string => {
   return String(raw).trim();
 };
 
-export const hasAuthFileStatusMessage = (file: AuthFileItem): boolean =>
-  getAuthFileStatusMessage(file).length > 0;
+export const isAuthFileRevalidated = (file: AuthFileItem): boolean =>
+  file.healthRevalidated === true;
+
+export const isHealthyAuthFileStatusMessage = (value: string): boolean =>
+  HEALTHY_AUTH_FILE_STATUS_MESSAGES.has(value.trim().toLowerCase());
+
+export const isTransientAuthFileStatusMessage = (value: string): boolean => {
+  const message = value.trim();
+  return (
+    message.length > 0 &&
+    TRANSIENT_AUTH_FILE_STATUS_PATTERNS.some((pattern) => pattern.test(message))
+  );
+};
+
+export const hasAuthFileStatusMessage = (file: AuthFileItem): boolean => {
+  const message = getAuthFileStatusMessage(file);
+  if (!message) return false;
+  if (isAuthFileRevalidated(file)) return false;
+  return !isHealthyAuthFileStatusMessage(message);
+};
 
 export const getTypeLabel = (t: TFunction, type: string): string => {
   const key = `auth_files.filter_${type}`;
@@ -280,7 +315,7 @@ export const formatModified = (item: AuthFileItem): string => {
   const date =
     Number.isFinite(asNumber) && !Number.isNaN(asNumber)
       ? new Date(asNumber < 1e12 ? asNumber * 1000 : asNumber)
-      : parseTimestamp(raw) ?? new Date(String(raw));
+      : (parseTimestamp(raw) ?? new Date(String(raw)));
   return Number.isNaN(date.getTime()) ? '-' : date.toLocaleString();
 };
 

--- a/src/features/authFiles/hooks/useAuthFilesData.ts
+++ b/src/features/authFiles/hooks/useAuthFilesData.ts
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useRef, useState, type ChangeEvent, type RefObject } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type RefObject,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { authFilesApi } from '@/services/api';
 import { apiClient } from '@/services/api/client';
@@ -16,7 +24,7 @@ import {
 type DeleteAllOptions = {
   filter: string;
   problemOnly: boolean;
-  sourceFiles?: AuthFileItem[];
+  sourceFilesRef?: RefObject<AuthFileItem[]>;
   onResetFilterToAll: () => void;
   onResetProblemOnly: () => void;
 };
@@ -69,8 +77,13 @@ export function useAuthFilesData(options: UseAuthFilesDataOptions): UseAuthFiles
   const [selectedFiles, setSelectedFiles] = useState<Set<string>>(new Set());
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const latestFilesRef = useRef<AuthFileItem[]>(files);
   const batchStatusPendingRef = useRef(false);
   const selectionCount = selectedFiles.size;
+
+  useLayoutEffect(() => {
+    latestFilesRef.current = files;
+  }, [files]);
   const toggleSelect = useCallback((name: string) => {
     setSelectedFiles((prev) => {
       const next = new Set(prev);
@@ -268,11 +281,10 @@ export function useAuthFilesData(options: UseAuthFilesDataOptions): UseAuthFiles
 
   const handleDeleteAll = useCallback(
     (deleteAllOptions: DeleteAllOptions) => {
-      const { filter, problemOnly, sourceFiles, onResetFilterToAll, onResetProblemOnly } =
+      const { filter, problemOnly, sourceFilesRef, onResetFilterToAll, onResetProblemOnly } =
         deleteAllOptions;
       const isFiltered = filter !== 'all';
       const isProblemOnly = problemOnly === true;
-      const candidateFiles = sourceFiles ?? files;
       const typeLabel = isFiltered ? getTypeLabel(t, filter) : t('auth_files.filter_all');
       const confirmMessage = isProblemOnly
         ? isFiltered
@@ -296,6 +308,7 @@ export function useAuthFilesData(options: UseAuthFilesDataOptions): UseAuthFiles
               setFiles((prev) => prev.filter((file) => isRuntimeOnlyAuthFile(file)));
               deselectAll();
             } else {
+              const candidateFiles = sourceFilesRef?.current ?? latestFilesRef.current;
               const filesToDelete = candidateFiles.filter((file) => {
                 if (isRuntimeOnlyAuthFile(file)) return false;
                 if (isFiltered && file.type !== filter) return false;
@@ -369,7 +382,7 @@ export function useAuthFilesData(options: UseAuthFilesDataOptions): UseAuthFiles
         },
       });
     },
-    [applyDeletedFiles, deselectAll, files, showConfirmation, showNotification, t]
+    [applyDeletedFiles, deselectAll, showConfirmation, showNotification, t]
   );
 
   const handleDownload = useCallback(

--- a/src/features/authFiles/hooks/useAuthFilesData.ts
+++ b/src/features/authFiles/hooks/useAuthFilesData.ts
@@ -16,6 +16,7 @@ import {
 type DeleteAllOptions = {
   filter: string;
   problemOnly: boolean;
+  sourceFiles?: AuthFileItem[];
   onResetFilterToAll: () => void;
   onResetProblemOnly: () => void;
 };
@@ -118,13 +119,7 @@ export function useAuthFilesData(options: UseAuthFilesDataOptions): UseAuthFiles
   }, []);
 
   const applyDeletedFiles = useCallback((names: string[]) => {
-    const deletedNames = Array.from(
-      new Set(
-        names
-          .map((name) => name.trim())
-          .filter(Boolean)
-      )
-    );
+    const deletedNames = Array.from(new Set(names.map((name) => name.trim()).filter(Boolean)));
     if (deletedNames.length === 0) return;
 
     const deletedSet = new Set(deletedNames);
@@ -232,9 +227,7 @@ export function useAuthFilesData(options: UseAuthFilesDataOptions): UseAuthFiles
         }
 
         if (result.failed.length > 0) {
-          const details = result.failed
-            .map((item) => `${item.name}: ${item.error}`)
-            .join('; ');
+          const details = result.failed.map((item) => `${item.name}: ${item.error}`).join('; ');
           showNotification(`${t('notification.upload_failed')}: ${details}`, 'error');
         }
       } catch (err: unknown) {
@@ -275,9 +268,11 @@ export function useAuthFilesData(options: UseAuthFilesDataOptions): UseAuthFiles
 
   const handleDeleteAll = useCallback(
     (deleteAllOptions: DeleteAllOptions) => {
-      const { filter, problemOnly, onResetFilterToAll, onResetProblemOnly } = deleteAllOptions;
+      const { filter, problemOnly, sourceFiles, onResetFilterToAll, onResetProblemOnly } =
+        deleteAllOptions;
       const isFiltered = filter !== 'all';
       const isProblemOnly = problemOnly === true;
+      const candidateFiles = sourceFiles ?? files;
       const typeLabel = isFiltered ? getTypeLabel(t, filter) : t('auth_files.filter_all');
       const confirmMessage = isProblemOnly
         ? isFiltered
@@ -301,7 +296,7 @@ export function useAuthFilesData(options: UseAuthFilesDataOptions): UseAuthFiles
               setFiles((prev) => prev.filter((file) => isRuntimeOnlyAuthFile(file)));
               deselectAll();
             } else {
-              const filesToDelete = files.filter((file) => {
+              const filesToDelete = candidateFiles.filter((file) => {
                 if (isRuntimeOnlyAuthFile(file)) return false;
                 if (isFiltered && file.type !== filter) return false;
                 if (isProblemOnly && !hasAuthFileStatusMessage(file)) return false;
@@ -319,9 +314,7 @@ export function useAuthFilesData(options: UseAuthFilesDataOptions): UseAuthFiles
                 return;
               }
 
-              const result = await authFilesApi.deleteFiles(
-                filesToDelete.map((file) => file.name)
-              );
+              const result = await authFilesApi.deleteFiles(filesToDelete.map((file) => file.name));
               const success = result.deleted;
               const failed = result.failed.length;
 
@@ -503,7 +496,10 @@ export function useAuthFilesData(options: UseAuthFilesDataOptions): UseAuthFiles
         );
 
         if (failCount === 0) {
-          showNotification(t('auth_files.batch_status_success', { count: successCount }), 'success');
+          showNotification(
+            t('auth_files.batch_status_success', { count: successCount }),
+            'success'
+          );
         } else {
           showNotification(
             t('auth_files.batch_status_partial', { success: successCount, failed: failCount }),

--- a/src/features/authFiles/hooks/useAuthFilesHealthRevalidation.ts
+++ b/src/features/authFiles/hooks/useAuthFilesHealthRevalidation.ts
@@ -1,0 +1,126 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { apiCallApi, authFilesApi } from '@/services/api';
+import type { AuthFileItem } from '@/types';
+import {
+  CODEX_REQUEST_HEADERS,
+  CODEX_USAGE_URL,
+  resolveAuthProvider,
+  resolveCodexChatgptAccountId,
+} from '@/utils/quota';
+import { normalizeAuthIndex } from '@/utils/usage';
+import {
+  getAuthFileStatusMessage,
+  isTransientAuthFileStatusMessage,
+} from '@/features/authFiles/constants';
+
+const REVALIDATION_TTL_MS = 5 * 60 * 1000;
+
+type RevalidationCacheEntry = {
+  expiresAt: number;
+  success: boolean;
+};
+
+const isTransientCodexCandidate = (file: AuthFileItem): boolean => {
+  if (resolveAuthProvider(file) !== 'codex') return false;
+  if (file.disabled === true) return false;
+  const statusMessage = getAuthFileStatusMessage(file);
+  return isTransientAuthFileStatusMessage(statusMessage);
+};
+
+export function useAuthFilesHealthRevalidation(files: AuthFileItem[]): AuthFileItem[] {
+  const [revalidatedByName, setRevalidatedByName] = useState<Record<string, true>>({});
+  const cacheRef = useRef<Map<string, RevalidationCacheEntry>>(new Map());
+  const inflightRef = useRef<Map<string, Promise<void>>>(new Map());
+
+  useEffect(() => {
+    const now = Date.now();
+    const candidateNames = new Set<string>();
+
+    files.forEach((file) => {
+      const name = String(file.name || '').trim();
+      if (!name || !isTransientCodexCandidate(file)) return;
+      candidateNames.add(name);
+    });
+
+    files.forEach((file) => {
+      const name = String(file.name || '').trim();
+      if (!name || !candidateNames.has(name)) {
+        return;
+      }
+
+      const cached = cacheRef.current.get(name);
+      if (cached && cached.expiresAt > now) {
+        return;
+      }
+
+      if (inflightRef.current.has(name)) {
+        return;
+      }
+
+      const authIndex = normalizeAuthIndex(file['auth_index'] ?? file.authIndex);
+      const accountId = resolveCodexChatgptAccountId(file);
+      if (!authIndex || !accountId) {
+        return;
+      }
+
+      const promise = (async () => {
+        let success = false;
+
+        try {
+          await authFilesApi.getModelsForAuthFile(name);
+          const result = await apiCallApi.request({
+            authIndex,
+            method: 'GET',
+            url: CODEX_USAGE_URL,
+            header: {
+              ...CODEX_REQUEST_HEADERS,
+              'Chatgpt-Account-Id': accountId,
+            },
+          });
+          success = result.statusCode >= 200 && result.statusCode < 300;
+        } catch {
+          success = false;
+        }
+
+        cacheRef.current.set(name, {
+          expiresAt: Date.now() + REVALIDATION_TTL_MS,
+          success,
+        });
+
+        setRevalidatedByName((prev) => {
+          if (success) {
+            return prev[name] ? prev : { ...prev, [name]: true };
+          }
+
+          if (!prev[name]) {
+            return prev;
+          }
+
+          const next = { ...prev };
+          delete next[name];
+          return next;
+        });
+      })().finally(() => {
+        inflightRef.current.delete(name);
+      });
+
+      inflightRef.current.set(name, promise);
+    });
+  }, [files]);
+
+  return useMemo(
+    () =>
+      files.map((file) => {
+        const name = String(file.name || '').trim();
+        if (!name || !isTransientCodexCandidate(file) || !revalidatedByName[name]) {
+          return file;
+        }
+
+        return {
+          ...file,
+          healthRevalidated: true,
+        };
+      }),
+    [files, revalidatedByName]
+  );
+}

--- a/src/features/authFiles/hooks/useAuthFilesHealthRevalidation.ts
+++ b/src/features/authFiles/hooks/useAuthFilesHealthRevalidation.ts
@@ -20,15 +20,35 @@ type RevalidationCacheEntry = {
   success: boolean;
 };
 
-const isTransientCodexCandidate = (file: AuthFileItem): boolean => {
-  if (resolveAuthProvider(file) !== 'codex') return false;
-  if (file.disabled === true) return false;
+type RevalidationTarget = {
+  name: string;
+  authIndex: string;
+  accountId: string;
+  cacheKey: string;
+};
+
+const resolveTransientCodexTarget = (file: AuthFileItem): RevalidationTarget | null => {
+  const name = String(file.name || '').trim();
+  if (!name) return null;
+  if (resolveAuthProvider(file) !== 'codex') return null;
+  if (file.disabled === true) return null;
   const statusMessage = getAuthFileStatusMessage(file);
-  return isTransientAuthFileStatusMessage(statusMessage);
+  if (!isTransientAuthFileStatusMessage(statusMessage)) return null;
+
+  const authIndex = normalizeAuthIndex(file['auth_index'] ?? file.authIndex);
+  const accountId = resolveCodexChatgptAccountId(file);
+  if (!authIndex || !accountId) return null;
+
+  return {
+    name,
+    authIndex,
+    accountId,
+    cacheKey: `${name}::${authIndex}::${accountId}`,
+  };
 };
 
 export function useAuthFilesHealthRevalidation(files: AuthFileItem[]): AuthFileItem[] {
-  const [revalidatedByName, setRevalidatedByName] = useState<Record<string, true>>({});
+  const [revalidatedByKey, setRevalidatedByKey] = useState<Record<string, true>>({});
   const cacheRef = useRef<Map<string, RevalidationCacheEntry>>(new Map());
   const inflightRef = useRef<Map<string, Promise<void>>>(new Map());
 
@@ -36,23 +56,16 @@ export function useAuthFilesHealthRevalidation(files: AuthFileItem[]): AuthFileI
     const now = Date.now();
 
     files.forEach((file) => {
-      const name = String(file.name || '').trim();
-      if (!name || !isTransientCodexCandidate(file)) {
-        return;
-      }
+      const target = resolveTransientCodexTarget(file);
+      if (!target) return;
 
-      const cached = cacheRef.current.get(name);
+      const { name, authIndex, accountId, cacheKey } = target;
+      const cached = cacheRef.current.get(cacheKey);
       if (cached && cached.expiresAt > now) {
         return;
       }
 
-      if (inflightRef.current.has(name)) {
-        return;
-      }
-
-      const authIndex = normalizeAuthIndex(file['auth_index'] ?? file.authIndex);
-      const accountId = resolveCodexChatgptAccountId(file);
-      if (!authIndex || !accountId) {
+      if (inflightRef.current.has(cacheKey)) {
         return;
       }
 
@@ -75,37 +88,37 @@ export function useAuthFilesHealthRevalidation(files: AuthFileItem[]): AuthFileI
           success = false;
         }
 
-        cacheRef.current.set(name, {
+        cacheRef.current.set(cacheKey, {
           expiresAt: Date.now() + REVALIDATION_TTL_MS,
           success,
         });
 
-        setRevalidatedByName((prev) => {
+        setRevalidatedByKey((prev) => {
           if (success) {
-            return prev[name] ? prev : { ...prev, [name]: true };
+            return prev[cacheKey] ? prev : { ...prev, [cacheKey]: true };
           }
 
-          if (!prev[name]) {
+          if (!prev[cacheKey]) {
             return prev;
           }
 
           const next = { ...prev };
-          delete next[name];
+          delete next[cacheKey];
           return next;
         });
       })().finally(() => {
-        inflightRef.current.delete(name);
+        inflightRef.current.delete(cacheKey);
       });
 
-      inflightRef.current.set(name, promise);
+      inflightRef.current.set(cacheKey, promise);
     });
   }, [files]);
 
   return useMemo(
     () =>
       files.map((file) => {
-        const name = String(file.name || '').trim();
-        if (!name || !isTransientCodexCandidate(file) || !revalidatedByName[name]) {
+        const target = resolveTransientCodexTarget(file);
+        if (!target || !revalidatedByKey[target.cacheKey]) {
           return file;
         }
 
@@ -114,6 +127,6 @@ export function useAuthFilesHealthRevalidation(files: AuthFileItem[]): AuthFileI
           healthRevalidated: true,
         };
       }),
-    [files, revalidatedByName]
+    [files, revalidatedByKey]
   );
 }

--- a/src/features/authFiles/hooks/useAuthFilesHealthRevalidation.ts
+++ b/src/features/authFiles/hooks/useAuthFilesHealthRevalidation.ts
@@ -34,17 +34,10 @@ export function useAuthFilesHealthRevalidation(files: AuthFileItem[]): AuthFileI
 
   useEffect(() => {
     const now = Date.now();
-    const candidateNames = new Set<string>();
 
     files.forEach((file) => {
       const name = String(file.name || '').trim();
-      if (!name || !isTransientCodexCandidate(file)) return;
-      candidateNames.add(name);
-    });
-
-    files.forEach((file) => {
-      const name = String(file.name || '').trim();
-      if (!name || !candidateNames.has(name)) {
+      if (!name || !isTransientCodexCandidate(file)) {
         return;
       }
 

--- a/src/pages/AuthFilesPage.module.scss
+++ b/src/pages/AuthFilesPage.module.scss
@@ -100,7 +100,6 @@
   }
 }
 
-
 .filterAllIconWrap {
   position: relative;
   border-color: color-mix(in srgb, var(--primary-color) 20%, var(--border-color));
@@ -118,7 +117,6 @@
   display: block;
   color: color-mix(in srgb, var(--primary-color) 70%, var(--text-primary));
 }
-
 
 .filterContent {
   display: flex;
@@ -898,6 +896,12 @@
   border: 1px solid var(--warning-border);
 }
 
+.stateBadgeRevalidated {
+  color: var(--success-badge-text, #065f46);
+  background: color-mix(in srgb, var(--success-badge-bg, #d1fae5) 80%, transparent);
+  border: 1px solid var(--success-badge-border, #6ee7b7);
+}
+
 .stateBadgeDisabled {
   color: var(--text-secondary);
   background: color-mix(in srgb, var(--bg-tertiary) 86%, transparent);
@@ -1020,6 +1024,12 @@
   border-radius: 8px;
   padding: 8px 10px;
   word-break: break-word;
+}
+
+.healthStatusMessageRevalidated {
+  color: var(--success-badge-text, #065f46);
+  background-color: color-mix(in srgb, var(--success-badge-bg, #d1fae5) 52%, transparent);
+  border-color: color-mix(in srgb, var(--success-badge-border, #6ee7b7) 72%, transparent);
 }
 
 .messageIcon {

--- a/src/pages/AuthFilesPage.tsx
+++ b/src/pages/AuthFilesPage.tsx
@@ -134,6 +134,11 @@ export function AuthFilesPage() {
     batchDelete,
   } = useAuthFilesData({ refreshKeyStats });
   const filesWithHealthState = useAuthFilesHealthRevalidation(files);
+  const latestHealthStateFilesRef = useRef(filesWithHealthState);
+
+  useLayoutEffect(() => {
+    latestHealthStateFilesRef.current = filesWithHealthState;
+  }, [filesWithHealthState]);
 
   const statusBarCache = useAuthFilesStatusBarCache(filesWithHealthState, usageDetails);
 
@@ -672,7 +677,7 @@ export function AuthFilesPage() {
                 handleDeleteAll({
                   filter,
                   problemOnly,
-                  sourceFiles: filesMatchingProblemFilter,
+                  sourceFilesRef: latestHealthStateFilesRef,
                   onResetFilterToAll: () => setFilter('all'),
                   onResetProblemOnly: () => setProblemOnly(false),
                 })

--- a/src/pages/AuthFilesPage.tsx
+++ b/src/pages/AuthFilesPage.tsx
@@ -45,6 +45,7 @@ import { AuthFilesPrefixProxyEditorModal } from '@/features/authFiles/components
 import { OAuthExcludedCard } from '@/features/authFiles/components/OAuthExcludedCard';
 import { OAuthModelAliasCard } from '@/features/authFiles/components/OAuthModelAliasCard';
 import { useAuthFilesData } from '@/features/authFiles/hooks/useAuthFilesData';
+import { useAuthFilesHealthRevalidation } from '@/features/authFiles/hooks/useAuthFilesHealthRevalidation';
 import { useAuthFilesModels } from '@/features/authFiles/hooks/useAuthFilesModels';
 import { useAuthFilesOauth } from '@/features/authFiles/hooks/useAuthFilesOauth';
 import { useAuthFilesPrefixProxyEditor } from '@/features/authFiles/hooks/useAuthFilesPrefixProxyEditor';
@@ -68,8 +69,7 @@ const BATCH_BAR_HIDDEN_TRANSFORM = 'translateX(-50%) translateY(56px)';
 const DEFAULT_REGULAR_PAGE_SIZE = 9;
 const DEFAULT_COMPACT_PAGE_SIZE = 12;
 
-const escapeWildcardSearchSegment = (value: string) =>
-  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const escapeWildcardSearchSegment = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 const buildWildcardSearch = (value: string): RegExp | null => {
   if (!value.includes('*')) return null;
@@ -133,8 +133,9 @@ export function AuthFilesPage() {
     batchSetStatus,
     batchDelete,
   } = useAuthFilesData({ refreshKeyStats });
+  const filesWithHealthState = useAuthFilesHealthRevalidation(files);
 
-  const statusBarCache = useAuthFilesStatusBarCache(files, usageDetails);
+  const statusBarCache = useAuthFilesStatusBarCache(filesWithHealthState, usageDetails);
 
   const {
     excluded,
@@ -201,10 +202,7 @@ export function AuthFilesPage() {
       if (typeof persisted.problemOnly === 'boolean') {
         setProblemOnly(persisted.problemOnly);
       }
-      if (
-        typeof persistedCompactMode !== 'boolean' &&
-        typeof persisted.compactMode === 'boolean'
-      ) {
+      if (typeof persistedCompactMode !== 'boolean' && typeof persisted.compactMode === 'boolean') {
         setCompactMode(persisted.compactMode);
       }
       if (typeof persisted.search === 'string') {
@@ -220,11 +218,11 @@ export function AuthFilesPage() {
       const regularPageSize =
         typeof persisted.regularPageSize === 'number' && Number.isFinite(persisted.regularPageSize)
           ? clampCardPageSize(persisted.regularPageSize)
-          : legacyPageSize ?? DEFAULT_REGULAR_PAGE_SIZE;
+          : (legacyPageSize ?? DEFAULT_REGULAR_PAGE_SIZE);
       const compactPageSize =
         typeof persisted.compactPageSize === 'number' && Number.isFinite(persisted.compactPageSize)
           ? clampCardPageSize(persisted.compactPageSize)
-          : legacyPageSize ?? DEFAULT_COMPACT_PAGE_SIZE;
+          : (legacyPageSize ?? DEFAULT_COMPACT_PAGE_SIZE);
       setPageSizeByMode({
         regular: regularPageSize,
         compact: compactPageSize,
@@ -346,17 +344,18 @@ export function AuthFilesPage() {
 
   const existingTypes = useMemo(() => {
     const types = new Set<string>(['all']);
-    files.forEach((file) => {
+    filesWithHealthState.forEach((file) => {
       if (file.type) {
         types.add(file.type);
       }
     });
     return Array.from(types);
-  }, [files]);
+  }, [filesWithHealthState]);
 
   const filesMatchingProblemFilter = useMemo(
-    () => (problemOnly ? files.filter(hasAuthFileStatusMessage) : files),
-    [files, problemOnly]
+    () =>
+      problemOnly ? filesWithHealthState.filter(hasAuthFileStatusMessage) : filesWithHealthState,
+    [filesWithHealthState, problemOnly]
   );
 
   const sortOptions = useMemo(
@@ -630,7 +629,9 @@ export function AuthFilesPage() {
   const titleNode = (
     <div className={styles.titleWrapper}>
       <span>{t('auth_files.title_section')}</span>
-      {files.length > 0 && <span className={styles.countBadge}>{files.length}</span>}
+      {filesWithHealthState.length > 0 && (
+        <span className={styles.countBadge}>{filesWithHealthState.length}</span>
+      )}
     </div>
   );
 
@@ -671,6 +672,7 @@ export function AuthFilesPage() {
                 handleDeleteAll({
                   filter,
                   problemOnly,
+                  sourceFiles: filesMatchingProblemFilter,
                   onResetFilterToAll: () => setFilter('all'),
                   onResetProblemOnly: () => setProblemOnly(false),
                 })

--- a/src/types/authFile.ts
+++ b/src/types/authFile.ts
@@ -28,6 +28,7 @@ export interface AuthFileItem {
   unavailable?: boolean;
   status?: string;
   statusMessage?: string;
+  healthRevalidated?: boolean;
   lastRefresh?: string | number;
   modified?: number;
   [key: string]: unknown;


### PR DESCRIPTION
## Summary
- detect transient cancel-like Codex auth status messages (`context canceled`, aborted, deadline exceeded, etc.)
- revalidate candidates with the existing management APIs (`/auth-files/models` plus `/api-call` to Codex usage)
- show revalidated auth files as `Revalidated` instead of a warning, while preserving the original raw status in the tooltip
- exclude revalidated auth files from `problemOnly` filtering and destructive "delete problem files" actions

## Why
We hit cases where `#/auth-files` kept showing `context canceled` even though the same auth could still:
- list models
- fetch Codex usage/quota
- serve normal responses

From an operator perspective that becomes a sticky false-positive warning and can lead to accidental cleanup of healthy auth files.

## Validation
- `npm run type-check`
- `npm run lint`
- `npm run build`