### PR TITLE
feat: add Codex quota ping button

### DIFF
--- a/src/components/quota/QuotaCard.tsx
+++ b/src/components/quota/QuotaCard.tsx
@@ -66,6 +66,7 @@ interface QuotaCardProps<TState extends QuotaStatusState> {
   defaultType: string;
   canRefresh?: boolean;
   onRefresh?: () => void;
+  cardAction?: ReactNode;
   renderQuotaItems: (quota: TState, t: TFunction, helpers: QuotaRenderHelpers) => ReactNode;
 }
 
@@ -79,6 +80,7 @@ export function QuotaCard<TState extends QuotaStatusState>({
   defaultType,
   canRefresh = false,
   onRefresh,
+  cardAction,
   renderQuotaItems
 }: QuotaCardProps<TState>) {
   const { t } = useTranslation();
@@ -118,6 +120,7 @@ export function QuotaCard<TState extends QuotaStatusState>({
           {getTypeLabel(displayType)}
         </span>
         <span className={styles.fileName}>{item.name}</span>
+        {cardAction}
       </div>
 
       <div className={styles.quotaSection}>

--- a/src/components/quota/QuotaSection.tsx
+++ b/src/components/quota/QuotaSection.tsx
@@ -8,9 +8,11 @@ import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { triggerHeaderRefresh } from '@/hooks/useHeaderRefresh';
+import { codexPingApi } from '@/services/api';
 import { useNotificationStore, useQuotaStore, useThemeStore } from '@/stores';
 import type { AuthFileItem, ResolvedTheme } from '@/types';
 import { getStatusFromError } from '@/utils/quota';
+import { normalizeAuthIndex } from '@/utils/authIndex';
 import { QuotaCard } from './QuotaCard';
 import type { QuotaStatusState } from './QuotaCard';
 import { useQuotaLoader } from './useQuotaLoader';
@@ -24,6 +26,12 @@ type QuotaUpdater<T> = T | ((prev: T) => T);
 type QuotaSetter<T> = (updater: QuotaUpdater<T>) => void;
 
 type ViewMode = 'paged' | 'all';
+type CodexPingButtonStatus = 'idle' | 'loading' | 'success';
+
+interface CodexPingButtonState {
+  status: CodexPingButtonStatus;
+  message?: string;
+}
 
 const MAX_ITEMS_PER_PAGE = 25;
 const MAX_SHOW_ALL_THRESHOLD = 30;
@@ -115,6 +123,8 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
   const [columns, gridRef] = useGridColumns(380); // Min card width 380px matches SCSS
   const [viewMode, setViewMode] = useState<ViewMode>('paged');
   const [showTooManyWarning, setShowTooManyWarning] = useState(false);
+  const [codexPingState, setCodexPingState] = useState<Record<string, CodexPingButtonState>>({});
+  const codexPingResetTimersRef = useRef<Record<string, ReturnType<typeof window.setTimeout>>>({});
 
   const filteredFiles = useMemo(() => files.filter((file) => config.filterFn(file)), [
     files,
@@ -165,6 +175,14 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
 
   const pendingQuotaRefreshRef = useRef(false);
   const prevFilesLoadingRef = useRef(loading);
+
+  useEffect(
+    () => () => {
+      Object.values(codexPingResetTimersRef.current).forEach((timer) => window.clearTimeout(timer));
+      codexPingResetTimersRef.current = {};
+    },
+    []
+  );
 
   const handleRefresh = useCallback(() => {
     pendingQuotaRefreshRef.current = true;
@@ -237,6 +255,66 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
     [config, disabled, quota, setQuota, showNotification, t]
   );
 
+  const resetCodexPingButtonLater = useCallback((fileName: string) => {
+    const existing = codexPingResetTimersRef.current[fileName];
+    if (existing) {
+      window.clearTimeout(existing);
+    }
+    codexPingResetTimersRef.current[fileName] = window.setTimeout(() => {
+      setCodexPingState((prev) => {
+        const next = { ...prev };
+        delete next[fileName];
+        return next;
+      });
+      delete codexPingResetTimersRef.current[fileName];
+    }, 3000);
+  }, []);
+
+  const pingCodexForFile = useCallback(
+    async (file: AuthFileItem) => {
+      if (disabled || file.disabled) return;
+      if (codexPingState[file.name]?.status === 'loading') return;
+
+      const authIndex = normalizeAuthIndex(file['auth_index'] ?? file.authIndex);
+      if (!authIndex) {
+        showNotification(t('codex_quota.missing_auth_index'), 'error');
+        return;
+      }
+
+      const existingTimer = codexPingResetTimersRef.current[file.name];
+      if (existingTimer) {
+        window.clearTimeout(existingTimer);
+        delete codexPingResetTimersRef.current[file.name];
+      }
+
+      setCodexPingState((prev) => ({
+        ...prev,
+        [file.name]: { status: 'loading' },
+      }));
+
+      try {
+        const result = await codexPingApi.ping(authIndex);
+        setCodexPingState((prev) => ({
+          ...prev,
+          [file.name]: {
+            status: 'success',
+            message: result.message || t('codex_quota.ping_success_default'),
+          },
+        }));
+        resetCodexPingButtonLater(file.name);
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : t('common.unknown_error');
+        setCodexPingState((prev) => {
+          const next = { ...prev };
+          delete next[file.name];
+          return next;
+        });
+        showNotification(t('codex_quota.ping_failed', { message }), 'error');
+      }
+    },
+    [codexPingState, disabled, resetCodexPingButtonLater, showNotification, t]
+  );
+
   const titleNode = (
     <div className={styles.titleWrapper}>
       <span>{t(`${config.i18nPrefix}.title`)}</span>
@@ -307,21 +385,49 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
       ) : (
         <>
           <div ref={gridRef} className={config.gridClassName}>
-            {pageItems.map((item) => (
-              <QuotaCard
-                key={item.name}
-                item={item}
-                quota={quota[item.name]}
-                resolvedTheme={resolvedTheme}
-                i18nPrefix={config.i18nPrefix}
-                cardIdleMessageKey={config.cardIdleMessageKey}
-                cardClassName={config.cardClassName}
-                defaultType={config.type}
-                canRefresh={!disabled && !item.disabled}
-                onRefresh={() => void refreshQuotaForFile(item)}
-                renderQuotaItems={config.renderQuotaItems}
-              />
-            ))}
+            {pageItems.map((item) => {
+              const itemQuota = quota[item.name];
+              const pingState = codexPingState[item.name] ?? { status: 'idle' };
+              const showCodexPingButton =
+                config.type === 'codex' && itemQuota?.status === 'success';
+              const codexPingLoading = pingState.status === 'loading';
+              const codexPingSuccess = pingState.status === 'success';
+              const codexPingLabel = codexPingSuccess
+                ? pingState.message || t('codex_quota.ping_success_default')
+                : t('codex_quota.ping_button');
+
+              return (
+                <QuotaCard
+                  key={item.name}
+                  item={item}
+                  quota={itemQuota}
+                  resolvedTheme={resolvedTheme}
+                  i18nPrefix={config.i18nPrefix}
+                  cardIdleMessageKey={config.cardIdleMessageKey}
+                  cardClassName={config.cardClassName}
+                  defaultType={config.type}
+                  canRefresh={!disabled && !item.disabled}
+                  onRefresh={() => void refreshQuotaForFile(item)}
+                  cardAction={
+                    showCodexPingButton ? (
+                      <Button
+                        variant="secondary"
+                        size="sm"
+                        className={`${styles.codexPingButton} ${
+                          codexPingSuccess ? styles.codexPingButtonSuccess : ''
+                        }`}
+                        onClick={() => void pingCodexForFile(item)}
+                        disabled={disabled || item.disabled || codexPingLoading}
+                        loading={codexPingLoading}
+                      >
+                        {codexPingLabel}
+                      </Button>
+                    ) : undefined
+                  }
+                  renderQuotaItems={config.renderQuotaItems}
+                />
+              );
+            })}
           </div>
           {filteredFiles.length > pageSize && effectiveViewMode === 'paged' && (
             <div className={styles.pagination}>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -681,7 +681,10 @@
     "plan_team": "Team",
     "plan_free": "Free",
     "plan_pro": "Pro 20x",
-    "plan_prolite": "Pro 5x"
+    "plan_prolite": "Pro 5x",
+    "ping_button": "Ping",
+    "ping_success_default": "Pong",
+    "ping_failed": "Ping failed: {{message}}"
   },
   "gemini_cli_quota": {
     "title": "Gemini CLI Quota",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -678,7 +678,10 @@
     "plan_team": "Team",
     "plan_free": "Free",
     "plan_pro": "Pro 20x",
-    "plan_prolite": "Pro 5x"
+    "plan_prolite": "Pro 5x",
+    "ping_button": "Ping",
+    "ping_success_default": "Pong",
+    "ping_failed": "Ping не удался: {{message}}"
   },
   "gemini_cli_quota": {
     "title": "Квота Gemini CLI",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -681,7 +681,10 @@
     "plan_team": "Team",
     "plan_free": "Free",
     "plan_pro": "Pro 20x",
-    "plan_prolite": "Pro 5x"
+    "plan_prolite": "Pro 5x",
+    "ping_button": "Ping",
+    "ping_success_default": "Pong",
+    "ping_failed": "Ping 失败：{{message}}"
   },
   "gemini_cli_quota": {
     "title": "Gemini CLI 额度",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -681,7 +681,10 @@
     "plan_team": "Team",
     "plan_free": "Free",
     "plan_pro": "Pro 20x",
-    "plan_prolite": "Pro 5x"
+    "plan_prolite": "Pro 5x",
+    "ping_button": "Ping",
+    "ping_success_default": "Pong",
+    "ping_failed": "Ping 失敗：{{message}}"
   },
   "gemini_cli_quota": {
     "title": "Gemini CLI 配額",

--- a/src/pages/QuotaPage.module.scss
+++ b/src/pages/QuotaPage.module.scss
@@ -630,6 +630,27 @@
   color: var(--text-primary);
   word-break: break-all;
   line-height: 1.4;
+  flex: 1;
+  min-width: 0;
+}
+
+.codexPingButton {
+  flex-shrink: 0;
+  min-width: 72px;
+  max-width: 140px;
+
+  span {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
+.codexPingButtonSuccess {
+  background-color: var(--success-color, #22c55e) !important;
+  border-color: var(--success-color, #22c55e) !important;
+  color: #ffffff !important;
 }
 
 .pagination {

--- a/src/services/api/codexPing.ts
+++ b/src/services/api/codexPing.ts
@@ -1,0 +1,47 @@
+import { apiClient } from './client';
+
+export interface CodexPingUsage {
+  input_tokens: number;
+  cached_input_tokens: number;
+  output_tokens: number;
+  reasoning_tokens: number;
+  total_tokens: number;
+}
+
+export interface CodexPingResponse {
+  message: string;
+  usage: CodexPingUsage;
+}
+
+const readNumber = (value: unknown): number =>
+  typeof value === 'number' && Number.isFinite(value) ? value : 0;
+
+const normalizeUsage = (value: unknown): CodexPingUsage => {
+  const record =
+    value && typeof value === 'object' && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {};
+  return {
+    input_tokens: readNumber(record.input_tokens),
+    cached_input_tokens: readNumber(record.cached_input_tokens),
+    output_tokens: readNumber(record.output_tokens),
+    reasoning_tokens: readNumber(record.reasoning_tokens),
+    total_tokens: readNumber(record.total_tokens),
+  };
+};
+
+export const codexPingApi = {
+  ping: async (authIndex: string): Promise<CodexPingResponse> => {
+    const response = await apiClient.post<Record<string, unknown>>('/codex/ping', {
+      auth_index: authIndex,
+    });
+    const message =
+      typeof response.message === 'string' && response.message.trim()
+        ? response.message.trim()
+        : 'Pong';
+    return {
+      message,
+      usage: normalizeUsage(response.usage),
+    };
+  },
+};

--- a/src/services/api/index.ts
+++ b/src/services/api/index.ts
@@ -7,6 +7,7 @@ export * from './apiKeys';
 export * from './ampcode';
 export * from './providers';
 export * from './authFiles';
+export * from './codexPing';
 export * from './oauth';
 export * from './logs';
 export * from './version';


### PR DESCRIPTION
## Summary
- Add a Codex quota card Ping button after quota loads successfully
- Call the new management Codex ping API with loading/success/failure states
- Add API types, styling, and i18n strings

## Dependency
- Depends on router-for-me/CLIProxyAPI#3186 for `POST /v0/management/codex/ping`.

## Screenshots

### Idle
![Codex quota Ping idle](https://gist.githubusercontent.com/mooons/7823a702b6f807647d0bada4743a1d54/raw/445c731135cb763c6faf1db9c88bfa4fc3a60654/codex-quota-ping-idle.png)

### Loading
![Codex quota Ping loading](https://gist.githubusercontent.com/mooons/7823a702b6f807647d0bada4743a1d54/raw/445c731135cb763c6faf1db9c88bfa4fc3a60654/codex-quota-ping-loading.png)

### Success
![Codex quota Ping success](https://gist.githubusercontent.com/mooons/7823a702b6f807647d0bada4743a1d54/raw/445c731135cb763c6faf1db9c88bfa4fc3a60654/codex-quota-ping-success.png)

## Tests
- npm run type-check
- npm run build
