### PR TITLE
feat(quota): add auth file filters

### DIFF
--- a/src/components/quota/QuotaSection.tsx
+++ b/src/components/quota/QuotaSection.tsx
@@ -115,11 +115,22 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
   const [columns, gridRef] = useGridColumns(380); // Min card width 380px matches SCSS
   const [viewMode, setViewMode] = useState<ViewMode>('paged');
   const [showTooManyWarning, setShowTooManyWarning] = useState(false);
+  const [fileFilter, setFileFilter] = useState('');
 
-  const filteredFiles = useMemo(() => files.filter((file) => config.filterFn(file)), [
+  const sectionFiles = useMemo(() => files.filter((file) => config.filterFn(file)), [
     files,
     config
   ]);
+  const filteredFiles = useMemo(() => {
+    const term = fileFilter.trim().toLowerCase();
+    if (!term) return sectionFiles;
+
+    return sectionFiles.filter((file) =>
+      [file.name, file.type, file.provider, file.email, file.account, file.label]
+        .filter((value) => value !== undefined && value !== null)
+        .some((value) => String(value).toLowerCase().includes(term))
+    );
+  }, [fileFilter, sectionFiles]);
   const showAllAllowed = filteredFiles.length <= MAX_SHOW_ALL_THRESHOLD;
   const effectiveViewMode: ViewMode = viewMode === 'all' && !showAllAllowed ? 'paged' : viewMode;
 
@@ -299,6 +310,25 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
         </div>
       }
     >
+      <div className={styles.filterPanel}>
+        <label className={styles.filterLabel} htmlFor={`${config.type}-quota-file-filter`}>
+          {t('quota_management.file_filter_label')}
+        </label>
+        <input
+          id={`${config.type}-quota-file-filter`}
+          className={styles.fileFilterInput}
+          value={fileFilter}
+          onChange={(event) => setFileFilter(event.currentTarget.value)}
+          placeholder={t('quota_management.file_filter_placeholder')}
+        />
+        <span className={styles.filterStats}>
+          {t('quota_management.file_filter_count', {
+            count: filteredFiles.length,
+            total: sectionFiles.length,
+          })}
+        </span>
+      </div>
+
       {filteredFiles.length === 0 ? (
         <EmptyState
           title={t(`${config.i18nPrefix}.empty_title`)}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1072,6 +1072,9 @@
     "refresh_files": "Refresh auth files",
     "refresh_files_and_quota": "Refresh files & quota",
     "refresh_all_credentials": "Refresh all credentials",
+    "file_filter_label": "Filter auth files",
+    "file_filter_placeholder": "Enter file name, email, or type",
+    "file_filter_count": "Showing {{count}} / {{total}} auth files",
     "card_idle_hint": "Use the top \"Refresh all credentials\" button to fetch the latest quota data."
   },
   "system_info": {

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1069,6 +1069,9 @@
     "refresh_files": "Обновить файлы авторизации",
     "refresh_files_and_quota": "Обновить файлы и квоты",
     "refresh_all_credentials": "Обновить все учётные данные",
+    "file_filter_label": "Фильтр файлов авторизации",
+    "file_filter_placeholder": "Введите имя файла, email или тип",
+    "file_filter_count": "Показано {{count}} / {{total}} файлов авторизации",
     "card_idle_hint": "Используйте кнопку «Обновить все учётные данные» сверху, чтобы загрузить актуальные данные по квотам."
   },
   "system_info": {

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1072,6 +1072,9 @@
     "refresh_files": "刷新认证文件",
     "refresh_files_and_quota": "刷新认证文件&额度",
     "refresh_all_credentials": "刷新全部凭证",
+    "file_filter_label": "过滤认证文件",
+    "file_filter_placeholder": "输入文件名、邮箱或类型",
+    "file_filter_count": "显示 {{count}} / {{total}} 个认证文件",
     "card_idle_hint": "请使用顶部“刷新全部凭证”按钮获取最新额度。"
   },
   "system_info": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1098,6 +1098,9 @@
     "refresh_files": "重新整理驗證檔案",
     "refresh_files_and_quota": "重新整理驗證檔案&配額",
     "refresh_all_credentials": "重新整理全部憑證",
+    "file_filter_label": "篩選驗證檔案",
+    "file_filter_placeholder": "輸入檔名、信箱或類型",
+    "file_filter_count": "顯示 {{count}} / {{total}} 個驗證檔案",
     "card_idle_hint": "請使用頂部「重新整理全部憑證」按鈕取得最新配額。"
   },
   "system_info": {

--- a/src/pages/QuotaPage.module.scss
+++ b/src/pages/QuotaPage.module.scss
@@ -80,6 +80,51 @@
   font-size: 14px;
 }
 
+.filterPanel {
+  display: flex;
+  align-items: flex-end;
+  gap: $spacing-md;
+  flex-wrap: wrap;
+  padding: $spacing-md;
+  border: 1px solid var(--border-color);
+  border-radius: $radius-md;
+  background-color: var(--bg-secondary);
+}
+
+.filterLabel {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.fileFilterInput {
+  width: min(420px, 100%);
+  height: 38px;
+  padding: 8px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: $radius-md;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  font-size: 14px;
+  box-sizing: border-box;
+
+  &:focus {
+    outline: none;
+    border-color: var(--primary-color);
+  }
+}
+
+.filterStats {
+  height: 38px;
+  display: inline-flex;
+  align-items: center;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
 .pageSizeSelect {
   padding: 8px 12px;
   border: 1px solid var(--border-color);
@@ -243,6 +288,15 @@
 }
 
 @include mobile {
+  .filterPanel {
+    align-items: stretch;
+  }
+
+  .filterLabel,
+  .fileFilterInput {
+    width: 100%;
+  }
+
   .headerActions {
     gap: $spacing-xs;
   }


### PR DESCRIPTION
## English

### Summary
- Add per-section auth file filters to quota management sections.
- Filter quota cards by file name, email, provider/type, account, or label.
- Add localized filter labels/placeholders/count text for English, Simplified Chinese, Traditional Chinese, and Russian.

### Verification
- `bun run build`

## 中文

### 摘要
- 在配额管理的每个分区中增加认证文件过滤输入框。
- 支持按文件名、邮箱、provider/type、账号或标签过滤配额卡片。
- 为英文、简体中文、繁体中文和俄语补充过滤相关文案。

### 验证
- `bun run build`

<img width="3000" height="1662" alt="image" src="https://github.com/user-attachments/assets/89363e3a-62b6-44cc-b541-dc2915d03fc8" />
