### PR TITLE
feat: expose weighted routing configuration

### DIFF
--- a/src/components/config/VisualConfigEditor.tsx
+++ b/src/components/config/VisualConfigEditor.tsx
@@ -263,9 +263,7 @@ export function VisualConfigEditor({
     handledJumpRef.current = jumpRequest; // handle each request once, even if deps re-fire
     const { fieldId, sectionId } = jumpRequest;
     const targetFieldId =
-      (fieldId === 'tlsCert' || fieldId === 'tlsKey') && !values.tlsEnable
-        ? 'tlsEnable'
-        : fieldId;
+      (fieldId === 'tlsCert' || fieldId === 'tlsKey') && !values.tlsEnable ? 'tlsEnable' : fieldId;
 
     const el = document.getElementById(configFieldDomId(targetFieldId));
     if (!el) {
@@ -1136,6 +1134,12 @@ export function VisualConfigEditor({
                             value: 'fill-first',
                             label: t(
                               'config_management.visual.sections.network.strategy_fill_first'
+                            ),
+                          },
+                          {
+                            value: 'weighted-round-robin',
+                            label: t(
+                              'config_management.visual.sections.network.strategy_weighted_round_robin'
                             ),
                           },
                         ]}

--- a/src/components/config/configSearchIndex.ts
+++ b/src/components/config/configSearchIndex.ts
@@ -159,7 +159,7 @@ export const CONFIG_FIELD_SEARCH_INDEX: ConfigFieldSearchEntry[] = [
     labelKey: L('sections.network.routing_strategy'),
     hintKey: L('sections.network.routing_strategy_hint'),
     yamlKeys: ['routing', 'strategy'],
-    keywords: ['round-robin', 'fill-first'],
+    keywords: ['round-robin', 'fill-first', 'weighted-round-robin'],
   },
   {
     fieldId: 'disableImageGeneration',

--- a/src/components/quota/QuotaCard.tsx
+++ b/src/components/quota/QuotaCard.tsx
@@ -28,10 +28,9 @@ export interface QuotaProgressBarProps {
 export function QuotaProgressBar({
   percent,
   highThreshold,
-  mediumThreshold
+  mediumThreshold,
 }: QuotaProgressBarProps) {
-  const clamp = (value: number, min: number, max: number) =>
-    Math.min(max, Math.max(min, value));
+  const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
   const normalized = percent === null ? null : clamp(percent, 0, 100);
   const fillClass =
     normalized === null
@@ -58,6 +57,17 @@ export interface QuotaRenderHelpers {
   QuotaProgressBar: (props: QuotaProgressBarProps) => ReactElement;
 }
 
+const parseIntegerField = (value: unknown, fallback: number): number => {
+  if (typeof value === 'number' && Number.isInteger(value)) return value;
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return fallback;
+    const parsed = Number(trimmed);
+    if (Number.isInteger(parsed)) return parsed;
+  }
+  return fallback;
+};
+
 interface QuotaCardProps<TState extends QuotaStatusState> {
   item: AuthFileItem;
   quota?: TState;
@@ -83,7 +93,7 @@ export function QuotaCard<TState extends QuotaStatusState>({
   canRefresh = false,
   onRefresh,
   resetQuotaAction,
-  renderQuotaItems
+  renderQuotaItems,
 }: QuotaCardProps<TState>) {
   const { t } = useTranslation();
 
@@ -91,6 +101,8 @@ export function QuotaCard<TState extends QuotaStatusState>({
   const typeColorSet = TYPE_COLORS[displayType] || TYPE_COLORS.unknown;
   const typeColor: ThemeColors =
     resolvedTheme === 'dark' && typeColorSet.dark ? typeColorSet.dark : typeColorSet.light;
+  const priority = parseIntegerField(item.priority, 0);
+  const selectionWeight = parseIntegerField(item.selection_weight ?? item['selection-weight'], 1);
 
   const quotaStatus = quota?.status ?? 'idle';
   const quotaLoading = quotaStatus === 'loading';
@@ -99,7 +111,9 @@ export function QuotaCard<TState extends QuotaStatusState>({
     quota?.errorStatus,
     quota?.error || t('common.unknown_error')
   );
-  const idleMessageKey = onRefresh ? `${i18nPrefix}.idle` : (cardIdleMessageKey ?? `${i18nPrefix}.idle`);
+  const idleMessageKey = onRefresh
+    ? `${i18nPrefix}.idle`
+    : (cardIdleMessageKey ?? `${i18nPrefix}.idle`);
 
   const getTypeLabel = (type: string): string => {
     const key = `auth_files.filter_${type}`;
@@ -117,12 +131,20 @@ export function QuotaCard<TState extends QuotaStatusState>({
           style={{
             backgroundColor: typeColor.bg,
             color: typeColor.text,
-            ...(typeColor.border ? { border: typeColor.border } : {})
+            ...(typeColor.border ? { border: typeColor.border } : {}),
           }}
         >
           {getTypeLabel(displayType)}
         </span>
         <span className={styles.fileName}>{item.name}</span>
+      </div>
+      <div className={styles.scheduleMeta}>
+        <span>
+          {t('auth_files.priority_display')}: {priority}
+        </span>
+        <span>
+          {t('auth_files.selection_weight_display')}: {selectionWeight}
+        </span>
       </div>
 
       <div className={styles.quotaSection}>
@@ -144,7 +166,7 @@ export function QuotaCard<TState extends QuotaStatusState>({
         ) : quotaStatus === 'error' ? (
           <div className={styles.quotaError}>
             {t(`${i18nPrefix}.load_failed`, {
-              message: quotaErrorMessage
+              message: quotaErrorMessage,
             })}
           </div>
         ) : quota ? (

--- a/src/features/authFiles/components/AuthFileCard.tsx
+++ b/src/features/authFiles/components/AuthFileCard.tsx
@@ -124,6 +124,8 @@ export function AuthFileCard(props: AuthFileCardProps) {
     Boolean(rawStatusMessage) && !HEALTHY_STATUS_MESSAGES.has(rawStatusMessage.toLowerCase());
 
   const priorityValue = parsePriorityValue(file.priority ?? file['priority']);
+  const selectionWeightRaw = file.selection_weight ?? file['selection-weight'];
+  const selectionWeightValue = parsePriorityValue(selectionWeightRaw);
   const noteValue = typeof file.note === 'string' ? file.note.trim() : '';
   const stateLabel = isRuntimeOnly
     ? t('auth_files.type_virtual') || '虚拟认证文件'
@@ -218,6 +220,14 @@ export function AuthFileCard(props: AuthFileCardProps) {
                 <span className={styles.metaLabel}>{t('auth_files.priority_display')}</span>
                 <span className={`${styles.metaValue} ${styles.priorityValue}`}>
                   {priorityValue}
+                </span>
+              </div>
+            )}
+            {selectionWeightValue !== undefined && selectionWeightValue >= 0 && (
+              <div className={`${styles.metaItem} ${styles.priorityBadge}`}>
+                <span className={styles.metaLabel}>{t('auth_files.selection_weight_display')}</span>
+                <span className={`${styles.metaValue} ${styles.priorityValue}`}>
+                  {selectionWeightValue}
                 </span>
               </div>
             )}

--- a/src/features/authFiles/components/AuthFilesPrefixProxyEditorModal.tsx
+++ b/src/features/authFiles/components/AuthFilesPrefixProxyEditorModal.tsx
@@ -142,6 +142,14 @@ export function AuthFilesPrefixProxyEditorModal(props: AuthFilesPrefixProxyEdito
                     disabled={disableControls || editor.saving || !editor.json}
                     onChange={(e) => onChange('priority', e.target.value)}
                   />
+                  <Input
+                    label={t('auth_files.selection_weight_label')}
+                    value={editor.selectionWeight}
+                    placeholder={t('auth_files.selection_weight_placeholder')}
+                    hint={t('auth_files.selection_weight_hint')}
+                    disabled={disableControls || editor.saving || !editor.json}
+                    onChange={(e) => onChange('selectionWeight', e.target.value)}
+                  />
                   {editor.providerKey === 'codex' && (
                     <div className="form-group">
                       <label>{t('auth_files.codex_websockets_label')}</label>

--- a/src/features/authFiles/hooks/useAuthFilesPrefixProxyEditor.ts
+++ b/src/features/authFiles/hooks/useAuthFilesPrefixProxyEditor.ts
@@ -23,6 +23,7 @@ export type PrefixProxyEditorField =
   | 'prefix'
   | 'proxyUrl'
   | 'priority'
+  | 'selectionWeight'
   | 'websockets'
   | 'note'
   | 'headersText';
@@ -43,6 +44,7 @@ export type PrefixProxyEditorState = {
   prefix: string;
   proxyUrl: string;
   priority: string;
+  selectionWeight: string;
   websockets: boolean;
   websocketsTouched: boolean;
   note: string;
@@ -107,6 +109,11 @@ const parseHeadersText = (
 
 const normalizeTextField = (value: unknown): string =>
   typeof value === 'string' ? value.trim() : '';
+
+const parseSelectionWeightValue = (value: unknown): number | undefined => {
+  const parsed = parsePriorityValue(value);
+  return parsed !== undefined && parsed >= 0 ? parsed : undefined;
+};
 
 const INVALID_CONTENT_PREVIEW_LIMIT = 1000;
 
@@ -248,6 +255,19 @@ const buildAuthFileFieldsPatch = (
     }
   }
 
+  const originalSelectionWeight = parseSelectionWeightValue(
+    original.selection_weight ?? original['selection-weight']
+  );
+  const selectionWeightText = editor.selectionWeight.trim();
+  const nextSelectionWeight = parseSelectionWeightValue(selectionWeightText);
+  if (!selectionWeightText) {
+    if (originalSelectionWeight !== undefined) {
+      patch.selection_weight = null;
+    }
+  } else if (nextSelectionWeight !== undefined && nextSelectionWeight !== originalSelectionWeight) {
+    patch.selection_weight = nextSelectionWeight;
+  }
+
   if (editor.noteTouched) {
     const originalNote = normalizeTextField(original.note);
     const nextNote = editor.note.trim();
@@ -308,6 +328,15 @@ const buildPrefixProxyUpdatedText = (
       delete next.priority;
     } else {
       next.priority = patch.priority;
+    }
+  }
+
+  if (patch.selection_weight !== undefined) {
+    delete next['selection-weight'];
+    if (patch.selection_weight === null) {
+      delete next.selection_weight;
+    } else {
+      next.selection_weight = patch.selection_weight;
     }
   }
 
@@ -380,6 +409,7 @@ export function useAuthFilesPrefixProxyEditor(
       prefix: '',
       proxyUrl: '',
       priority: '',
+      selectionWeight: '',
       websockets: false,
       websocketsTouched: false,
       note: '',
@@ -426,6 +456,9 @@ export function useAuthFilesPrefixProxyEditor(
       const prefix = typeof json.prefix === 'string' ? json.prefix : '';
       const proxyUrl = typeof json.proxy_url === 'string' ? json.proxy_url : '';
       const priority = parsePriorityValue(json.priority);
+      const selectionWeight = parseSelectionWeightValue(
+        json.selection_weight ?? json['selection-weight']
+      );
       const websockets = providerKey === 'codex' ? readCodexAuthFileWebsockets(json) : false;
       const note = typeof json.note === 'string' ? json.note : '';
       const headers = json.headers;
@@ -450,6 +483,7 @@ export function useAuthFilesPrefixProxyEditor(
           prefix,
           proxyUrl,
           priority: priority !== undefined ? String(priority) : '',
+          selectionWeight: selectionWeight !== undefined ? String(selectionWeight) : '',
           websockets,
           websocketsTouched: false,
           note,
@@ -479,6 +513,7 @@ export function useAuthFilesPrefixProxyEditor(
       if (field === 'prefix') return { ...prev, prefix: String(value) };
       if (field === 'proxyUrl') return { ...prev, proxyUrl: String(value) };
       if (field === 'priority') return { ...prev, priority: String(value) };
+      if (field === 'selectionWeight') return { ...prev, selectionWeight: String(value) };
       if (field === 'websockets') {
         return { ...prev, websockets: Boolean(value), websocketsTouched: true };
       }

--- a/src/features/providers/adapters.ts
+++ b/src/features/providers/adapters.ts
@@ -1,14 +1,7 @@
 import type { GeminiKeyConfig, OpenAIProviderConfig, ProviderKeyConfig } from '@/types';
-import {
-  hasDisableAllModelsRule,
-  stripDisableAllModelsRule,
-} from '@/components/providers/utils';
+import { hasDisableAllModelsRule, stripDisableAllModelsRule } from '@/components/providers/utils';
 import { maskApiKey } from '@/utils/format';
-import type {
-  ProviderBrand,
-  ProviderResource,
-  ProviderResourceSelector,
-} from './types';
+import type { ProviderBrand, ProviderResource, ProviderResourceSelector } from './types';
 
 const countHeaders = (headers?: Record<string, string>): number =>
   headers ? Object.keys(headers).length : 0;
@@ -24,6 +17,9 @@ const collectModelNames = (models?: Array<{ name?: string }>): string[] => {
 
 const normalizePriority = (priority?: number): number =>
   typeof priority === 'number' && Number.isFinite(priority) ? priority : 0;
+
+const normalizeSelectionWeight = (weight?: number): number | undefined =>
+  typeof weight === 'number' && Number.isInteger(weight) && weight >= 0 ? weight : undefined;
 
 const buildId = (brand: ProviderBrand, index: number, fragment: string) =>
   `${brand}:${index}:${fragment || 'item'}`;
@@ -73,6 +69,7 @@ function providerKeyToResource(
     modelCount: config.models?.length ?? 0,
     models: collectModelNames(config.models),
     priority: normalizePriority(config.priority),
+    selectionWeight: normalizeSelectionWeight(config.selectionWeight),
     headerCount: countHeaders(config.headers),
     excludedModelCount: stripDisableAllModelsRule(config.excludedModels).length,
     apiKeyEntryCount: 0,
@@ -99,10 +96,7 @@ export function vertexToResource(config: ProviderKeyConfig, index: number): Prov
   return providerKeyToResource('vertex', config, index);
 }
 
-export function openaiToResource(
-  config: OpenAIProviderConfig,
-  index: number
-): ProviderResource {
+export function openaiToResource(config: OpenAIProviderConfig, index: number): ProviderResource {
   const name = (config.name ?? '').trim();
   const firstEntry = config.apiKeyEntries?.[0];
   const previewApiKey = firstEntry?.apiKey ? maskApiKey(firstEntry.apiKey) : null;
@@ -121,6 +115,7 @@ export function openaiToResource(
     modelCount: config.models?.length ?? 0,
     models: collectModelNames(config.models),
     priority: normalizePriority(config.priority),
+    selectionWeight: normalizeSelectionWeight(config.selectionWeight),
     headerCount: countHeaders(config.headers),
     excludedModelCount: 0,
     apiKeyEntryCount: config.apiKeyEntries?.length ?? 0,

--- a/src/features/providers/components/ProviderResourceTable.tsx
+++ b/src/features/providers/components/ProviderResourceTable.tsx
@@ -48,10 +48,7 @@ const resolveStatusBarData = (
   usageByProvider: ProviderRecentUsageMap
 ): StatusBarData => {
   if (resource.brand === 'openaiCompatibility') {
-    return getOpenAIProviderRecentStatusData(
-      resource.raw as OpenAIProviderConfig,
-      usageByProvider
-    );
+    return getOpenAIProviderRecentStatusData(resource.raw as OpenAIProviderConfig, usageByProvider);
   }
   return getProviderRecentStatusData(
     usageByProvider,
@@ -66,10 +63,7 @@ const resolveTotalStats = (
   usageByProvider: ProviderRecentUsageMap
 ): { success: number; failure: number } => {
   if (resource.brand === 'openaiCompatibility') {
-    return getOpenAIProviderTotalStats(
-      resource.raw as OpenAIProviderConfig,
-      usageByProvider
-    );
+    return getOpenAIProviderTotalStats(resource.raw as OpenAIProviderConfig, usageByProvider);
   }
   return getProviderTotalStats(
     usageByProvider,
@@ -106,16 +100,24 @@ export function ProviderResourceTable({
 
   const renderModelsSummary = (r: ProviderResource) => {
     const items: ReactNode[] = [];
+    const selectionWeight =
+      r.selectionWeight !== undefined
+        ? renderMetric(
+            'selection-weight',
+            t('providersPage.table.metrics.selectionWeight'),
+            r.selectionWeight
+          )
+        : null;
     if (r.brand === 'openaiCompatibility') {
       items.push(
         renderMetric('models', t('providersPage.table.metrics.models'), r.modelCount),
         renderMetric('keys', t('providersPage.table.metrics.keys'), r.apiKeyEntryCount),
-        renderMetric('headers', t('providersPage.table.metrics.headers'), r.headerCount),
+        renderMetric('headers', t('providersPage.table.metrics.headers'), r.headerCount)
       );
     } else {
       items.push(
         renderMetric('models', t('providersPage.table.metrics.models'), r.modelCount),
-        renderMetric('headers', t('providersPage.table.metrics.headers'), r.headerCount),
+        renderMetric('headers', t('providersPage.table.metrics.headers'), r.headerCount)
       );
       if (r.brand === 'codex' && r.flags.websockets) {
         items.push(renderFlagTag('ws', t('providersPage.table.websocketsTag')));
@@ -123,6 +125,9 @@ export function ProviderResourceTable({
       if (r.brand === 'claude' && r.flags.cloakEnabled) {
         items.push(renderFlagTag('cloak', t('providersPage.table.cloakTag')));
       }
+    }
+    if (selectionWeight) {
+      items.push(selectionWeight);
     }
     return <div className={styles.metricsCell}>{items}</div>;
   };
@@ -150,18 +155,14 @@ export function ProviderResourceTable({
       return (
         <div className={styles.primaryCell}>
           <span className={styles.primaryName}>{r.name ?? r.identifier}</span>
-          <span className={styles.primarySub}>
-            {(r.apiKeyPreview ?? '—') + extra}
-          </span>
+          <span className={styles.primarySub}>{(r.apiKeyPreview ?? '—') + extra}</span>
         </div>
       );
     }
     return (
       <div className={styles.primaryCell}>
         <span className={styles.primaryName}>{r.apiKeyPreview ?? '—'}</span>
-        {r.authIndex ? (
-          <span className={styles.primarySub}>auth: {r.authIndex}</span>
-        ) : null}
+        {r.authIndex ? <span className={styles.primarySub}>auth: {r.authIndex}</span> : null}
       </div>
     );
   };
@@ -174,11 +175,7 @@ export function ProviderResourceTable({
         </span>
       );
     }
-    return (
-      <span className={styles.baseUrl}>
-        {r.baseUrl ?? t('providersPage.status.notSet')}
-      </span>
-    );
+    return <span className={styles.baseUrl}>{r.baseUrl ?? t('providersPage.status.notSet')}</span>;
   };
 
   return (
@@ -240,16 +237,11 @@ export function ProviderResourceTable({
               <TableCell alignRight>
                 <div className={styles.actions}>
                   {onToggleDisabled ? (
-                    <span
-                      className={styles.toggleWrap}
-                      onClick={(e) => e.stopPropagation()}
-                    >
+                    <span className={styles.toggleWrap} onClick={(e) => e.stopPropagation()}>
                       <ToggleSwitch
                         checked={!resource.disabled}
                         disabled={disableMutations}
-                        onChange={(value) =>
-                          onToggleDisabled(resource, !value)
-                        }
+                        onChange={(value) => onToggleDisabled(resource, !value)}
                         ariaLabel={
                           resource.disabled
                             ? t('providersPage.actions.enable')

--- a/src/features/providers/sheets/ResourceDetailView.tsx
+++ b/src/features/providers/sheets/ResourceDetailView.tsx
@@ -1,10 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { Collapsible } from '@/components/ui/Collapsible';
 import { IconCheck, IconX } from '@/components/ui/icons';
-import {
-  getProviderTotalStats,
-  type ProviderRecentUsageMap,
-} from '@/components/providers/utils';
+import { getProviderTotalStats, type ProviderRecentUsageMap } from '@/components/providers/utils';
 import type { OpenAIProviderConfig } from '@/types';
 import { maskApiKey } from '@/utils/format';
 import type { ProviderResource } from '../types';
@@ -23,6 +20,12 @@ export function ResourceDetailView({ resource, usageByProvider }: ResourceDetail
     ['baseUrl', resource.baseUrl ?? t('providersPage.status.notSet')],
     ['proxyUrl', resource.proxyUrl ?? t('providersPage.status.notSet')],
     ['prefix', resource.prefix ?? t('providersPage.status.none')],
+    [
+      'selectionWeight',
+      resource.selectionWeight !== undefined
+        ? String(resource.selectionWeight)
+        : t('providersPage.status.defaultSuffix'),
+    ],
     ['models', String(resource.modelCount)],
     ['headers', String(resource.headerCount)],
   ];
@@ -34,17 +37,13 @@ export function ResourceDetailView({ resource, usageByProvider }: ResourceDetail
   ];
 
   const openaiConfig =
-    resource.brand === 'openaiCompatibility'
-      ? (resource.raw as OpenAIProviderConfig)
-      : null;
+    resource.brand === 'openaiCompatibility' ? (resource.raw as OpenAIProviderConfig) : null;
   const apiKeyEntries = openaiConfig?.apiKeyEntries ?? [];
 
   return (
     <div>
       <div className={styles.detailHeader}>
-        <div className={styles.sectionTitle}>
-          {resource.name ?? resource.identifier}
-        </div>
+        <div className={styles.sectionTitle}>{resource.name ?? resource.identifier}</div>
       </div>
 
       <dl className={styles.dl}>
@@ -72,24 +71,22 @@ export function ResourceDetailView({ resource, usageByProvider }: ResourceDetail
                   )
                 : { success: 0, failure: 0 };
               return (
-                <div
-                  key={`${entry.apiKey}-${entryIndex}`}
-                  className={styles.apiKeyEntryCard}
-                >
+                <div key={`${entry.apiKey}-${entryIndex}`} className={styles.apiKeyEntryCard}>
                   <span className={styles.apiKeyEntryIndex}>{entryIndex + 1}</span>
                   <span className={styles.apiKeyEntryKey}>{maskApiKey(entry.apiKey)}</span>
                   {entry.proxyUrl ? (
                     <span className={styles.apiKeyEntryProxy}>{entry.proxyUrl}</span>
                   ) : null}
+                  {entry.selectionWeight !== undefined ? (
+                    <span className={styles.apiKeyEntryProxy}>
+                      {t('providersPage.form.selectionWeight')}: {entry.selectionWeight}
+                    </span>
+                  ) : null}
                   <div className={styles.apiKeyEntryStats}>
-                    <span
-                      className={`${styles.apiKeyEntryStat} ${styles.apiKeyEntryStatSuccess}`}
-                    >
+                    <span className={`${styles.apiKeyEntryStat} ${styles.apiKeyEntryStatSuccess}`}>
                       <IconCheck size={12} /> {entryStats.success}
                     </span>
-                    <span
-                      className={`${styles.apiKeyEntryStat} ${styles.apiKeyEntryStatFailure}`}
-                    >
+                    <span className={`${styles.apiKeyEntryStat} ${styles.apiKeyEntryStatFailure}`}>
                       <IconX size={12} /> {entryStats.failure}
                     </span>
                   </div>

--- a/src/features/providers/sheets/forms/BaseProviderForm.tsx
+++ b/src/features/providers/sheets/forms/BaseProviderForm.tsx
@@ -53,6 +53,9 @@ const emptyApiKeyEntry = (): ApiKeyEntryInput => ({
   proxyUrl: '',
 });
 
+const selectionWeightValid = (value: number | undefined): boolean =>
+  value === undefined || (Number.isInteger(value) && value >= 0);
+
 const stripDisableAllRule = (list?: string[]): string[] =>
   (list ?? []).filter((s) => s.trim() !== '*');
 
@@ -76,6 +79,7 @@ function buildInitialForm(
       disabled: false,
       disableCooling: false,
       priority: undefined,
+      selectionWeight: undefined,
       models: [emptyModel()],
       headers: [emptyHeader()],
       excludedModelsText: '',
@@ -108,6 +112,7 @@ function buildInitialForm(
       disabled: cfg.disabled === true,
       disableCooling: cfg.disableCooling === true,
       priority: cfg.priority,
+      selectionWeight: cfg.selectionWeight,
       models: cfg.models?.length
         ? cfg.models.map((m) => ({
             name: m.name,
@@ -128,6 +133,7 @@ function buildInitialForm(
             apiKey: '',
             existingApiKey: entry.apiKey,
             proxyUrl: entry.proxyUrl ?? '',
+            selectionWeight: entry.selectionWeight,
             authIndex: entry.authIndex,
           }))
         : [emptyApiKeyEntry()],
@@ -150,6 +156,7 @@ function buildInitialForm(
     disabled,
     disableCooling: cfg.disableCooling === true,
     priority: cfg.priority,
+    selectionWeight: cfg.selectionWeight,
     models: cfg.models?.length
       ? cfg.models.map((m) => ({
           name: m.name,
@@ -173,9 +180,7 @@ function buildInitialForm(
           }
         : undefined,
     experimentalCchSigning:
-      brand === 'claude'
-        ? (cfg as ProviderKeyConfig).experimentalCchSigning === true
-        : undefined,
+      brand === 'claude' ? (cfg as ProviderKeyConfig).experimentalCchSigning === true : undefined,
     testModel: brand === 'codex' || brand === 'claude' || brand === 'gemini' ? '' : undefined,
   };
 }
@@ -410,6 +415,12 @@ export function BaseProviderForm({
     if (descriptor.baseUrlRequired && !form.baseUrl.trim()) {
       return t('providersPage.form.validation.baseUrlRequired');
     }
+    if (!selectionWeightValid(form.selectionWeight)) {
+      return t('providersPage.form.validation.selectionWeightInvalid');
+    }
+    if (form.apiKeyEntries?.some((entry) => !selectionWeightValid(entry.selectionWeight))) {
+      return t('providersPage.form.validation.selectionWeightInvalid');
+    }
     return null;
   };
 
@@ -454,10 +465,10 @@ export function BaseProviderForm({
     brand === 'codex'
       ? { status: connectivity.codexStatus, run: connectivity.runCodex }
       : brand === 'gemini'
-      ? { status: connectivity.geminiStatus, run: connectivity.runGemini }
-      : brand === 'claude'
-        ? { status: connectivity.claudeStatus, run: connectivity.runClaude }
-        : null;
+        ? { status: connectivity.geminiStatus, run: connectivity.runGemini }
+        : brand === 'claude'
+          ? { status: connectivity.claudeStatus, run: connectivity.runClaude }
+          : null;
 
   const removeApiKeyEntry = (removeIdx: number) => {
     setShowPasswords((prev) => {
@@ -628,6 +639,33 @@ export function BaseProviderForm({
                 />
               </div>
             ) : null}
+          </div>
+        ) : null}
+
+        {descriptor.supportsPriority ? (
+          <div className={styles.field}>
+            <label className={styles.label} htmlFor={`${fid}-selection-weight`}>
+              {t('providersPage.form.selectionWeight')}
+              <span className={styles.labelHint}>
+                {' '}
+                · {t('providersPage.form.selectionWeightHint')}
+              </span>
+            </label>
+            <input
+              id={`${fid}-selection-weight`}
+              type="number"
+              min={0}
+              step={1}
+              className={styles.input}
+              value={form.selectionWeight ?? ''}
+              onChange={(e) =>
+                updateField(
+                  'selectionWeight',
+                  e.target.value === '' ? undefined : Number(e.target.value)
+                )
+              }
+              disabled={mutating}
+            />
           </div>
         ) : null}
 
@@ -865,6 +903,33 @@ export function BaseProviderForm({
                       }
                       disabled={mutating}
                       placeholder="http://127.0.0.1:7890"
+                    />
+                  </div>
+                  <div className={styles.field}>
+                    <label className={styles.label}>
+                      {t('providersPage.form.selectionWeight')}
+                    </label>
+                    <input
+                      className={styles.input}
+                      type="number"
+                      min={0}
+                      step={1}
+                      value={entry.selectionWeight ?? ''}
+                      onChange={(e) =>
+                        updateField(
+                          'apiKeyEntries',
+                          apiKeyEntries.map((it, i) =>
+                            i === realIdx
+                              ? {
+                                  ...it,
+                                  selectionWeight:
+                                    e.target.value === '' ? undefined : Number(e.target.value),
+                                }
+                              : it
+                          )
+                        )
+                      }
+                      disabled={mutating}
                     />
                   </div>
                   {status.state === 'error' ? (

--- a/src/features/providers/types.ts
+++ b/src/features/providers/types.ts
@@ -2,12 +2,7 @@
  * AI 提供商 Workbench 视图模型(归一化各 brand 的异构 config)
  */
 
-export type ProviderBrand =
-  | 'gemini'
-  | 'codex'
-  | 'claude'
-  | 'vertex'
-  | 'openaiCompatibility';
+export type ProviderBrand = 'gemini' | 'codex' | 'claude' | 'vertex' | 'openaiCompatibility';
 
 export const PROVIDER_SORT_BY_VALUES = ['name', 'priority', 'recent-success'] as const;
 export type ProviderSortBy = (typeof PROVIDER_SORT_BY_VALUES)[number];
@@ -51,6 +46,8 @@ export interface ProviderResource {
   models: string[];
   /** 排序用优先级,未配置时为 0 */
   priority: number;
+  /** weighted-round-robin 选择权重,未配置时后端按 1 处理 */
+  selectionWeight?: number;
   headerCount: number;
   excludedModelCount: number;
   /** 仅 OpenAI 有意义,其它 brand 该字段不展示但保留 */
@@ -92,6 +89,7 @@ export interface ApiKeyEntryInput {
   apiKey: string;
   existingApiKey?: string;
   proxyUrl: string;
+  selectionWeight?: number;
   authIndex?: string;
 }
 
@@ -113,6 +111,7 @@ export interface ProviderEntryFormInput {
   disabled: boolean;
   disableCooling?: boolean;
   priority?: number;
+  selectionWeight?: number;
 
   /** 高级折叠区 */
   models: ModelEntryInput[];

--- a/src/features/providers/useProviderWorkbench.ts
+++ b/src/features/providers/useProviderWorkbench.ts
@@ -6,11 +6,7 @@ import {
   withDisableAllModelsRule,
   withoutDisableAllModelsRule,
 } from '@/components/providers/utils';
-import type {
-  GeminiKeyConfig,
-  OpenAIProviderConfig,
-  ProviderKeyConfig,
-} from '@/types';
+import type { GeminiKeyConfig, OpenAIProviderConfig, ProviderKeyConfig } from '@/types';
 import {
   claudeToResource,
   codexToResource,
@@ -111,6 +107,7 @@ const buildProviderKeyConfig = (
   const next: ProviderKeyConfig = {
     apiKey: apiKeyChanged ? input.apiKey.trim() : (existing?.apiKey ?? ''),
     priority: input.priority,
+    selectionWeight: input.selectionWeight,
     prefix: input.prefix.trim() || undefined,
     baseUrl: input.baseUrl.trim() || undefined,
     proxyUrl: input.proxyUrl.trim() || undefined,
@@ -160,6 +157,7 @@ const buildOpenAIConfig = (
         return {
           apiKey: entry.apiKey.trim() || fallbackApiKey,
           proxyUrl: entry.proxyUrl.trim() || undefined,
+          selectionWeight: entry.selectionWeight,
           authIndex: entry.authIndex?.trim() || undefined,
         };
       })
@@ -176,6 +174,7 @@ const buildOpenAIConfig = (
     headers: Object.keys(headers).length ? headers : undefined,
     models: models.length ? models : undefined,
     priority: input.priority,
+    selectionWeight: input.selectionWeight,
     testModel: input.testModel?.trim() || undefined,
   };
 };

--- a/src/hooks/useVisualConfig.ts
+++ b/src/hooks/useVisualConfig.ts
@@ -1037,7 +1037,12 @@ export function useVisualConfig() {
         quotaSwitchPreviewModel: Boolean(quotaExceeded?.['switch-preview-model'] ?? true),
         quotaAntigravityCredits: Boolean(quotaExceeded?.['antigravity-credits'] ?? false),
 
-        routingStrategy: routing?.strategy === 'fill-first' ? 'fill-first' : 'round-robin',
+        routingStrategy:
+          routing?.strategy === 'fill-first'
+            ? 'fill-first'
+            : routing?.strategy === 'weighted-round-robin'
+              ? 'weighted-round-robin'
+              : 'round-robin',
         routingSessionAffinity: Boolean(
           routing?.['session-affinity'] ?? routing?.sessionAffinity ?? routing?.['sessionAffinity']
         ),

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -194,10 +194,11 @@
     "ws_auth_enable": "Require auth for /ws/*",
     "routing_title": "Routing Strategy",
     "routing_strategy_label": "Routing strategy:",
-    "routing_strategy_hint": "round-robin cycles through keys; fill-first prioritizes the first available key.",
+    "routing_strategy_hint": "round-robin cycles through keys; fill-first prioritizes the first available key; weighted-round-robin distributes by selection weight.",
     "routing_strategy_update": "Update",
     "routing_strategy_round_robin": "round-robin (cycle)",
-    "routing_strategy_fill_first": "fill-first (prioritize)"
+    "routing_strategy_fill_first": "fill-first (prioritize)",
+    "routing_strategy_weighted_round_robin": "weighted-round-robin (weighted)"
   },
   "api_keys": {
     "title": "API Keys Management",
@@ -279,6 +280,7 @@
     "sort_az": "A-Z Name",
     "sort_priority": "Priority",
     "priority_display": "Priority",
+    "selection_weight_display": "Selection weight",
     "page_size_label": "Per page",
     "page_size_unit": "items",
     "view_mode_paged": "Paged",
@@ -350,6 +352,9 @@
     "priority_label": "Priority (priority)",
     "priority_placeholder": "e.g. 10 or -1",
     "priority_hint": "Integers only. Invalid values are ignored. Larger value means higher priority.",
+    "selection_weight_label": "Selection weight (selection_weight)",
+    "selection_weight_placeholder": "e.g. 2",
+    "selection_weight_hint": "Non-negative integers only. Leave empty to use the default weight 1.",
     "codex_websockets_label": "WebSockets (websockets)",
     "codex_websockets_hint": "Enable Responses API websocket transport for this Codex credential.",
     "excluded_models_label": "Excluded models (excluded_models)",
@@ -972,7 +977,7 @@
           "stabilize_device_desc": "Pin OS/Arch and stabilize the software fingerprint per credential/API key",
           "beta_features": "Beta Features",
           "codex_identity_confuse": "Codex Identity Confuse",
-          "codex_identity_confuse_desc": "When fill-first routing or session affinity is used, remap Codex prompt_cache_key and installation identity for the selected auth"
+          "codex_identity_confuse_desc": "When fill-first routing, weighted-round-robin, or session affinity is used, remap Codex prompt_cache_key and installation identity for the selected auth"
         },
         "network": {
           "title": "Network Configuration",
@@ -995,6 +1000,7 @@
           "routing_strategy_hint": "Select credential selection strategy",
           "strategy_round_robin": "Round Robin",
           "strategy_fill_first": "Fill First",
+          "strategy_weighted_round_robin": "Weighted Round Robin",
           "session_affinity_ttl": "Session Affinity TTL",
           "force_model_prefix": "Force Model Prefix",
           "force_model_prefix_desc": "Unprefixed model requests only use credentials without prefix",
@@ -1448,7 +1454,8 @@
       "metrics": {
         "models": "Models",
         "keys": "Keys",
-        "headers": "Headers"
+        "headers": "Headers",
+        "selectionWeight": "Weight"
       },
       "websocketsTag": "WebSockets",
       "cloakTag": "Cloak",
@@ -1477,7 +1484,8 @@
         "headers": "Headers",
         "authIndex": "Auth Index",
         "excludedModels": "Excluded models",
-        "apiKeyEntries": "API key entries"
+        "apiKeyEntries": "API key entries",
+        "selectionWeight": "Selection weight"
       }
     },
     "form": {
@@ -1492,6 +1500,8 @@
       "proxyUrl": "Proxy URL",
       "prefix": "Prefix",
       "priority": "Priority",
+      "selectionWeight": "Selection weight",
+      "selectionWeightHint": "Used by weighted round-robin; leave empty for the default weight 1.",
       "disabled": "Disable this entry",
       "disabledHint": "Disabled entries won't be used by the gateway",
       "websockets": "Enable WebSockets",
@@ -1531,7 +1541,8 @@
       "validation": {
         "nameRequired": "Name is required",
         "apiKeyRequired": "At least one API key is required",
-        "baseUrlRequired": "Base URL is required"
+        "baseUrlRequired": "Base URL is required",
+        "selectionWeightInvalid": "Selection weight must be a non-negative integer"
       }
     },
     "delete": {

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -193,10 +193,11 @@
     "ws_auth_enable": "Требовать аутентификацию для /ws/*",
     "routing_title": "Стратегия маршрутизации",
     "routing_strategy_label": "Стратегия маршрутизации:",
-    "routing_strategy_hint": "round-robin циклически перебирает ключи; fill-first отдаёт приоритет первому доступному ключу.",
+    "routing_strategy_hint": "round-robin циклически перебирает ключи; fill-first отдаёт приоритет первому доступному ключу; weighted-round-robin распределяет по весу выбора.",
     "routing_strategy_update": "Обновить",
     "routing_strategy_round_robin": "round-robin (цикл)",
-    "routing_strategy_fill_first": "fill-first (приоритет)"
+    "routing_strategy_fill_first": "fill-first (приоритет)",
+    "routing_strategy_weighted_round_robin": "weighted-round-robin (по весу)"
   },
   "api_keys": {
     "title": "Управление API-ключами",
@@ -278,6 +279,7 @@
     "sort_az": "A-Z Имя",
     "sort_priority": "Приоритет",
     "priority_display": "Приоритет",
+    "selection_weight_display": "Вес выбора",
     "page_size_label": "На странице",
     "page_size_unit": "элементов",
     "view_mode_paged": "Постранично",
@@ -349,6 +351,9 @@
     "priority_label": "Приоритет (priority)",
     "priority_placeholder": "например: 10 или -1",
     "priority_hint": "Только целые числа. Некорректные значения игнорируются. Чем больше число, тем выше приоритет.",
+    "selection_weight_label": "Вес выбора (selection_weight)",
+    "selection_weight_placeholder": "например: 2",
+    "selection_weight_hint": "Только неотрицательные целые числа. Оставьте пустым для веса по умолчанию 1.",
     "codex_websockets_label": "WebSockets (websockets)",
     "codex_websockets_hint": "Включает websocket-транспорт Responses API для этих учётных данных Codex.",
     "excluded_models_label": "Исключённые модели (excluded_models)",
@@ -959,7 +964,7 @@
           "stabilize_device_desc": "Фиксировать OS/Arch и стабилизировать программный отпечаток для учётных данных/API-ключа",
           "beta_features": "Beta Features",
           "codex_identity_confuse": "Codex identity-confuse",
-          "codex_identity_confuse_desc": "При fill-first routing или session affinity переопределяет Codex prompt_cache_key и installation identity под выбранную auth-запись"
+          "codex_identity_confuse_desc": "При fill-first routing, weighted-round-robin или session affinity переопределяет Codex prompt_cache_key и installation identity под выбранную auth-запись"
         },
         "network": {
           "title": "Сетевые настройки",
@@ -982,6 +987,7 @@
           "routing_strategy_hint": "Выберите стратегию подбора учётных данных",
           "strategy_round_robin": "По кругу",
           "strategy_fill_first": "Сначала заполнить",
+          "strategy_weighted_round_robin": "По весу",
           "session_affinity_ttl": "TTL привязки сессии",
           "force_model_prefix": "Принудительный префикс модели",
           "force_model_prefix_desc": "Запросы к моделям без префикса используют только учётные данные без префикса",
@@ -1425,7 +1431,8 @@
       "metrics": {
         "models": "Модели",
         "keys": "Ключи",
-        "headers": "Заголовки"
+        "headers": "Заголовки",
+        "selectionWeight": "Вес"
       },
       "websocketsTag": "WebSockets",
       "cloakTag": "Cloak",
@@ -1454,7 +1461,8 @@
         "headers": "Заголовков",
         "authIndex": "Auth Index",
         "excludedModels": "Исключённых моделей",
-        "apiKeyEntries": "API-ключей"
+        "apiKeyEntries": "API-ключей",
+        "selectionWeight": "Вес выбора"
       }
     },
     "form": {
@@ -1469,6 +1477,8 @@
       "proxyUrl": "Proxy URL",
       "prefix": "Префикс",
       "priority": "Приоритет",
+      "selectionWeight": "Вес выбора",
+      "selectionWeightHint": "Используется weighted round-robin; оставьте пустым для веса по умолчанию 1.",
       "disabled": "Отключить эту запись",
       "disabledHint": "Отключённые записи не используются шлюзом",
       "websockets": "Включить WebSockets",
@@ -1508,7 +1518,8 @@
       "validation": {
         "nameRequired": "Название обязательно",
         "apiKeyRequired": "Нужен хотя бы один API-ключ",
-        "baseUrlRequired": "Base URL обязателен"
+        "baseUrlRequired": "Base URL обязателен",
+        "selectionWeightInvalid": "Вес выбора должен быть неотрицательным целым числом"
       }
     },
     "delete": {

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -194,10 +194,11 @@
     "ws_auth_enable": "启用 /ws/* 鉴权",
     "routing_title": "路由策略",
     "routing_strategy_label": "路由策略:",
-    "routing_strategy_hint": "round-robin 为轮询，fill-first 为优先填充。",
+    "routing_strategy_hint": "round-robin 为轮询，fill-first 为优先填充，weighted-round-robin 按选择权重分配。",
     "routing_strategy_update": "更新",
     "routing_strategy_round_robin": "round-robin (轮询)",
-    "routing_strategy_fill_first": "fill-first (优先填充)"
+    "routing_strategy_fill_first": "fill-first (优先填充)",
+    "routing_strategy_weighted_round_robin": "weighted-round-robin (加权轮询)"
   },
   "api_keys": {
     "title": "API 密钥管理",
@@ -279,6 +280,7 @@
     "sort_az": "A-Z 名称",
     "sort_priority": "优先级",
     "priority_display": "优先级",
+    "selection_weight_display": "选择权重",
     "page_size_label": "单页数量",
     "page_size_unit": "个/页",
     "view_mode_paged": "按页显示",
@@ -350,6 +352,9 @@
     "priority_label": "优先级（priority）",
     "priority_placeholder": "例如: 10 或 -1",
     "priority_hint": "仅支持整数；非法值会被忽略。数值越大优先级越高。",
+    "selection_weight_label": "选择权重（selection_weight）",
+    "selection_weight_placeholder": "例如: 2",
+    "selection_weight_hint": "仅支持非负整数；留空按默认权重 1 处理。",
     "codex_websockets_label": "WebSockets（websockets）",
     "codex_websockets_hint": "为该 Codex 凭证开启 Responses API 的 websocket 传输。",
     "excluded_models_label": "排除模型（excluded_models）",
@@ -972,7 +977,7 @@
           "stabilize_device_desc": "固定 OS/Arch，并按凭据/API Key 稳定软件指纹",
           "beta_features": "Beta Features",
           "codex_identity_confuse": "Codex 身份混淆",
-          "codex_identity_confuse_desc": "在 fill-first 或会话粘性路由下，按所选认证重映射 Codex prompt_cache_key 与安装身份"
+          "codex_identity_confuse_desc": "在 fill-first、weighted-round-robin 或会话粘性路由下，按所选认证重映射 Codex prompt_cache_key 与安装身份"
         },
         "network": {
           "title": "网络配置",
@@ -995,6 +1000,7 @@
           "routing_strategy_hint": "选择凭据选择策略",
           "strategy_round_robin": "轮询 (Round Robin)",
           "strategy_fill_first": "填充优先 (Fill First)",
+          "strategy_weighted_round_robin": "加权轮询 (Weighted Round Robin)",
           "session_affinity_ttl": "会话粘性 TTL",
           "force_model_prefix": "强制模型前缀",
           "force_model_prefix_desc": "未带前缀的模型请求只使用无前缀凭据",
@@ -1448,7 +1454,8 @@
       "metrics": {
         "models": "模型",
         "keys": "密钥",
-        "headers": "请求头"
+        "headers": "请求头",
+        "selectionWeight": "权重"
       },
       "websocketsTag": "WebSockets",
       "cloakTag": "Cloak",
@@ -1477,7 +1484,8 @@
         "headers": "请求头数",
         "authIndex": "Auth Index",
         "excludedModels": "排除模型数",
-        "apiKeyEntries": "密钥条目数"
+        "apiKeyEntries": "密钥条目数",
+        "selectionWeight": "选择权重"
       }
     },
     "form": {
@@ -1492,6 +1500,8 @@
       "proxyUrl": "代理 URL",
       "prefix": "前缀",
       "priority": "优先级",
+      "selectionWeight": "选择权重",
+      "selectionWeightHint": "用于 weighted round-robin；留空按默认权重 1 处理。",
       "disabled": "停用此条目",
       "disabledHint": "停用后不会被网关使用",
       "websockets": "启用 WebSockets",
@@ -1531,7 +1541,8 @@
       "validation": {
         "nameRequired": "名称必填",
         "apiKeyRequired": "至少填写一个 API 密钥",
-        "baseUrlRequired": "服务地址必填"
+        "baseUrlRequired": "服务地址必填",
+        "selectionWeightInvalid": "选择权重必须是非负整数"
       }
     },
     "delete": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -194,10 +194,11 @@
     "ws_auth_enable": "啟用 /ws/* 驗證",
     "routing_title": "路由策略",
     "routing_strategy_label": "路由策略:",
-    "routing_strategy_hint": "round-robin 為輪詢，fill-first 為優先填充。",
+    "routing_strategy_hint": "round-robin 為輪詢，fill-first 為優先填充，weighted-round-robin 按選擇權重分配。",
     "routing_strategy_update": "更新",
     "routing_strategy_round_robin": "round-robin（輪詢）",
-    "routing_strategy_fill_first": "fill-first（優先填充）"
+    "routing_strategy_fill_first": "fill-first（優先填充）",
+    "routing_strategy_weighted_round_robin": "weighted-round-robin（加權輪詢）"
   },
   "api_keys": {
     "title": "API 金鑰管理",
@@ -279,6 +280,7 @@
     "sort_az": "A-Z 名稱",
     "sort_priority": "優先順序",
     "priority_display": "優先順序",
+    "selection_weight_display": "選擇權重",
     "page_size_label": "單頁數量",
     "page_size_unit": "個/頁",
     "view_mode_paged": "分頁顯示",
@@ -350,6 +352,9 @@
     "priority_label": "優先順序（priority）",
     "priority_placeholder": "例如: 10 或 -1",
     "priority_hint": "僅支援整數；無效值會被忽略。數值越大優先順序越高。",
+    "selection_weight_label": "選擇權重（selection_weight）",
+    "selection_weight_placeholder": "例如: 2",
+    "selection_weight_hint": "僅支援非負整數；留空按預設權重 1 處理。",
     "codex_websockets_label": "WebSockets（websockets）",
     "codex_websockets_hint": "為該 Codex 憑證開啟 Responses API 的 websocket 傳輸。",
     "excluded_models_label": "排除模型（excluded_models）",
@@ -998,7 +1003,7 @@
           "stabilize_device_desc": "固定 OS/Arch，並按憑證/API Key 穩定軟體指紋",
           "beta_features": "Beta Features",
           "codex_identity_confuse": "Codex 身分混淆",
-          "codex_identity_confuse_desc": "在 fill-first 或會話黏性路由下，按所選驗證重映射 Codex prompt_cache_key 與安裝身分"
+          "codex_identity_confuse_desc": "在 fill-first、weighted-round-robin 或會話黏性路由下，按所選驗證重映射 Codex prompt_cache_key 與安裝身分"
         },
         "network": {
           "title": "網路設定",
@@ -1021,6 +1026,7 @@
           "routing_strategy_hint": "選擇憑證選擇策略",
           "strategy_round_robin": "輪詢（Round Robin）",
           "strategy_fill_first": "填充優先（Fill First）",
+          "strategy_weighted_round_robin": "加權輪詢（Weighted Round Robin）",
           "session_affinity_ttl": "會話黏性 TTL",
           "force_model_prefix": "強制模型前綴",
           "force_model_prefix_desc": "未帶前綴的模型請求只使用無前綴憑證",
@@ -1474,7 +1480,8 @@
       "metrics": {
         "models": "模型",
         "keys": "金鑰",
-        "headers": "請求標頭"
+        "headers": "請求標頭",
+        "selectionWeight": "權重"
       },
       "websocketsTag": "WebSockets",
       "cloakTag": "Cloak",
@@ -1503,7 +1510,8 @@
         "headers": "請求標頭數",
         "authIndex": "Auth Index",
         "excludedModels": "排除模型數",
-        "apiKeyEntries": "金鑰條目數"
+        "apiKeyEntries": "金鑰條目數",
+        "selectionWeight": "選擇權重"
       }
     },
     "form": {
@@ -1518,6 +1526,8 @@
       "proxyUrl": "代理 URL",
       "prefix": "前綴",
       "priority": "優先級",
+      "selectionWeight": "選擇權重",
+      "selectionWeightHint": "用於 weighted round-robin；留空按預設權重 1 處理。",
       "disabled": "停用此條目",
       "disabledHint": "停用後不會被閘道使用",
       "websockets": "啟用 WebSockets",
@@ -1557,7 +1567,8 @@
       "validation": {
         "nameRequired": "名稱必填",
         "apiKeyRequired": "至少填寫一個 API 金鑰",
-        "baseUrlRequired": "服務位址必填"
+        "baseUrlRequired": "服務位址必填",
+        "selectionWeightInvalid": "選擇權重必須是非負整數"
       }
     },
     "delete": {

--- a/src/pages/DashboardPage.module.scss
+++ b/src/pages/DashboardPage.module.scss
@@ -499,6 +499,12 @@
   background: rgba($success-color, 0.12);
 }
 
+.configBadgeWeightedRoundRobin {
+  color: $warning-color;
+  border-color: rgba($warning-color, 0.32);
+  background: rgba($warning-color, 0.12);
+}
+
 .configBadgeUnknown {
   color: var(--text-secondary);
   background: var(--bg-primary);

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -165,14 +165,18 @@ export function DashboardPage() {
       ? t('basic_settings.routing_strategy_round_robin')
       : routingStrategyRaw === 'fill-first'
         ? t('basic_settings.routing_strategy_fill_first')
-        : routingStrategyRaw;
+        : routingStrategyRaw === 'weighted-round-robin'
+          ? t('basic_settings.routing_strategy_weighted_round_robin')
+          : routingStrategyRaw;
   const routingStrategyBadgeClass = !routingStrategyRaw
     ? styles.configBadgeUnknown
     : routingStrategyRaw === 'round-robin'
       ? styles.configBadgeRoundRobin
       : routingStrategyRaw === 'fill-first'
         ? styles.configBadgeFillFirst
-        : styles.configBadgeUnknown;
+        : routingStrategyRaw === 'weighted-round-robin'
+          ? styles.configBadgeWeightedRoundRobin
+          : styles.configBadgeUnknown;
 
   // Derived time-based values
   const greetingKey = `dashboard.greeting_${timeOfDay}`;

--- a/src/pages/QuotaPage.module.scss
+++ b/src/pages/QuotaPage.module.scss
@@ -734,6 +734,26 @@
   line-height: 1.4;
 }
 
+.scheduleMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+
+  span {
+    display: inline-flex;
+    align-items: center;
+    min-height: 22px;
+    padding: 2px 8px;
+    border: 1px solid color-mix(in srgb, var(--border-color) 75%, transparent);
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--bg-secondary) 78%, transparent);
+    color: var(--text-secondary);
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1.2;
+  }
+}
+
 .pagination {
   display: flex;
   justify-content: center;

--- a/src/services/api/authFiles.ts
+++ b/src/services/api/authFiles.ts
@@ -16,6 +16,7 @@ export type AuthFileFieldsPatch = {
   proxy_url?: string;
   headers?: Record<string, string>;
   priority?: number;
+  selection_weight?: number | null;
   websockets?: boolean;
   note?: string;
 };

--- a/src/services/api/providers.ts
+++ b/src/services/api/providers.ts
@@ -25,6 +25,7 @@ const RESPONSE_ONLY_FIELDS = ['auth-index'] as const;
 const PROVIDER_COMMON_KEY_FIELDS = [
   'api-key',
   'priority',
+  'selection-weight',
   'prefix',
   'base-url',
   'proxy-url',
@@ -55,6 +56,7 @@ const VERTEX_KEY_FIELDS = [
 const OPENAI_PROVIDER_FIELDS = [
   'name',
   'priority',
+  'selection-weight',
   'disabled',
   'prefix',
   'base-url',
@@ -68,7 +70,7 @@ const OPENAI_PROVIDER_FIELDS = [
 const MODEL_ALIAS_FIELDS = ['name', 'alias', 'priority', 'test-model'] as const;
 const OPENAI_MODEL_ALIAS_FIELDS = [...MODEL_ALIAS_FIELDS, 'image', 'thinking'] as const;
 
-const API_KEY_ENTRY_FIELDS = ['api-key', 'proxy-url'] as const;
+const API_KEY_ENTRY_FIELDS = ['api-key', 'selection-weight', 'proxy-url'] as const;
 
 const CLOAK_FIELDS = ['mode', 'strict-mode', 'sensitive-words', 'cache-user-id'] as const;
 
@@ -300,6 +302,7 @@ const serializeModelAliases = (models?: ModelAlias[], includeOpenAIFields = fals
 
 const serializeApiKeyEntry = (entry: ApiKeyEntry) => {
   const payload: Record<string, unknown> = { 'api-key': entry.apiKey };
+  if (entry.selectionWeight !== undefined) payload['selection-weight'] = entry.selectionWeight;
   if (entry.proxyUrl) payload['proxy-url'] = entry.proxyUrl;
   return payload;
 };
@@ -307,6 +310,7 @@ const serializeApiKeyEntry = (entry: ApiKeyEntry) => {
 const serializeProviderKey = (config: ProviderKeyConfig) => {
   const payload: Record<string, unknown> = { 'api-key': config.apiKey };
   if (config.priority !== undefined) payload.priority = config.priority;
+  if (config.selectionWeight !== undefined) payload['selection-weight'] = config.selectionWeight;
   if (config.prefix?.trim()) payload.prefix = config.prefix.trim();
   if (config.baseUrl) payload['base-url'] = config.baseUrl;
   if (config.websockets !== undefined) payload.websockets = config.websockets;
@@ -356,6 +360,7 @@ const serializeVertexModelAliases = (models?: ModelAlias[]) =>
 const serializeVertexKey = (config: ProviderKeyConfig) => {
   const payload: Record<string, unknown> = { 'api-key': config.apiKey };
   if (config.priority !== undefined) payload.priority = config.priority;
+  if (config.selectionWeight !== undefined) payload['selection-weight'] = config.selectionWeight;
   if (config.prefix?.trim()) payload.prefix = config.prefix.trim();
   if (config.baseUrl) payload['base-url'] = config.baseUrl;
   if (config.proxyUrl) payload['proxy-url'] = config.proxyUrl;
@@ -372,6 +377,7 @@ const serializeVertexKey = (config: ProviderKeyConfig) => {
 const serializeGeminiKey = (config: GeminiKeyConfig) => {
   const payload: Record<string, unknown> = { 'api-key': config.apiKey };
   if (config.priority !== undefined) payload.priority = config.priority;
+  if (config.selectionWeight !== undefined) payload['selection-weight'] = config.selectionWeight;
   if (config.prefix?.trim()) payload.prefix = config.prefix.trim();
   if (config.baseUrl) payload['base-url'] = config.baseUrl;
   if (config.proxyUrl) payload['proxy-url'] = config.proxyUrl;
@@ -401,6 +407,8 @@ const serializeOpenAIProvider = (provider: OpenAIProviderConfig) => {
   const models = serializeModelAliases(provider.models, true);
   if (models && models.length) payload.models = models;
   if (provider.priority !== undefined) payload.priority = provider.priority;
+  if (provider.selectionWeight !== undefined)
+    payload['selection-weight'] = provider.selectionWeight;
   if (provider.testModel) payload['test-model'] = provider.testModel;
   if (provider.disableCooling) payload['disable-cooling'] = true;
   return payload;

--- a/src/services/api/transformers.ts
+++ b/src/services/api/transformers.ts
@@ -4,7 +4,7 @@ import type {
   GeminiKeyConfig,
   ModelAlias,
   OpenAIProviderConfig,
-  ProviderKeyConfig
+  ProviderKeyConfig,
 } from '@/types';
 import type { Config } from '@/types/config';
 import { buildHeaderObject } from '@/utils/headers';
@@ -69,7 +69,11 @@ const normalizeHeaders = (headers: unknown) => {
 };
 
 const normalizeExcludedModels = (input: unknown): string[] => {
-  const rawList = Array.isArray(input) ? input : typeof input === 'string' ? input.split(/[\n,]/) : [];
+  const rawList = Array.isArray(input)
+    ? input
+    : typeof input === 'string'
+      ? input.split(/[\n,]/)
+      : [];
   const seen = new Set<string>();
   const normalized: string[] = [];
 
@@ -97,6 +101,12 @@ const normalizeAuthIndex = (value: unknown): string | undefined => {
   return trimmed ? trimmed : undefined;
 };
 
+const normalizeSelectionWeight = (value: unknown): number | undefined => {
+  if (value === undefined || value === null || String(value).trim() === '') return undefined;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : undefined;
+};
+
 const normalizeApiKeyEntry = (entry: unknown): ApiKeyEntry | null => {
   if (entry === undefined || entry === null) return null;
   const record = isRecord(entry) ? entry : null;
@@ -105,12 +115,14 @@ const normalizeApiKeyEntry = (entry: unknown): ApiKeyEntry | null => {
   if (!trimmed) return null;
 
   const proxyUrl = record?.['proxy-url'];
+  const selectionWeight = normalizeSelectionWeight(record?.['selection-weight']);
   const authIndex = normalizeAuthIndex(record?.['auth-index']);
 
   const result: ApiKeyEntry = {
     apiKey: trimmed,
-    proxyUrl: proxyUrl ? String(proxyUrl) : undefined
+    proxyUrl: proxyUrl ? String(proxyUrl) : undefined,
   };
+  if (selectionWeight !== undefined) result.selectionWeight = selectionWeight;
   if (authIndex) result.authIndex = authIndex;
   return result;
 };
@@ -130,6 +142,8 @@ const normalizeProviderKeyConfig = (item: unknown): ProviderKeyConfig | null => 
       config.priority = parsed;
     }
   }
+  const selectionWeight = normalizeSelectionWeight(record?.['selection-weight']);
+  if (selectionWeight !== undefined) config.selectionWeight = selectionWeight;
   const prefix = normalizePrefix(record?.prefix);
   if (prefix) config.prefix = prefix;
   const baseUrl = record?.['base-url'];
@@ -198,6 +212,8 @@ const normalizeGeminiKeyConfig = (item: unknown): GeminiKeyConfig | null => {
       config.priority = parsed;
     }
   }
+  const selectionWeight = normalizeSelectionWeight(record?.['selection-weight']);
+  if (selectionWeight !== undefined) config.selectionWeight = selectionWeight;
   const prefix = normalizePrefix(record?.prefix);
   if (prefix) config.prefix = prefix;
   const baseUrl = record?.['base-url'];
@@ -237,7 +253,7 @@ const normalizeOpenAIProvider = (provider: unknown): OpenAIProviderConfig | null
   const result: OpenAIProviderConfig = {
     name: String(name),
     baseUrl: String(baseUrl),
-    apiKeyEntries
+    apiKeyEntries,
   };
 
   const disabled = normalizeBoolean(provider.disabled);
@@ -249,6 +265,8 @@ const normalizeOpenAIProvider = (provider: unknown): OpenAIProviderConfig | null
   if (headers) result.headers = headers;
   if (models.length) result.models = models;
   if (priority !== undefined) result.priority = Number(priority);
+  const selectionWeight = normalizeSelectionWeight(provider['selection-weight']);
+  if (selectionWeight !== undefined) result.selectionWeight = selectionWeight;
   if (testModel) result.testModel = String(testModel);
   const authIndex = normalizeAuthIndex(provider['auth-index']);
   if (authIndex) result.authIndex = authIndex;
@@ -281,7 +299,11 @@ export const normalizeConfigResponse = (raw: unknown): Config => {
   config.debug = normalizeBoolean(raw.debug);
   const proxyUrl = raw['proxy-url'];
   config.proxyUrl =
-    typeof proxyUrl === 'string' ? proxyUrl : proxyUrl === undefined || proxyUrl === null ? undefined : String(proxyUrl);
+    typeof proxyUrl === 'string'
+      ? proxyUrl
+      : proxyUrl === undefined || proxyUrl === null
+        ? undefined
+        : String(proxyUrl);
   const requestRetry = raw['request-retry'];
   if (typeof requestRetry === 'number' && Number.isFinite(requestRetry)) {
     config.requestRetry = requestRetry;
@@ -297,7 +319,7 @@ export const normalizeConfigResponse = (raw: unknown): Config => {
     config.quotaExceeded = {
       switchProject: normalizeBoolean(quota['switch-project']),
       switchPreviewModel: normalizeBoolean(quota['switch-preview-model']),
-      antigravityCredits: normalizeBoolean(quota['antigravity-credits'])
+      antigravityCredits: normalizeBoolean(quota['antigravity-credits']),
     };
   }
 
@@ -374,5 +396,5 @@ export {
   normalizeOpenAIProvider,
   normalizeProviderKeyConfig,
   normalizeHeaders,
-  normalizeExcludedModels
+  normalizeExcludedModels,
 };

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -15,6 +15,7 @@ export interface ModelAlias {
 export interface ApiKeyEntry {
   apiKey: string;
   proxyUrl?: string;
+  selectionWeight?: number;
   authIndex?: string;
 }
 
@@ -28,6 +29,7 @@ export interface CloakConfig {
 export interface GeminiKeyConfig {
   apiKey: string;
   priority?: number;
+  selectionWeight?: number;
   prefix?: string;
   baseUrl?: string;
   proxyUrl?: string;
@@ -41,6 +43,7 @@ export interface GeminiKeyConfig {
 export interface ProviderKeyConfig {
   apiKey: string;
   priority?: number;
+  selectionWeight?: number;
   prefix?: string;
   baseUrl?: string;
   websockets?: boolean;
@@ -63,6 +66,7 @@ export interface OpenAIProviderConfig {
   headers?: Record<string, string>;
   models?: ModelAlias[];
   priority?: number;
+  selectionWeight?: number;
   testModel?: string;
   disableCooling?: boolean;
   authIndex?: string;

--- a/src/types/visualConfig.ts
+++ b/src/types/visualConfig.ts
@@ -102,7 +102,7 @@ export type VisualConfigValues = {
   quotaSwitchProject: boolean;
   quotaSwitchPreviewModel: boolean;
   quotaAntigravityCredits: boolean;
-  routingStrategy: 'round-robin' | 'fill-first';
+  routingStrategy: 'round-robin' | 'fill-first' | 'weighted-round-robin';
   routingSessionAffinity: boolean;
   routingSessionAffinityTTL: string;
   wsAuth: boolean;


### PR DESCRIPTION
## Summary

Exposes the new weighted routing controls in the management UI so operators can configure and inspect `weighted-round-robin` without editing YAML or auth JSON by hand.

The UI now supports selecting `weighted-round-robin` globally, editing provider-level and OpenAI-compatible per-key `selection-weight`, editing auth-file `selection_weight`, and seeing priority/weight metadata where quota and credential decisions are made.

## Details

- Adds `weighted-round-robin` to visual config editing, dashboard badges, search metadata, and i18n strings.
- Adds `selection-weight` parsing/serialization for provider lists and OpenAI-compatible API key entries.
- Adds provider/auth-file form controls with non-negative integer validation and default handling.
- Shows priority and selection weight on quota cards so weighted routing can be checked alongside quota state.

## Validation

- `bun run type-check`
- `bun run lint`
- `bun run build`
- `git diff --check`