### PR TITLE
Show Codex subscription expiry in quota cards

### DIFF
--- a/src/components/quota/quotaConfigs.ts
+++ b/src/components/quota/quotaConfigs.ts
@@ -58,8 +58,10 @@ import {
   parseKimiUsagePayload,
   resolveCodexChatgptAccountId,
   resolveCodexPlanType,
+  resolveCodexSubscriptionActiveUntil,
   resolveGeminiCliProjectId,
   formatCodexResetLabel,
+  formatDateTimeValue,
   formatQuotaResetTime,
   formatKimiResetHint,
   buildAntigravityQuotaGroups,
@@ -401,7 +403,11 @@ const buildCodexQuotaWindows = (payload: CodexUsagePayload, t: TFunction): Codex
 const fetchCodexQuota = async (
   file: AuthFileItem,
   t: TFunction
-): Promise<{ planType: string | null; windows: CodexQuotaWindow[] }> => {
+): Promise<{
+  planType: string | null;
+  subscriptionActiveUntil: string | number | null;
+  windows: CodexQuotaWindow[];
+}> => {
   const rawAuthIndex = file['auth_index'] ?? file.authIndex;
   const authIndex = normalizeAuthIndex(rawAuthIndex);
   if (!authIndex) {
@@ -409,6 +415,7 @@ const fetchCodexQuota = async (
   }
 
   const planTypeFromFile = resolveCodexPlanType(file);
+  const subscriptionActiveUntil = resolveCodexSubscriptionActiveUntil(file);
   const accountId = resolveCodexChatgptAccountId(file);
   if (!accountId) {
     throw new Error(t('codex_quota.missing_account_id'));
@@ -437,7 +444,7 @@ const fetchCodexQuota = async (
 
   const planTypeFromUsage = normalizePlanType(payload.plan_type ?? payload.planType);
   const windows = buildCodexQuotaWindows(payload, t);
-  return { planType: planTypeFromUsage ?? planTypeFromFile, windows };
+  return { planType: planTypeFromUsage ?? planTypeFromFile, subscriptionActiveUntil, windows };
 };
 
 const GEMINI_CLI_G1_CREDIT_TYPE = 'GOOGLE_ONE_AI';
@@ -744,6 +751,7 @@ const renderCodexItems = (
   const { createElement: h, Fragment } = React;
   const windows = quota.windows ?? [];
   const planType = quota.planType ?? null;
+  const subscriptionActiveUntil = quota.subscriptionActiveUntil ?? null;
 
   const getPlanLabel = (pt?: string | null): string | null => {
     const normalized = normalizePlanType(pt);
@@ -760,16 +768,45 @@ const renderCodexItems = (
 
   const planLabel = getPlanLabel(planType);
   const isPremiumPlan = PREMIUM_CODEX_PLAN_TYPES.has(normalizePlanType(planType) ?? '');
+  const expiryLabel =
+    subscriptionActiveUntil !== null ? formatDateTimeValue(subscriptionActiveUntil) : '-';
   const nodes: ReactNode[] = [];
 
-  if (planLabel) {
-    const valueClass = isPremiumPlan ? styleMap.premiumPlanValue : styleMap.codexPlanValue;
+  if (planLabel || expiryLabel !== '-') {
+    const planValueClass = isPremiumPlan ? styleMap.premiumPlanValue : styleMap.codexPlanValue;
+    const planNodes: ReactNode[] = [];
+
+    if (planLabel) {
+      planNodes.push(
+        h('span', { key: 'plan-label', className: styleMap.codexPlanLabel }, t('codex_quota.plan_label')),
+        h('span', { key: 'plan-value', className: planValueClass }, planLabel)
+      );
+    }
+
+    if (expiryLabel !== '-') {
+      if (planNodes.length > 0) {
+        planNodes.push(
+          h('span', {
+            key: 'subscription-expiry-separator',
+            className: styleMap.codexPlanSeparator,
+          })
+        );
+      }
+      planNodes.push(
+        h(
+          'span',
+          { key: 'subscription-expiry-label', className: styleMap.codexPlanLabel },
+          t('codex_quota.expires_label')
+        ),
+        h('span', { key: 'subscription-expiry-value', className: styleMap.codexPlanValue }, expiryLabel)
+      );
+    }
+
     nodes.push(
       h(
         'div',
         { key: 'plan', className: styleMap.codexPlan },
-        h('span', { className: styleMap.codexPlanLabel }, t('codex_quota.plan_label')),
-        h('span', { className: valueClass }, planLabel)
+        ...planNodes
       )
     );
   }
@@ -1171,7 +1208,11 @@ export const ANTIGRAVITY_CONFIG: QuotaConfig<AntigravityQuotaState, AntigravityQ
 
 export const CODEX_CONFIG: QuotaConfig<
   CodexQuotaState,
-  { planType: string | null; windows: CodexQuotaWindow[] }
+  {
+    planType: string | null;
+    subscriptionActiveUntil: string | number | null;
+    windows: CodexQuotaWindow[];
+  }
 > = {
   type: 'codex',
   i18nPrefix: 'codex_quota',
@@ -1185,6 +1226,7 @@ export const CODEX_CONFIG: QuotaConfig<
     status: 'success',
     windows: data.windows,
     planType: data.planType,
+    subscriptionActiveUntil: data.subscriptionActiveUntil,
   }),
   buildErrorState: (message, status) => ({
     status: 'error',

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -688,6 +688,7 @@
     "additional_primary_window": "{{name}} 5-hour limit",
     "additional_secondary_window": "{{name}} weekly limit",
     "plan_label": "Plan",
+    "expires_label": "Expires",
     "plan_plus": "Plus",
     "plan_team": "Team",
     "plan_free": "Free",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -685,6 +685,7 @@
     "additional_primary_window": "{{name}}: лимит на 5 часов",
     "additional_secondary_window": "{{name}}: недельный лимит",
     "plan_label": "Тариф",
+    "expires_label": "Истекает",
     "plan_plus": "Plus",
     "plan_team": "Team",
     "plan_free": "Free",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -688,6 +688,7 @@
     "additional_primary_window": "{{name}} 5 小时限额",
     "additional_secondary_window": "{{name}} 周限额",
     "plan_label": "套餐",
+    "expires_label": "到期时间",
     "plan_plus": "Plus",
     "plan_team": "Team",
     "plan_free": "Free",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -688,6 +688,7 @@
     "additional_primary_window": "{{name}} 5 小時限額",
     "additional_secondary_window": "{{name}} 週限額",
     "plan_label": "方案",
+    "expires_label": "到期時間",
     "plan_plus": "Plus",
     "plan_team": "Team",
     "plan_free": "Free",

--- a/src/pages/QuotaPage.module.scss
+++ b/src/pages/QuotaPage.module.scss
@@ -419,6 +419,7 @@
   gap: 6px;
   font-size: 12px;
   color: var(--text-secondary);
+  flex-wrap: wrap;
 }
 
 .codexPlanLabel {
@@ -429,6 +430,12 @@
   font-weight: 600;
   color: var(--text-primary);
   text-transform: capitalize;
+}
+
+.codexPlanSeparator {
+  width: 1px;
+  height: 12px;
+  background-color: var(--border-color);
 }
 
 .premiumPlanValue {

--- a/src/types/quota.ts
+++ b/src/types/quota.ts
@@ -242,6 +242,7 @@ export interface CodexQuotaState {
   status: 'idle' | 'loading' | 'success' | 'error';
   windows: CodexQuotaWindow[];
   planType?: string | null;
+  subscriptionActiveUntil?: string | number | null;
   error?: string;
   errorStatus?: number;
 }

--- a/src/utils/quota/formatters.ts
+++ b/src/utils/quota/formatters.ts
@@ -32,6 +32,30 @@ export function formatUnixSeconds(value: number | null): string {
   });
 }
 
+export function formatDateTimeValue(value?: string | number | null): string {
+  if (value === undefined || value === null || value === '') return '-';
+  const timestamp =
+    typeof value === 'number'
+      ? value > 100000000000
+        ? value
+        : value * 1000
+      : Number.isFinite(Number(value)) && value.trim() !== ''
+        ? Number(value) > 100000000000
+          ? Number(value)
+          : Number(value) * 1000
+        : value;
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return '-';
+  return date.toLocaleString(undefined, {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false
+  });
+}
+
 export function formatCodexResetLabel(window?: CodexUsageWindow | null): string {
   if (!window) return '-';
   const resetAt = normalizeNumberValue(window.reset_at ?? window.resetAt);

--- a/src/utils/quota/formatters.ts
+++ b/src/utils/quota/formatters.ts
@@ -33,7 +33,7 @@ export function formatUnixSeconds(value: number | null): string {
 }
 
 export function formatDateTimeValue(value?: string | number | null): string {
-  if (value === undefined || value === null || value === '') return '-';
+  if (value === undefined || value === null || value === '' || value === 0 || value === '0') return '-';
   const timestamp =
     typeof value === 'number'
       ? value > 100000000000

--- a/src/utils/quota/resolvers.ts
+++ b/src/utils/quota/resolvers.ts
@@ -85,7 +85,7 @@ const toRecord = (value: unknown): Record<string, unknown> | null => {
 };
 
 const resolveCodexAuthInfo = (value: unknown): Record<string, unknown> | null => {
-  const payload = parseIdTokenPayload(value);
+  const payload = toRecord(value) ?? parseIdTokenPayload(value);
   if (!payload) return null;
   const nested = toRecord(payload['https://api.openai.com/auth']);
   return nested ?? payload;

--- a/src/utils/quota/resolvers.ts
+++ b/src/utils/quota/resolvers.ts
@@ -4,6 +4,7 @@
 
 import type { AuthFileItem } from '@/types';
 import {
+  normalizeNumberValue,
   normalizeStringValue,
   normalizePlanType,
   parseIdTokenPayload
@@ -73,6 +74,64 @@ export function resolveCodexPlanType(file: AuthFileItem): string | null {
   for (const candidate of candidates) {
     const planType = normalizePlanType(candidate);
     if (planType) return planType;
+  }
+
+  return null;
+}
+
+const toRecord = (value: unknown): Record<string, unknown> | null => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+};
+
+const resolveCodexAuthInfo = (value: unknown): Record<string, unknown> | null => {
+  const payload = parseIdTokenPayload(value);
+  if (!payload) return null;
+  const nested = toRecord(payload['https://api.openai.com/auth']);
+  return nested ?? payload;
+};
+
+const normalizeDateLikeValue = (value: unknown): string | number | null => {
+  const stringValue = normalizeStringValue(value);
+  if (stringValue) return stringValue;
+  const numberValue = normalizeNumberValue(value);
+  return numberValue !== null ? numberValue : null;
+};
+
+export function resolveCodexSubscriptionActiveUntil(file: AuthFileItem): string | number | null {
+  const metadata = toRecord(file.metadata);
+  const attributes = toRecord(file.attributes);
+  const idToken = resolveCodexAuthInfo(file.id_token);
+  const metadataIdToken = resolveCodexAuthInfo(metadata?.id_token);
+  const attributesIdToken = resolveCodexAuthInfo(attributes?.id_token);
+  const subscription = toRecord(file.subscription);
+  const metadataSubscription = toRecord(metadata?.subscription);
+  const attributesSubscription = toRecord(attributes?.subscription);
+
+  const candidates = [
+    file.subscription_active_until,
+    file.subscriptionActiveUntil,
+    subscription?.active_until,
+    subscription?.activeUntil,
+    idToken?.chatgpt_subscription_active_until,
+    idToken?.chatgptSubscriptionActiveUntil,
+    metadata?.subscription_active_until,
+    metadata?.subscriptionActiveUntil,
+    metadataSubscription?.active_until,
+    metadataSubscription?.activeUntil,
+    metadataIdToken?.chatgpt_subscription_active_until,
+    metadataIdToken?.chatgptSubscriptionActiveUntil,
+    attributes?.subscription_active_until,
+    attributes?.subscriptionActiveUntil,
+    attributesSubscription?.active_until,
+    attributesSubscription?.activeUntil,
+    attributesIdToken?.chatgpt_subscription_active_until,
+    attributesIdToken?.chatgptSubscriptionActiveUntil,
+  ];
+
+  for (const candidate of candidates) {
+    const value = normalizeDateLikeValue(candidate);
+    if (value !== null) return value;
   }
 
   return null;


### PR DESCRIPTION
## Summary
- resolve Codex subscription expiry from auth file fields and id_token claims
- show the subscription expiry next to the Codex plan in quota cards
- add localized labels for the expiry field

## Dependency
Depends on https://github.com/router-for-me/CLIProxyAPI/pull/3093

## Tests
- npm run type-check
- npm run lint
- npm run build
