### PR TITLE
WIP feat(quota): improve credential refresh and filtering

### DIFF
--- a/src/components/quota/QuotaCard.tsx
+++ b/src/components/quota/QuotaCard.tsx
@@ -5,6 +5,8 @@
 import { useTranslation } from 'react-i18next';
 import type { ReactElement, ReactNode } from 'react';
 import type { TFunction } from 'i18next';
+import { Button } from '@/components/ui/Button';
+import { IconRefreshCw } from '@/components/ui/icons';
 import type { AuthFileItem, ResolvedTheme, ThemeColors } from '@/types';
 import { TYPE_COLORS } from '@/utils/quota';
 import styles from '@/pages/QuotaPage.module.scss';
@@ -89,6 +91,7 @@ export function QuotaCard<TState extends QuotaStatusState>({
     resolvedTheme === 'dark' && typeColorSet.dark ? typeColorSet.dark : typeColorSet.light;
 
   const quotaStatus = quota?.status ?? 'idle';
+  const quotaLoading = quotaStatus === 'loading';
   const quotaErrorMessage = resolveQuotaErrorMessage(
     t,
     quota?.errorStatus,
@@ -121,7 +124,7 @@ export function QuotaCard<TState extends QuotaStatusState>({
       </div>
 
       <div className={styles.quotaSection}>
-        {quotaStatus === 'loading' ? (
+        {quotaLoading ? (
           <div className={styles.quotaMessage}>{t(`${i18nPrefix}.loading`)}</div>
         ) : quotaStatus === 'idle' ? (
           onRefresh ? (
@@ -148,6 +151,24 @@ export function QuotaCard<TState extends QuotaStatusState>({
           <div className={styles.quotaMessage}>{t(idleMessageKey)}</div>
         )}
       </div>
+
+      {onRefresh && (
+        <div className={styles.quotaCardActions}>
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            className={styles.quotaRefreshButton}
+            onClick={onRefresh}
+            disabled={!canRefresh || quotaLoading}
+            loading={quotaLoading}
+            title={t('auth_files.quota_refresh_hint')}
+          >
+            {!quotaLoading && <IconRefreshCw size={14} />}
+            {t('auth_files.quota_refresh_single')}
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/quota/QuotaSection.tsx
+++ b/src/components/quota/QuotaSection.tsx
@@ -115,11 +115,22 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
   const [columns, gridRef] = useGridColumns(380); // Min card width 380px matches SCSS
   const [viewMode, setViewMode] = useState<ViewMode>('paged');
   const [showTooManyWarning, setShowTooManyWarning] = useState(false);
+  const [fileFilter, setFileFilter] = useState('');
 
-  const filteredFiles = useMemo(() => files.filter((file) => config.filterFn(file)), [
+  const sectionFiles = useMemo(() => files.filter((file) => config.filterFn(file)), [
     files,
     config
   ]);
+  const filteredFiles = useMemo(() => {
+    const term = fileFilter.trim().toLowerCase();
+    if (!term) return sectionFiles;
+
+    return sectionFiles.filter((file) =>
+      [file.name, file.type, file.provider, file.email, file.account, file.label]
+        .filter((value) => value !== undefined && value !== null)
+        .some((value) => String(value).toLowerCase().includes(term))
+    );
+  }, [fileFilter, sectionFiles]);
   const showAllAllowed = filteredFiles.length <= MAX_SHOW_ALL_THRESHOLD;
   const effectiveViewMode: ViewMode = viewMode === 'all' && !showAllAllowed ? 'paged' : viewMode;
 
@@ -299,6 +310,25 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
         </div>
       }
     >
+      <div className={styles.filterPanel}>
+        <label className={styles.filterLabel} htmlFor={`${config.type}-quota-file-filter`}>
+          {t('quota_management.file_filter_label')}
+        </label>
+        <input
+          id={`${config.type}-quota-file-filter`}
+          className={styles.fileFilterInput}
+          value={fileFilter}
+          onChange={(event) => setFileFilter(event.currentTarget.value)}
+          placeholder={t('quota_management.file_filter_placeholder')}
+        />
+        <span className={styles.filterStats}>
+          {t('quota_management.file_filter_count', {
+            count: filteredFiles.length,
+            total: sectionFiles.length,
+          })}
+        </span>
+      </div>
+
       {filteredFiles.length === 0 ? (
         <EmptyState
           title={t(`${config.i18nPrefix}.empty_title`)}

--- a/src/features/authFiles/components/AuthFileCard.tsx
+++ b/src/features/authFiles/components/AuthFileCard.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/Button';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
@@ -7,6 +8,7 @@ import {
   IconDownload,
   IconInfo,
   IconModelCluster,
+  IconRefreshCw,
   IconSettings,
   IconTrash2,
 } from '@/components/ui/icons';
@@ -65,6 +67,10 @@ const resolveQuotaType = (file: AuthFileItem): QuotaProviderType | null => {
 
 export function AuthFileCard(props: AuthFileCardProps) {
   const { t } = useTranslation();
+  const [quotaRefreshHandler, setQuotaRefreshHandler] = useState<(() => void) | null>(null);
+  const registerQuotaRefreshHandler = useCallback((handler: (() => void) | null) => {
+    setQuotaRefreshHandler(() => handler);
+  }, []);
   const {
     file,
     compact,
@@ -256,6 +262,7 @@ export function AuthFileCard(props: AuthFileCardProps) {
                 file={file}
                 quotaType={quotaType}
                 disableControls={disableControls}
+                registerRefreshHandler={registerQuotaRefreshHandler}
               />
             )}
           </div>
@@ -303,6 +310,21 @@ export function AuthFileCard(props: AuthFileCardProps) {
                   >
                     <IconSettings className={styles.actionIcon} size={16} />
                   </Button>
+                  {showQuotaLayout && (
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      onClick={() => quotaRefreshHandler?.()}
+                      className={styles.quotaActionButton}
+                      title={t('auth_files.quota_refresh_hint')}
+                      disabled={disableControls || file.disabled || !quotaRefreshHandler}
+                    >
+                      <>
+                        <IconRefreshCw className={styles.actionIcon} size={14} />
+                        <span>{t('auth_files.quota_refresh_single')}</span>
+                      </>
+                    </Button>
+                  )}
                   <Button
                     variant="danger"
                     size="sm"

--- a/src/features/authFiles/components/AuthFileQuotaSection.tsx
+++ b/src/features/authFiles/components/AuthFileQuotaSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, type ReactNode } from 'react';
+import { useCallback, useEffect, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import {
@@ -35,10 +35,11 @@ export type AuthFileQuotaSectionProps = {
   file: AuthFileItem;
   quotaType: QuotaProviderType;
   disableControls: boolean;
+  registerRefreshHandler?: (handler: (() => void) | null) => void;
 };
 
 export function AuthFileQuotaSection(props: AuthFileQuotaSectionProps) {
-  const { file, quotaType, disableControls } = props;
+  const { file, quotaType, disableControls, registerRefreshHandler } = props;
   const { t } = useTranslation();
   const showNotification = useNotificationStore((state) => state.showNotification);
 
@@ -99,6 +100,12 @@ export function AuthFileQuotaSection(props: AuthFileQuotaSectionProps) {
       showNotification(t('auth_files.quota_refresh_failed', { name: file.name, message }), 'error');
     }
   }, [disableControls, file, quota?.status, quotaType, showNotification, t, updateQuotaState]);
+
+  useEffect(() => {
+    if (!registerRefreshHandler) return;
+    registerRefreshHandler(() => void refreshQuotaForFile());
+    return () => registerRefreshHandler(null);
+  }, [refreshQuotaForFile, registerRefreshHandler]);
 
   const config = getQuotaConfig(quotaType) as unknown as {
     i18nPrefix: string;

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -368,6 +368,8 @@
     "prefix_proxy_invalid_json": "This auth file is not a JSON object, so fields cannot be edited.",
     "prefix_proxy_html_challenge": "Downloaded content is an HTML challenge page, not an auth JSON object. Re-authenticate or replace this auth file before editing fields.",
     "prefix_proxy_saved_success": "Updated auth file \"{{name}}\" successfully",
+    "quota_refresh_single": "Refresh quota",
+    "quota_refresh_hint": "Refresh quota only for this credential",
     "quota_refresh_success": "Quota refreshed for \"{{name}}\"",
     "quota_refresh_failed": "Failed to refresh quota for \"{{name}}\": {{message}}"
   },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1074,6 +1074,9 @@
     "refresh_files": "Refresh auth files",
     "refresh_files_and_quota": "Refresh files & quota",
     "refresh_all_credentials": "Refresh all credentials",
+    "file_filter_label": "Filter auth files",
+    "file_filter_placeholder": "Enter file name, email, or type",
+    "file_filter_count": "Showing {{count}} / {{total}} auth files",
     "card_idle_hint": "Use the top \"Refresh all credentials\" button to fetch the latest quota data."
   },
   "system_info": {

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1069,6 +1069,9 @@
     "refresh_files": "Обновить файлы авторизации",
     "refresh_files_and_quota": "Обновить файлы и квоты",
     "refresh_all_credentials": "Обновить все учётные данные",
+    "file_filter_label": "Фильтр файлов авторизации",
+    "file_filter_placeholder": "Введите имя файла, email или тип",
+    "file_filter_count": "Показано {{count}} / {{total}} файлов авторизации",
     "card_idle_hint": "Используйте кнопку «Обновить все учётные данные» сверху, чтобы загрузить актуальные данные по квотам."
   },
   "system_info": {

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -368,6 +368,8 @@
     "prefix_proxy_invalid_json": "该认证文件不是 JSON 对象，无法编辑字段。",
     "prefix_proxy_html_challenge": "下载到的是 HTML 验证页面，不是认证 JSON 对象。请重新认证或替换该认证文件后再编辑字段。",
     "prefix_proxy_saved_success": "已更新认证文件 \"{{name}}\"",
+    "quota_refresh_single": "刷新额度",
+    "quota_refresh_hint": "仅刷新该认证文件的额度",
     "quota_refresh_success": "已刷新 \"{{name}}\" 的额度",
     "quota_refresh_failed": "刷新 \"{{name}}\" 的额度失败：{{message}}"
   },

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1074,6 +1074,9 @@
     "refresh_files": "刷新认证文件",
     "refresh_files_and_quota": "刷新认证文件&额度",
     "refresh_all_credentials": "刷新全部凭证",
+    "file_filter_label": "过滤认证文件",
+    "file_filter_placeholder": "输入文件名、邮箱或类型",
+    "file_filter_count": "显示 {{count}} / {{total}} 个认证文件",
     "card_idle_hint": "请使用顶部“刷新全部凭证”按钮获取最新额度。"
   },
   "system_info": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -368,6 +368,8 @@
     "prefix_proxy_invalid_json": "該驗證檔案不是 JSON 物件，無法編輯欄位。",
     "prefix_proxy_html_challenge": "下載到的是 HTML 驗證頁面，不是驗證 JSON 物件。請重新驗證或替換該驗證檔案後再編輯欄位。",
     "prefix_proxy_saved_success": "已更新驗證檔案「{{name}}」",
+    "quota_refresh_single": "重新整理配額",
+    "quota_refresh_hint": "僅重新整理該驗證檔案的配額",
     "quota_refresh_success": "已重新整理「{{name}}」的配額",
     "quota_refresh_failed": "重新整理「{{name}}」的配額失敗：{{message}}"
   },

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1100,6 +1100,9 @@
     "refresh_files": "重新整理驗證檔案",
     "refresh_files_and_quota": "重新整理驗證檔案&配額",
     "refresh_all_credentials": "重新整理全部憑證",
+    "file_filter_label": "篩選驗證檔案",
+    "file_filter_placeholder": "輸入檔名、信箱或類型",
+    "file_filter_count": "顯示 {{count}} / {{total}} 個驗證檔案",
     "card_idle_hint": "請使用頂部「重新整理全部憑證」按鈕取得最新配額。"
   },
   "system_info": {

--- a/src/pages/AuthFilesPage.module.scss
+++ b/src/pages/AuthFilesPage.module.scss
@@ -1549,6 +1549,19 @@
   gap: 0;
 }
 
+.quotaActionButton:global(.btn.btn-sm) {
+  height: 32px;
+  padding-inline: 9px;
+  border-radius: 8px;
+
+  > span {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    white-space: nowrap;
+  }
+}
+
 .actionIcon {
   display: block;
 }

--- a/src/pages/QuotaPage.module.scss
+++ b/src/pages/QuotaPage.module.scss
@@ -392,6 +392,24 @@
   }
 }
 
+.quotaCardActions {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: $spacing-xs;
+}
+
+.quotaRefreshButton:global(.btn.btn-sm) {
+  border-radius: 999px;
+  padding-inline: 12px;
+
+  > span {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    white-space: nowrap;
+  }
+}
+
 .quotaError {
   font-size: 12px;
   color: var(--danger-color);

--- a/src/pages/QuotaPage.module.scss
+++ b/src/pages/QuotaPage.module.scss
@@ -80,6 +80,51 @@
   font-size: 14px;
 }
 
+.filterPanel {
+  display: flex;
+  align-items: flex-end;
+  gap: $spacing-md;
+  flex-wrap: wrap;
+  padding: $spacing-md;
+  border: 1px solid var(--border-color);
+  border-radius: $radius-md;
+  background-color: var(--bg-secondary);
+}
+
+.filterLabel {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.fileFilterInput {
+  width: min(420px, 100%);
+  height: 38px;
+  padding: 8px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: $radius-md;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  font-size: 14px;
+  box-sizing: border-box;
+
+  &:focus {
+    outline: none;
+    border-color: var(--primary-color);
+  }
+}
+
+.filterStats {
+  height: 38px;
+  display: inline-flex;
+  align-items: center;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
 .pageSizeSelect {
   padding: 8px 12px;
   border: 1px solid var(--border-color);
@@ -243,6 +288,15 @@
 }
 
 @include mobile {
+  .filterPanel {
+    align-items: stretch;
+  }
+
+  .filterLabel,
+  .fileFilterInput {
+    width: 100%;
+  }
+
   .headerActions {
     gap: $spacing-xs;
   }


### PR DESCRIPTION
## English

### Summary
- Keep per-credential quota refresh actions available from auth file cards.
- Add per-section auth file filters to quota management sections.
- Filter quota cards by file name, email, provider/type, account, or label.
- Add localized labels/placeholders/count text for English, Simplified Chinese, Traditional Chinese, and Russian.

### Verification
- `bun run build`

## 中文

### 摘要
- 保持认证文件卡片中的单凭证额度刷新入口可用。
- 在配额管理的每个分区中增加认证文件过滤输入框。
- 支持按文件名、邮箱、provider/type、账号或标签过滤配额卡片。
- 为英文、简体中文、繁体中文和俄语补充过滤相关文案。

### 验证
- `bun run build`

<img width="3000" height="1662" alt="image" src="https://github.com/user-attachments/assets/a9c79db8-db21-4049-96aa-59aaf39b07e4" />
