### PR TITLE
fix(quota): show Codex used percentage

### DIFF
--- a/src/components/quota/quotaConfigs.ts
+++ b/src/components/quota/quotaConfigs.ts
@@ -785,8 +785,7 @@ const renderCodexItems = (
     ...windows.map((window) => {
       const used = window.usedPercent;
       const clampedUsed = used === null ? null : Math.max(0, Math.min(100, used));
-      const remaining = clampedUsed === null ? null : Math.max(0, Math.min(100, 100 - clampedUsed));
-      const percentLabel = remaining === null ? '--' : `${Math.round(remaining)}%`;
+      const percentLabel = clampedUsed === null ? '--' : `${Math.round(clampedUsed)}% used`;
       const windowLabel = window.labelKey
         ? t(window.labelKey, window.labelParams as Record<string, string | number>)
         : window.label;
@@ -806,7 +805,7 @@ const renderCodexItems = (
           )
         ),
         h(QuotaProgressBar, {
-          percent: remaining,
+          percent: clampedUsed,
           highThreshold: QUOTA_PROGRESS_HIGH_THRESHOLD,
           mediumThreshold: QUOTA_PROGRESS_MEDIUM_THRESHOLD,
         })


### PR DESCRIPTION
## Summary
- Render Codex quota `usedPercent` directly instead of converting it to remaining percentage.
- Label Codex quota values as `% used` so low upstream usage appears low in UI.
- Feed used percentage into progress bar so bar semantics match label.

## Verification
- `npm --prefix /config/Desktop/projects/Cli-Proxy-API-Management-Center run type-check`
- `npm --prefix /config/Desktop/projects/Cli-Proxy-API-Management-Center run build`

Closes #262