### PR TITLE
feat: usage & analytics

### DIFF
--- a/src/components/config/VisualConfigEditor.tsx
+++ b/src/components/config/VisualConfigEditor.tsx
@@ -558,19 +558,6 @@ export function VisualConfigEditor({
                       disabled={disabled}
                       onChange={(rmDisableControlPanel) => onChange({ rmDisableControlPanel })}
                     />
-                    <ToggleRow
-                      title={t(
-                        'config_management.visual.sections.remote.disable_auto_update_panel'
-                      )}
-                      description={t(
-                        'config_management.visual.sections.remote.disable_auto_update_panel_desc'
-                      )}
-                      checked={values.rmDisableAutoUpdatePanel}
-                      disabled={disabled}
-                      onChange={(rmDisableAutoUpdatePanel) =>
-                        onChange({ rmDisableAutoUpdatePanel })
-                      }
-                    />
                   </SectionGrid>
                   <SectionGrid>
                     <Input
@@ -581,13 +568,6 @@ export function VisualConfigEditor({
                       )}
                       value={values.rmSecretKey}
                       onChange={(e) => onChange({ rmSecretKey: e.target.value })}
-                      disabled={disabled}
-                    />
-                    <Input
-                      label={t('config_management.visual.sections.remote.panel_repo')}
-                      placeholder="https://github.com/router-for-me/Cli-Proxy-API-Management-Center"
-                      value={values.rmPanelRepo}
-                      onChange={(e) => onChange({ rmPanelRepo: e.target.value })}
                       disabled={disabled}
                     />
                   </SectionGrid>

--- a/src/hooks/useVisualConfig.ts
+++ b/src/hooks/useVisualConfig.ts
@@ -725,7 +725,6 @@ function getNextDirtyFields(
 
   (
     [
-      'rmDisableAutoUpdatePanel',
       'errorLogsMaxFiles',
       'usageStatisticsEnabled',
       'redisUsageQueueRetentionSeconds',
@@ -774,9 +773,6 @@ function getNextDirtyFields(
       'rmDisableControlPanel',
       nextValues.rmDisableControlPanel === baselineValues.rmDisableControlPanel
     );
-  }
-  if (Object.prototype.hasOwnProperty.call(patch, 'rmPanelRepo')) {
-    updateDirty('rmPanelRepo', nextValues.rmPanelRepo === baselineValues.rmPanelRepo);
   }
   if (Object.prototype.hasOwnProperty.call(patch, 'authDir')) {
     updateDirty('authDir', nextValues.authDir === baselineValues.authDir);
@@ -1013,13 +1009,6 @@ export function useVisualConfig() {
             ? remoteManagement['secret-key']
             : '',
         rmDisableControlPanel: Boolean(remoteManagement?.['disable-control-panel']),
-        rmDisableAutoUpdatePanel: Boolean(remoteManagement?.['disable-auto-update-panel']),
-        rmPanelRepo:
-          typeof remoteManagement?.['panel-github-repository'] === 'string'
-            ? remoteManagement['panel-github-repository']
-            : typeof remoteManagement?.['panel-repo'] === 'string'
-              ? remoteManagement['panel-repo']
-              : '',
 
         authDir: typeof parsed['auth-dir'] === 'string' ? parsed['auth-dir'] : '',
         apiKeysText: resolveApiKeysText(parsed),
@@ -1148,9 +1137,7 @@ export function useVisualConfig() {
           docHas(doc, ['remote-management']) ||
           values.rmAllowRemote ||
           values.rmSecretKey.trim() ||
-          values.rmDisableControlPanel ||
-          values.rmDisableAutoUpdatePanel ||
-          values.rmPanelRepo.trim()
+          values.rmDisableControlPanel
         ) {
           ensureMapInDoc(doc, ['remote-management']);
           setBooleanInDoc(doc, ['remote-management', 'allow-remote'], values.rmAllowRemote);
@@ -1160,12 +1147,12 @@ export function useVisualConfig() {
             ['remote-management', 'disable-control-panel'],
             values.rmDisableControlPanel
           );
-          setBooleanInDoc(
-            doc,
-            ['remote-management', 'disable-auto-update-panel'],
-            values.rmDisableAutoUpdatePanel
-          );
-          setStringInDoc(doc, ['remote-management', 'panel-github-repository'], values.rmPanelRepo);
+          if (docHas(doc, ['remote-management', 'disable-auto-update-panel'])) {
+            doc.deleteIn(['remote-management', 'disable-auto-update-panel']);
+          }
+          if (docHas(doc, ['remote-management', 'panel-github-repository'])) {
+            doc.deleteIn(['remote-management', 'panel-github-repository']);
+          }
           if (docHas(doc, ['remote-management', 'panel-repo'])) {
             doc.deleteIn(['remote-management', 'panel-repo']);
           }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -116,6 +116,7 @@
     "auth_files": "Auth Files",
     "oauth": "OAuth Login",
     "quota_management": "Quota Management",
+    "usage_analytics": "Usage & Analytics",
     "config_management": "Config Panel",
     "logs": "Logs Viewer",
     "system_info": "Management Center Info"
@@ -1111,11 +1112,8 @@
           "allow_remote_desc": "Allow management access from other hosts",
           "disable_panel": "Disable Control Panel",
           "disable_panel_desc": "Disable the built-in web control panel",
-          "disable_auto_update_panel": "Disable Panel Auto Updates",
-          "disable_auto_update_panel_desc": "Download the panel when first missing, but never auto-update it from GitHub",
           "secret_key": "Management Key",
-          "secret_key_placeholder": "Set management key",
-          "panel_repo": "Panel Repository"
+          "secret_key_placeholder": "Set management key"
         },
         "auth": {
           "title": "Authentication Configuration",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -116,6 +116,7 @@
     "auth_files": "Файлы аутентификации",
     "oauth": "OAuth вход",
     "quota_management": "Управление квотами",
+    "usage_analytics": "Usage & Analytics",
     "config_management": "Панель конфигурации",
     "logs": "Просмотр логов",
     "system_info": "Информация системы"
@@ -1108,11 +1109,8 @@
           "allow_remote_desc": "Разрешить управление с других хостов",
           "disable_panel": "Отключить панель",
           "disable_panel_desc": "Отключить встроенную веб-панель управления",
-          "disable_auto_update_panel": "Отключить автообновление панели",
-          "disable_auto_update_panel_desc": "Скачивать панель при первом отсутствии, но не обновлять её автоматически с GitHub",
           "secret_key": "Ключ управления",
-          "secret_key_placeholder": "Задайте ключ управления",
-          "panel_repo": "Репозиторий панели"
+          "secret_key_placeholder": "Задайте ключ управления"
         },
         "auth": {
           "title": "Настройки аутентификации",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -116,6 +116,7 @@
     "auth_files": "认证文件",
     "oauth": "OAuth 登录",
     "quota_management": "配额管理",
+    "usage_analytics": "用量分析",
     "config_management": "配置面板",
     "logs": "日志查看",
     "system_info": "中心信息"
@@ -1111,11 +1112,8 @@
           "allow_remote_desc": "允许从其他主机访问管理接口",
           "disable_panel": "禁用控制面板",
           "disable_panel_desc": "禁用内置的 Web 控制面板",
-          "disable_auto_update_panel": "禁用面板自动更新",
-          "disable_auto_update_panel_desc": "首次缺失时仍可下载，但不再从 GitHub 后台自动更新",
           "secret_key": "管理密钥",
-          "secret_key_placeholder": "设置管理密钥",
-          "panel_repo": "面板仓库"
+          "secret_key_placeholder": "设置管理密钥"
         },
         "auth": {
           "title": "认证配置",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -116,6 +116,7 @@
     "auth_files": "驗證檔案",
     "oauth": "OAuth 登入",
     "quota_management": "配額管理",
+    "usage_analytics": "用量分析",
     "config_management": "設定面板",
     "logs": "記錄檢視",
     "system_info": "中心資訊"
@@ -1137,11 +1138,8 @@
           "allow_remote_desc": "允許從其他主機存取管理介面",
           "disable_panel": "停用控制面板",
           "disable_panel_desc": "停用內建的 Web 控制面板",
-          "disable_auto_update_panel": "停用面板自動更新",
-          "disable_auto_update_panel_desc": "首次缺失時仍可下載，但不再從 GitHub 背景自動更新",
           "secret_key": "管理金鑰",
-          "secret_key_placeholder": "設定管理金鑰",
-          "panel_repo": "面板儲存庫"
+          "secret_key_placeholder": "設定管理金鑰"
         },
         "auth": {
           "title": "驗證設定",

--- a/src/types/visualConfig.ts
+++ b/src/types/visualConfig.ts
@@ -76,8 +76,6 @@ export type VisualConfigValues = {
   rmAllowRemote: boolean;
   rmSecretKey: string;
   rmDisableControlPanel: boolean;
-  rmDisableAutoUpdatePanel: boolean;
-  rmPanelRepo: string;
   authDir: string;
   apiKeysText: string;
   debug: boolean;
@@ -137,8 +135,6 @@ export const DEFAULT_VISUAL_VALUES: VisualConfigValues = {
   rmAllowRemote: false,
   rmSecretKey: '',
   rmDisableControlPanel: false,
-  rmDisableAutoUpdatePanel: false,
-  rmPanelRepo: '',
   authDir: '',
   apiKeysText: '',
   debug: false,


### PR DESCRIPTION
## Add management usage analytics observability

Expose token/cost analytics, API-key tracking, request detail summaries, and table-based recent requests in the Management Center. Keep the chart token-focused, add instant point tooltips, and match the injected sidebar icon to the existing navigation style.

- **Constraint**: Must integrate with the bundled Management Center shell and existing usage portal storage.
Rejected: Native chart title tooltips | Browser delay made the UI feel unresponsive.
- **Confidence**: high
- **Scope-risk**: moderate
- **Directive**: Keep asset regression tests updated when changing chart, sidebar injection, or request table markup.
- **Tested**: node --check internal/managementasset/static/usage-analytics-extension.js; go test ./...; go build -o test-output ./cmd/server && rm test-output; browser smoke for chart, detail stats, recent table, tooltip, and sidebar icon.

<img width="1906" height="759" alt="Screenshot 2026-05-25 at 18 24 03" src="https://github.com/user-attachments/assets/22610864-be3f-44a8-b879-1c032e6e9569" />
<img width="1910" height="928" alt="Screenshot 2026-05-25 at 18 23 56" src="https://github.com/user-attachments/assets/56424722-d155-4ad7-aef6-25fd56aaf656" />
<img width="1913" height="930" alt="Screenshot 2026-05-25 at 18 24 09" src="https://github.com/user-attachments/assets/27ac4785-e462-4c50-845f-e1793acfbedd" />
