### PR TITLE
fix(logs): make log panel natively resizable

### DIFF
--- a/src/pages/LogsPage.module.scss
+++ b/src/pages/LogsPage.module.scss
@@ -318,10 +318,10 @@
   background: var(--bg-secondary);
   border: 1px solid var(--border-color);
   border-radius: $radius-md;
-  flex: 1 0 auto;
+  flex: 0 0 auto;
   min-height: 420px;
   max-height: none;
-  height: max(420px, calc(100vh - 520px));
+  height: calc(100vh - 520px);
   overflow: auto;
   resize: vertical;
   position: relative;
@@ -331,7 +331,7 @@
 
   @include tablet {
     min-height: 360px;
-    height: max(360px, calc(100vh - 500px));
+    height: calc(100vh - 500px);
     max-height: none;
   }
 
@@ -340,7 +340,6 @@
     height: 420px;
     max-height: 480px;
     flex: 0 0 auto;
-    overflow: auto;
   }
 }
 
@@ -785,12 +784,6 @@
 
   .logCard {
     padding: $spacing-md;
-  }
-
-  .logPanel {
-    min-height: 420px;
-    height: max(420px, calc(100vh - 460px));
-    max-height: none;
   }
 
   .logRow {

--- a/src/pages/LogsPage.module.scss
+++ b/src/pages/LogsPage.module.scss
@@ -318,22 +318,26 @@
   background: var(--bg-secondary);
   border: 1px solid var(--border-color);
   border-radius: $radius-md;
-  flex: 1 1 auto;
-  min-height: 280px;
-  max-height: calc(100vh - 320px);
+  flex: 1 0 auto;
+  min-height: 420px;
+  max-height: none;
+  height: max(420px, calc(100vh - 520px));
   overflow: auto;
+  resize: vertical;
   position: relative;
   -webkit-overflow-scrolling: touch;
   touch-action: pan-y;
   overscroll-behavior: contain;
 
   @include tablet {
-    min-height: 240px;
-    max-height: calc(100vh - 300px);
+    min-height: 360px;
+    height: max(360px, calc(100vh - 500px));
+    max-height: none;
   }
 
   @include mobile {
     min-height: 360px;
+    height: 420px;
     max-height: 480px;
     flex: 0 0 auto;
     overflow: auto;
@@ -784,8 +788,9 @@
   }
 
   .logPanel {
-    min-height: 200px;
-    max-height: calc(100vh - 280px);
+    min-height: 420px;
+    height: max(420px, calc(100vh - 460px));
+    max-height: none;
   }
 
   .logRow {
@@ -827,8 +832,9 @@
   }
 
   .logPanel {
-    min-height: 160px;
-    max-height: calc(100vh - 220px);
+    min-height: 320px;
+    height: 320px;
+    max-height: none;
   }
 
   .logRow {


### PR DESCRIPTION
## Summary
- Increase the log viewer minimum height so it shows more content on desktop.
- Use the browser-native vertical resize handle for manual height adjustment.
- Remove the previous max-height cap so overflowing pages can scroll instead of clipping the panel.

## Test plan
- [x] npm run type-check
- [x] npm run build