### PR TITLE
feat: highlight fully recovered Codex quotas

### DIFF
--- a/src/components/quota/quotaConfigs.ts
+++ b/src/components/quota/quotaConfigs.ts
@@ -230,6 +230,7 @@ const fetchAntigravityQuota = async (
 const buildCodexQuotaWindows = (payload: CodexUsagePayload, t: TFunction): CodexQuotaWindow[] => {
   const FIVE_HOUR_SECONDS = 18000;
   const WEEK_SECONDS = 604800;
+  const FRESH_WINDOW_TOLERANCE_SECONDS = 60;
   const WINDOW_META = {
     codeFiveHour: { id: 'five-hour', labelKey: 'codex_quota.primary_window' },
     codeWeekly: { id: 'weekly', labelKey: 'codex_quota.secondary_window' },
@@ -241,6 +242,37 @@ const buildCodexQuotaWindows = (payload: CodexUsagePayload, t: TFunction): Codex
   const codeReviewLimit = payload.code_review_rate_limit ?? payload.codeReviewRateLimit ?? undefined;
   const additionalRateLimits = payload.additional_rate_limits ?? payload.additionalRateLimits ?? [];
   const windows: CodexQuotaWindow[] = [];
+  const nowSeconds = Math.floor(Date.now() / 1000);
+
+  const getResetDistanceSeconds = (window?: CodexUsageWindow | null): number | null => {
+    if (!window) return null;
+
+    const resetAfter = normalizeNumberValue(window.reset_after_seconds ?? window.resetAfterSeconds);
+    if (resetAfter !== null && resetAfter > 0) {
+      return resetAfter;
+    }
+
+    const resetAt = normalizeNumberValue(window.reset_at ?? window.resetAt);
+    if (resetAt !== null && resetAt > 0) {
+      return resetAt - nowSeconds;
+    }
+
+    return null;
+  };
+
+  const isFreshQuotaWindow = (
+    window: CodexUsageWindow,
+    usedPercentRaw: number | null,
+    windowSeconds?: number
+  ): boolean => {
+    if (usedPercentRaw === null || usedPercentRaw > 0) return false;
+    if (!windowSeconds) return false;
+
+    const resetDistanceSeconds = getResetDistanceSeconds(window);
+    if (resetDistanceSeconds === null) return false;
+
+    return Math.abs(resetDistanceSeconds - windowSeconds) <= FRESH_WINDOW_TOLERANCE_SECONDS;
+  };
 
   const addWindow = (
     id: string,
@@ -249,7 +281,8 @@ const buildCodexQuotaWindows = (payload: CodexUsagePayload, t: TFunction): Codex
     labelParams: Record<string, string | number> | undefined,
     window?: CodexUsageWindow | null,
     limitReached?: boolean,
-    allowed?: boolean
+    allowed?: boolean,
+    fullyRecoveredWindowSeconds?: number
   ) => {
     if (!window) return;
     const resetLabel = formatCodexResetLabel(window);
@@ -263,6 +296,7 @@ const buildCodexQuotaWindows = (payload: CodexUsagePayload, t: TFunction): Codex
       labelParams,
       usedPercent,
       resetLabel,
+      isFreshQuotaWindow: isFreshQuotaWindow(window, usedPercentRaw, fullyRecoveredWindowSeconds),
     });
   };
 
@@ -317,7 +351,8 @@ const buildCodexQuotaWindows = (payload: CodexUsagePayload, t: TFunction): Codex
     undefined,
     rateWindows.fiveHourWindow,
     rawLimitReached,
-    rawAllowed
+    rawAllowed,
+    FIVE_HOUR_SECONDS
   );
   addWindow(
     WINDOW_META.codeWeekly.id,
@@ -326,7 +361,8 @@ const buildCodexQuotaWindows = (payload: CodexUsagePayload, t: TFunction): Codex
     undefined,
     rateWindows.weeklyWindow,
     rawLimitReached,
-    rawAllowed
+    rawAllowed,
+    WEEK_SECONDS
   );
 
   const codeReviewWindows = pickClassifiedWindows(codeReviewLimit);
@@ -789,6 +825,9 @@ const renderCodexItems = (
       const windowLabel = window.labelKey
         ? t(window.labelKey, window.labelParams as Record<string, string | number>)
         : window.label;
+      const resetClassName = window.isFreshQuotaWindow
+        ? `${styleMap.quotaReset} ${styleMap.quotaResetRecovered}`
+        : styleMap.quotaReset;
 
       return h(
         'div',
@@ -801,7 +840,7 @@ const renderCodexItems = (
             'div',
             { className: styleMap.quotaMeta },
             h('span', { className: styleMap.quotaPercent }, percentLabel),
-            h('span', { className: styleMap.quotaReset }, window.resetLabel)
+            h('span', { className: resetClassName }, window.resetLabel)
           )
         ),
         h(QuotaProgressBar, {

--- a/src/pages/QuotaPage.module.scss
+++ b/src/pages/QuotaPage.module.scss
@@ -366,6 +366,11 @@
   color: var(--text-tertiary);
 }
 
+.quotaResetRecovered {
+  color: var(--success-badge-text, var(--success-color));
+  font-weight: 600;
+}
+
 .quotaAmount {
   color: var(--text-secondary);
 }

--- a/src/types/quota.ts
+++ b/src/types/quota.ts
@@ -236,6 +236,7 @@ export interface CodexQuotaWindow {
   labelParams?: Record<string, string | number>;
   usedPercent: number | null;
   resetLabel: string;
+  isFreshQuotaWindow: boolean;
 }
 
 export interface CodexQuotaState {


### PR DESCRIPTION
## Summary

- Highlight Codex quota reset labels in the theme success color when a normal reset window is fully recovered.
- Applies to the normal 5-hour and weekly Codex quota windows only.
- Uses raw reset timing instead of parsing the formatted label, with a ±60s tolerance to avoid UI timing drift.

## Rationale

When the reset time is effectively one full quota window away, the account has fully recovered for that window. Showing that reset label in green makes the recovered state easier to scan without adding extra UI text or changing quota percentages.

This is independent from but related to #252, which adds the Codex Ping button UI.

## Screenshots

**Before**

![Before: neutral quota reset labels](https://gist.githubusercontent.com/mooons/cd1224b98e589d53704e27c75596cc2a/raw/df7e21c11cbe79793c110646d91a3c9c43af17bf/before.svg)

**After**

![After: fully recovered reset labels highlighted in theme success green](https://gist.githubusercontent.com/mooons/cd1224b98e589d53704e27c75596cc2a/raw/f13c86ffc20de769dd62d489a2ec61df851ba154/after.svg)

## Verification

- `npm run type-check`
- `npm run build`
