### PR TITLE
fix(ui): add show/hide toggle for API key inputs and populate key on edit

### DIFF
--- a/src/features/providers/sheets/forms/BaseProviderForm.tsx
+++ b/src/features/providers/sheets/forms/BaseProviderForm.tsx
@@ -67,19 +67,6 @@ const headersObjectToText = (headers?: Record<string, string>): string =>
 const stripDisableAllRule = (list?: string[]): string[] =>
   (list ?? []).filter((s) => s.trim() !== '*');
 
-/** Populate apiKey from resource.raw when editing a non-OpenAI provider. */
-const applyRawApiKey = (
-  brand: Exclude<ProviderBrand, 'ampcode'>,
-  resource: ProviderResource | null,
-  mode: 'create' | 'edit',
-  form: ProviderEntryFormInput
-): void => {
-  if (mode === 'edit' && resource && brand !== 'openaiCompatibility') {
-    const rawKey = (resource.raw as { apiKey?: string } | undefined)?.apiKey ?? '';
-    if (rawKey) form.apiKey = rawKey;
-  }
-};
-
 function buildInitialForm(
   brand: Exclude<ProviderBrand, 'ampcode'>,
   resource: ProviderResource | null,
@@ -148,7 +135,8 @@ function buildInitialForm(
   const disabled = hasDisableAllModelsRule(cfg.excludedModels);
   const excludedList = stripDisableAllRule(cfg.excludedModels);
   return {
-    apiKey: '',
+    // Populate apiKey from resource.raw in edit mode so the field is not empty
+    apiKey: cfg.apiKey ?? '',
     name: '',
     baseUrl: cfg.baseUrl ?? '',
     proxyUrl: cfg.proxyUrl ?? '',
@@ -219,16 +207,12 @@ export function BaseProviderForm({
   const { t } = useTranslation();
   const descriptor = PROVIDER_DESCRIPTORS[brand];
   const fid = useId();
-  const [form, setForm] = useState<ProviderEntryFormInput>(() => {
-    const initial = buildInitialForm(brand, resource, mode);
-    applyRawApiKey(brand, resource, mode, initial);
-    return initial;
-  });
-  const [initialFormSignature] = useState<string>(() => {
-    const initial = buildInitialForm(brand, resource, mode);
-    applyRawApiKey(brand, resource, mode, initial);
-    return JSON.stringify(initial);
-  });
+  const [form, setForm] = useState<ProviderEntryFormInput>(() =>
+    buildInitialForm(brand, resource, mode)
+  );
+  const [initialFormSignature] = useState<string>(() =>
+    JSON.stringify(buildInitialForm(brand, resource, mode))
+  );
   const [error, setError] = useState<string | null>(null);
   const [showPasswords, setShowPasswords] = useState<Set<number>>(new Set());
   const [showSingleApiKey, setShowSingleApiKey] = useState(false);

--- a/src/features/providers/sheets/forms/BaseProviderForm.tsx
+++ b/src/features/providers/sheets/forms/BaseProviderForm.tsx
@@ -4,6 +4,8 @@ import {
   IconAlertTriangle,
   IconCheckCircle2,
   IconDownload,
+  IconEye,
+  IconEyeOff,
   IconLoader2,
   IconPlus,
   IconX,
@@ -64,6 +66,19 @@ const headersObjectToText = (headers?: Record<string, string>): string =>
 
 const stripDisableAllRule = (list?: string[]): string[] =>
   (list ?? []).filter((s) => s.trim() !== '*');
+
+/** Populate apiKey from resource.raw when editing a non-OpenAI provider. */
+const applyRawApiKey = (
+  brand: Exclude<ProviderBrand, 'ampcode'>,
+  resource: ProviderResource | null,
+  mode: 'create' | 'edit',
+  form: ProviderEntryFormInput
+): void => {
+  if (mode === 'edit' && resource && brand !== 'openaiCompatibility') {
+    const rawKey = (resource.raw as { apiKey?: string } | undefined)?.apiKey ?? '';
+    if (rawKey) form.apiKey = rawKey;
+  }
+};
 
 function buildInitialForm(
   brand: Exclude<ProviderBrand, 'ampcode'>,
@@ -204,13 +219,37 @@ export function BaseProviderForm({
   const { t } = useTranslation();
   const descriptor = PROVIDER_DESCRIPTORS[brand];
   const fid = useId();
-  const [form, setForm] = useState<ProviderEntryFormInput>(() =>
-    buildInitialForm(brand, resource, mode)
-  );
-  const [initialFormSignature] = useState<string>(() =>
-    JSON.stringify(buildInitialForm(brand, resource, mode))
-  );
+  const [form, setForm] = useState<ProviderEntryFormInput>(() => {
+    const initial = buildInitialForm(brand, resource, mode);
+    applyRawApiKey(brand, resource, mode, initial);
+    return initial;
+  });
+  const [initialFormSignature] = useState<string>(() => {
+    const initial = buildInitialForm(brand, resource, mode);
+    applyRawApiKey(brand, resource, mode, initial);
+    return JSON.stringify(initial);
+  });
   const [error, setError] = useState<string | null>(null);
+  const [showPasswords, setShowPasswords] = useState<Set<number>>(new Set());
+  const [showSingleApiKey, setShowSingleApiKey] = useState(false);
+
+  // Reset password visibility when the sheet closes or resource changes
+  useEffect(() => {
+    setShowPasswords(new Set());
+    setShowSingleApiKey(false);
+  }, [resource?.id, mode]);
+
+  const togglePasswordVisibility = (idx: number) => {
+    setShowPasswords((prev) => {
+      const next = new Set(prev);
+      if (next.has(idx)) {
+        next.delete(idx);
+      } else {
+        next.add(idx);
+      }
+      return next;
+    });
+  };
 
   const isDirty = useMemo(
     () => JSON.stringify(form) !== initialFormSignature,
@@ -454,19 +493,43 @@ export function BaseProviderForm({
             <label className={styles.label} htmlFor={`${fid}-apiKey`}>
               {t('providersPage.form.apiKey')}
             </label>
-            <input
-              id={`${fid}-apiKey`}
-              className={styles.input}
-              type="password"
-              value={form.apiKey}
-              onChange={(e) => updateField('apiKey', e.target.value)}
-              placeholder={
-                mode === 'edit'
-                  ? t('providersPage.form.apiKeyEditPlaceholder')
-                  : t('providersPage.form.apiKeyCreatePlaceholder')
-              }
-              disabled={mutating}
-            />
+            <div className={styles.passwordField}>
+              <input
+                id={`${fid}-apiKey`}
+                className={styles.passwordInput}
+                type={showSingleApiKey ? 'text' : 'password'}
+                value={form.apiKey}
+                onChange={(e) => updateField('apiKey', e.target.value)}
+                placeholder={
+                  mode === 'edit'
+                    ? t('providersPage.form.apiKeyEditPlaceholder')
+                    : t('providersPage.form.apiKeyCreatePlaceholder')
+                }
+                disabled={mutating}
+              />
+              <button
+                type="button"
+                className={styles.passwordToggle}
+                onClick={() => setShowSingleApiKey((v) => !v)}
+                disabled={mutating}
+                aria-label={
+                  showSingleApiKey
+                    ? t('providersPage.form.hideApiKey')
+                    : t('providersPage.form.showApiKey')
+                }
+                title={
+                  showSingleApiKey
+                    ? t('providersPage.form.hideApiKey')
+                    : t('providersPage.form.showApiKey')
+                }
+              >
+                {showSingleApiKey ? (
+                  <IconEyeOff size={16} />
+                ) : (
+                  <IconEye size={16} />
+                )}
+              </button>
+            </div>
           </div>
         ) : null}
 
@@ -695,21 +758,45 @@ export function BaseProviderForm({
                     <label className={styles.label}>
                       {t('providersPage.form.apiKey')}
                     </label>
-                    <input
-                      className={styles.input}
-                      type="password"
-                      value={entry.apiKey}
-                      onChange={(e) =>
-                        updateField(
-                          'apiKeyEntries',
-                          apiKeyEntries.map((it, i) =>
-                            i === idx ? { ...it, apiKey: e.target.value } : it
+                    <div className={styles.passwordField}>
+                      <input
+                        className={styles.passwordInput}
+                        type={showPasswords.has(idx) ? 'text' : 'password'}
+                        value={entry.apiKey}
+                        onChange={(e) =>
+                          updateField(
+                            'apiKeyEntries',
+                            apiKeyEntries.map((it, i) =>
+                              i === idx ? { ...it, apiKey: e.target.value } : it
+                            )
                           )
-                        )
-                      }
-                      disabled={mutating}
-                      placeholder={t('providersPage.form.apiKeyCreatePlaceholder')}
-                    />
+                        }
+                        disabled={mutating}
+                        placeholder={t('providersPage.form.apiKeyCreatePlaceholder')}
+                      />
+                      <button
+                        type="button"
+                        className={styles.passwordToggle}
+                        onClick={() => togglePasswordVisibility(idx)}
+                        disabled={mutating}
+                        aria-label={
+                          showPasswords.has(idx)
+                            ? t('providersPage.form.hideApiKey')
+                            : t('providersPage.form.showApiKey')
+                        }
+                        title={
+                          showPasswords.has(idx)
+                            ? t('providersPage.form.hideApiKey')
+                            : t('providersPage.form.showApiKey')
+                        }
+                      >
+                        {showPasswords.has(idx) ? (
+                          <IconEyeOff size={16} />
+                        ) : (
+                          <IconEye size={16} />
+                        )}
+                      </button>
+                    </div>
                   </div>
                   <div className={styles.field}>
                     <label className={styles.label}>

--- a/src/features/providers/sheets/forms/sharedForm.module.scss
+++ b/src/features/providers/sheets/forms/sharedForm.module.scss
@@ -490,6 +490,64 @@
   }
 }
 
+.passwordField {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.passwordInput {
+  width: 100%;
+  height: 36px;
+  padding: 8px 36px 8px 12px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-color);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-size: 13px;
+  font-family: inherit;
+  box-sizing: border-box;
+
+  &::placeholder {
+    color: var(--text-tertiary);
+  }
+
+  &:focus {
+    outline: none;
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 3px var(--primary-10);
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+}
+
+.passwordToggle {
+  position: absolute;
+  right: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+  border: none;
+  background: transparent;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition: color $transition-fast;
+
+  &:hover:not(:disabled) {
+    color: var(--text-primary);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
 .entriesList {
   display: flex;
   flex-direction: column;

--- a/src/features/providers/sheets/forms/sharedForm.module.scss
+++ b/src/features/providers/sheets/forms/sharedForm.module.scss
@@ -497,31 +497,8 @@
 }
 
 .passwordInput {
-  width: 100%;
-  height: 36px;
-  padding: 8px 36px 8px 12px;
-  border-radius: var(--radius-md);
-  border: 1px solid var(--border-color);
-  background: var(--bg-primary);
-  color: var(--text-primary);
-  font-size: 13px;
-  font-family: inherit;
-  box-sizing: border-box;
-
-  &::placeholder {
-    color: var(--text-tertiary);
-  }
-
-  &:focus {
-    outline: none;
-    border-color: var(--primary-color);
-    box-shadow: 0 0 0 3px var(--primary-10);
-  }
-
-  &:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-  }
+  @extend .input;
+  padding-right: 36px;
 }
 
 .passwordToggle {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1313,6 +1313,8 @@
       "apiKeyEntriesSection": "API key entries",
       "apiKeyEntry": "Key #{{index}}",
       "addApiKeyEntry": "Add key entry",
+      "showApiKey": "Show API key",
+      "hideApiKey": "Hide API key",
       "validation": {
         "nameRequired": "Name is required",
         "apiKeyRequired": "At least one API key is required",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1310,6 +1310,8 @@
       "apiKeyEntriesSection": "API-ключи",
       "apiKeyEntry": "Ключ #{{index}}",
       "addApiKeyEntry": "Добавить ключ",
+      "showApiKey": "Показать ключ API",
+      "hideApiKey": "Скрыть ключ API",
       "validation": {
         "nameRequired": "Название обязательно",
         "apiKeyRequired": "Нужен хотя бы один API-ключ",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1313,6 +1313,8 @@
       "apiKeyEntriesSection": "API 密钥条目",
       "apiKeyEntry": "密钥 #{{index}}",
       "addApiKeyEntry": "添加密钥条目",
+      "showApiKey": "显示密钥",
+      "hideApiKey": "隐藏密钥",
       "validation": {
         "nameRequired": "名称必填",
         "apiKeyRequired": "至少填写一个 API 密钥",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1339,6 +1339,8 @@
       "apiKeyEntriesSection": "API 金鑰條目",
       "apiKeyEntry": "金鑰 #{{index}}",
       "addApiKeyEntry": "新增金鑰條目",
+      "showApiKey": "顯示金鑰",
+      "hideApiKey": "隱藏金鑰",
       "validation": {
         "nameRequired": "名稱必填",
         "apiKeyRequired": "至少填寫一個 API 金鑰",


### PR DESCRIPTION

## Summary

- Add a show/hide password toggle button to **all** API key input fields in the provider form.
- Apply the toggle to both the single API key field (`descriptor.supportsApiKey`, used by Gemini/Codex/Claude/Vertex) and the per-entry API key fields (`apiKeyEntries`, used by OpenAI-compatible providers).
- Fix the edit-mode API key field displaying as empty — now populates the value from `resource.raw.apiKey` so existing keys can be verified without re-entering.

## Background

All API key inputs in the provider form use `type="password"` with no visibility toggle. Two problems exist:

1. **No toggle**: When editing an existing provider the key is masked as `••••••`, making it impossible to verify or partially update the value without re-entering the entire key.
2. **Empty field on edit**: For non-OpenAI providers, `buildInitialForm` sets `apiKey: ''` in edit mode (security design — backend doesn't return plaintext). The value exists in `resource.raw.apiKey` but was never populated into the form, so the field appeared completely empty.

The login page (`LoginPage.tsx`) already implements the eye-toggle pattern using `IconEye` / `IconEyeOff` from `@/components/ui/icons`. This PR follows the same approach.

## Changes

### `src/features/providers/sheets/forms/BaseProviderForm.tsx`

**State additions:**
- `showPasswords` (`Set<number>`) — tracks which OpenAI-entry API key fields are in "visible" mode (per-entry independent toggle).
- `showSingleApiKey` (`boolean`) — tracks visibility for the single API key field (non-OpenAI providers).
- `useEffect` resets both states to default (hidden) when `resource?.id` or `mode` changes (i.e., sheet closes or switches to a different provider).

**Edit-mode API key initialization (line ~209–226):**
- `form` state initializer: in edit mode for non-OpenAI providers, reads `resource.raw.apiKey` and populates `initial.apiKey` so the field is not empty.
- `initialFormSignature`: applies the same logic to keep `isDirty` detection in sync (avoids false-positive dirty state on open).

**Single API key field (line ~491–513):**
- Wraps the input in `.passwordField` container.
- Changes `className` from `styles.input` to `styles.passwordInput`.
- Changes `type` from hardcoded `"password"` to `showSingleApiKey ? 'text' : 'password'`.
- Adds a toggle `<button>` with `IconEye` / `IconEyeOff` inside `.passwordToggle`.

**Per-entry API key fields (line ~740–772):**
- Same pattern as above, but uses `showPasswords.has(idx)` for per-entry independent visibility.
- Toggle button calls `togglePasswordVisibility(idx)` which adds/removes the index from the `Set`.

### `src/features/providers/sheets/forms/sharedForm.module.scss`

New styles (line ~541–597):
- `.passwordField` — `position: relative; display: flex; align-items: center` wrapper.
- `.passwordInput` — input styled to match existing `.input` but with `padding-right: 36px` to make room for the toggle button.
- `.passwordToggle` — absolutely-positioned button on the right side of the input, with hover/disabled states.

## Verification

- [x] `bun run type-check`
- [x] `bun run build`
- [x] Manually verify: open a non-OpenAI provider (e.g. Gemini) in edit mode — API key field should show the existing key (masked), toggle reveals it.
- [x] Manually verify: open an OpenAI-compatible provider with multiple API key entries — each entry has an independent show/hide toggle.
- [x] Manually verify: close the sheet and reopen — password visibility resets to hidden.
- [x] Manually verify: switch between providers — password visibility resets to hidden.
- [x] Manually verify: edit mode dirty detection — opening a provider and not changing anything should NOT show unsaved changes.
<img width="1598" height="592" alt="2026-05-27_22-50-59" src="https://github.com/user-attachments/assets/9ac329d6-46e9-44f7-af82-3e1f978c943a" />
<img width="694" height="782" alt="2026-05-27_22-51-44" src="https://github.com/user-attachments/assets/d8560488-93e8-467f-9241-92a3a1f184fc" />