### PR TITLE
fix: keep quota credential refresh available

### DIFF
--- a/src/components/quota/QuotaCard.tsx
+++ b/src/components/quota/QuotaCard.tsx
@@ -5,6 +5,8 @@
 import { useTranslation } from 'react-i18next';
 import type { ReactElement, ReactNode } from 'react';
 import type { TFunction } from 'i18next';
+import { Button } from '@/components/ui/Button';
+import { IconRefreshCw } from '@/components/ui/icons';
 import type { AuthFileItem, ResolvedTheme, ThemeColors } from '@/types';
 import { TYPE_COLORS } from '@/utils/quota';
 import styles from '@/pages/QuotaPage.module.scss';
@@ -95,6 +97,7 @@ export function QuotaCard<TState extends QuotaStatusState>({
     quota?.error || t('common.unknown_error')
   );
   const idleMessageKey = onRefresh ? `${i18nPrefix}.idle` : (cardIdleMessageKey ?? `${i18nPrefix}.idle`);
+  const refreshLabel = t(`${i18nPrefix}.refresh_button`);
 
   const getTypeLabel = (type: string): string => {
     const key = `auth_files.filter_${type}`;
@@ -118,6 +121,20 @@ export function QuotaCard<TState extends QuotaStatusState>({
           {getTypeLabel(displayType)}
         </span>
         <span className={styles.fileName}>{item.name}</span>
+        {onRefresh && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className={styles.cardRefreshButton}
+            onClick={onRefresh}
+            disabled={!canRefresh}
+            title={refreshLabel}
+            aria-label={refreshLabel}
+          >
+            <IconRefreshCw size={15} />
+          </Button>
+        )}
       </div>
 
       <div className={styles.quotaSection}>

--- a/src/components/quota/QuotaCard.tsx
+++ b/src/components/quota/QuotaCard.tsx
@@ -98,6 +98,7 @@ export function QuotaCard<TState extends QuotaStatusState>({
   );
   const idleMessageKey = onRefresh ? `${i18nPrefix}.idle` : (cardIdleMessageKey ?? `${i18nPrefix}.idle`);
   const refreshLabel = t(`${i18nPrefix}.refresh_button`);
+  const refreshButtonLoading = quotaStatus === 'loading';
 
   const getTypeLabel = (type: string): string => {
     const key = `auth_files.filter_${type}`;
@@ -128,11 +129,12 @@ export function QuotaCard<TState extends QuotaStatusState>({
             size="sm"
             className={styles.cardRefreshButton}
             onClick={onRefresh}
-            disabled={!canRefresh}
+            disabled={!canRefresh || refreshButtonLoading}
+            loading={refreshButtonLoading}
             title={refreshLabel}
             aria-label={refreshLabel}
           >
-            <IconRefreshCw size={15} />
+            {!refreshButtonLoading && <IconRefreshCw size={15} />}
           </Button>
         )}
       </div>

--- a/src/components/quota/QuotaSection.tsx
+++ b/src/components/quota/QuotaSection.tsx
@@ -207,7 +207,6 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
   const refreshQuotaForFile = useCallback(
     async (file: AuthFileItem) => {
       if (disabled || file.disabled) return;
-      if (quota[file.name]?.status === 'loading') return;
 
       setQuota((prev) => ({
         ...prev,
@@ -234,7 +233,7 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
         );
       }
     },
-    [config, disabled, quota, setQuota, showNotification, t]
+    [config, disabled, setQuota, showNotification, t]
   );
 
   const titleNode = (

--- a/src/components/quota/QuotaSection.tsx
+++ b/src/components/quota/QuotaSection.tsx
@@ -165,6 +165,7 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
 
   const pendingQuotaRefreshRef = useRef(false);
   const prevFilesLoadingRef = useRef(loading);
+  const singleRefreshInFlightRef = useRef<Set<string>>(new Set());
 
   const handleRefresh = useCallback(() => {
     pendingQuotaRefreshRef.current = true;
@@ -207,6 +208,10 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
   const refreshQuotaForFile = useCallback(
     async (file: AuthFileItem) => {
       if (disabled || file.disabled) return;
+      if (quota[file.name]?.status === 'loading') return;
+      if (singleRefreshInFlightRef.current.has(file.name)) return;
+
+      singleRefreshInFlightRef.current.add(file.name);
 
       setQuota((prev) => ({
         ...prev,
@@ -231,9 +236,11 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
           t('auth_files.quota_refresh_failed', { name: file.name, message }),
           'error'
         );
+      } finally {
+        singleRefreshInFlightRef.current.delete(file.name);
       }
     },
-    [config, disabled, setQuota, showNotification, t]
+    [config, disabled, quota, setQuota, showNotification, t]
   );
 
   const titleNode = (

--- a/src/pages/QuotaPage.module.scss
+++ b/src/pages/QuotaPage.module.scss
@@ -630,6 +630,28 @@
   color: var(--text-primary);
   word-break: break-all;
   line-height: 1.4;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.cardRefreshButton:global(.btn.btn-sm) {
+  flex: 0 0 auto;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border-radius: 999px;
+  color: var(--text-secondary);
+
+  > span {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  &:hover:not(:disabled) {
+    color: var(--text-primary);
+    background-color: var(--bg-hover);
+  }
 }
 
 .pagination {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "ignoreDeprecations": "5.0",
 
     /* Bundler mode */
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Summary
- add a fixed per-credential refresh action on quota cards
- allow single credential refresh to overwrite any current quota state after refresh-all
- add TypeScript deprecation compatibility so type-check/build run on TS 5.9

## Verification
- npm run type-check
- npm run build

