### PR TITLE
feat: expose weighted routing configuration

### DIFF
--- a/src/components/config/VisualConfigEditor.tsx
+++ b/src/components/config/VisualConfigEditor.tsx
@@ -1146,6 +1146,12 @@ export function VisualConfigEditor({
                               'config_management.visual.sections.network.strategy_fill_first'
                             ),
                           },
+                          {
+                            value: 'weighted-round-robin',
+                            label: t(
+                              'config_management.visual.sections.network.strategy_weighted_round_robin'
+                            ),
+                          },
                         ]}
                         id={`${routingStrategyLabelId}-select`}
                         disabled={disabled}

--- a/src/components/config/configSearchIndex.ts
+++ b/src/components/config/configSearchIndex.ts
@@ -159,7 +159,7 @@ export const CONFIG_FIELD_SEARCH_INDEX: ConfigFieldSearchEntry[] = [
     labelKey: L('sections.network.routing_strategy'),
     hintKey: L('sections.network.routing_strategy_hint'),
     yamlKeys: ['routing', 'strategy'],
-    keywords: ['round-robin', 'fill-first'],
+    keywords: ['round-robin', 'fill-first', 'weighted-round-robin'],
   },
   {
     fieldId: 'disableImageGeneration',

--- a/src/components/quota/QuotaCard.tsx
+++ b/src/components/quota/QuotaCard.tsx
@@ -57,11 +57,23 @@ export interface QuotaRenderHelpers {
   QuotaProgressBar: (props: QuotaProgressBarProps) => ReactElement;
 }
 
+const parseIntegerField = (value: unknown, fallback: number): number => {
+  if (typeof value === 'number' && Number.isInteger(value)) return value;
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return fallback;
+    const parsed = Number(trimmed);
+    if (Number.isInteger(parsed)) return parsed;
+  }
+  return fallback;
+};
+
 interface QuotaCardProps<TState extends QuotaStatusState> {
   item: AuthFileItem;
   quota?: TState;
   resolvedTheme: ResolvedTheme;
   i18nPrefix: string;
+  cardIdleMessageKey?: string;
   cardClassName: string;
   defaultType: string;
   canRefresh?: boolean;
@@ -75,6 +87,7 @@ export function QuotaCard<TState extends QuotaStatusState>({
   quota,
   resolvedTheme,
   i18nPrefix,
+  cardIdleMessageKey,
   cardClassName,
   defaultType,
   canRefresh = false,
@@ -88,6 +101,12 @@ export function QuotaCard<TState extends QuotaStatusState>({
   const typeColorSet = TYPE_COLORS[displayType] || TYPE_COLORS.unknown;
   const typeColor: ThemeColors =
     resolvedTheme === 'dark' && typeColorSet.dark ? typeColorSet.dark : typeColorSet.light;
+  const priority = parseIntegerField(item.priority, 0);
+  const parsedSelectionWeight = parseIntegerField(
+    item.selection_weight ?? item['selection-weight'],
+    1
+  );
+  const selectionWeight = parsedSelectionWeight >= 0 ? parsedSelectionWeight : 1;
 
   const quotaStatus = quota?.status ?? 'idle';
   const quotaLoading = quotaStatus === 'loading';
@@ -96,7 +115,9 @@ export function QuotaCard<TState extends QuotaStatusState>({
     quota?.errorStatus,
     quota?.error || t('common.unknown_error')
   );
-  const idleMessageKey = `${i18nPrefix}.idle`;
+  const idleMessageKey = onRefresh
+    ? `${i18nPrefix}.idle`
+    : (cardIdleMessageKey ?? `${i18nPrefix}.idle`);
 
   const getTypeLabel = (type: string): string => {
     const key = `auth_files.filter_${type}`;
@@ -120,6 +141,14 @@ export function QuotaCard<TState extends QuotaStatusState>({
           {getTypeLabel(displayType)}
         </span>
         <span className={styles.fileName}>{item.name}</span>
+      </div>
+      <div className={styles.scheduleMeta}>
+        <span>
+          {t('auth_files.priority_display')}: {priority}
+        </span>
+        <span>
+          {t('auth_files.selection_weight_display')}: {selectionWeight}
+        </span>
       </div>
 
       <div className={styles.quotaSection}>

--- a/src/features/authFiles/components/AuthFileCard.tsx
+++ b/src/features/authFiles/components/AuthFileCard.tsx
@@ -124,6 +124,8 @@ export function AuthFileCard(props: AuthFileCardProps) {
     Boolean(rawStatusMessage) && !HEALTHY_STATUS_MESSAGES.has(rawStatusMessage.toLowerCase());
 
   const priorityValue = parsePriorityValue(file.priority ?? file['priority']);
+  const selectionWeightRaw = file.selection_weight ?? file['selection-weight'];
+  const selectionWeightValue = parsePriorityValue(selectionWeightRaw);
   const noteValue = typeof file.note === 'string' ? file.note.trim() : '';
   const stateLabel = isRuntimeOnly
     ? t('auth_files.type_virtual') || '虚拟认证文件'
@@ -218,6 +220,14 @@ export function AuthFileCard(props: AuthFileCardProps) {
                 <span className={styles.metaLabel}>{t('auth_files.priority_display')}</span>
                 <span className={`${styles.metaValue} ${styles.priorityValue}`}>
                   {priorityValue}
+                </span>
+              </div>
+            )}
+            {selectionWeightValue !== undefined && selectionWeightValue >= 0 && (
+              <div className={`${styles.metaItem} ${styles.priorityBadge}`}>
+                <span className={styles.metaLabel}>{t('auth_files.selection_weight_display')}</span>
+                <span className={`${styles.metaValue} ${styles.priorityValue}`}>
+                  {selectionWeightValue}
                 </span>
               </div>
             )}

--- a/src/features/authFiles/components/AuthFilesPrefixProxyEditorModal.tsx
+++ b/src/features/authFiles/components/AuthFilesPrefixProxyEditorModal.tsx
@@ -75,7 +75,9 @@ export function AuthFilesPrefixProxyEditorModal(props: AuthFilesPrefixProxyEdito
               editor?.saving === true ||
               !dirty ||
               !editor?.json ||
-              Boolean(editor?.headersTouched && editor.headersError)
+              Boolean(
+                (editor?.headersTouched && editor.headersError) || editor?.selectionWeightError
+              )
             }
           >
             {t('common.save')}

--- a/src/features/authFiles/components/AuthFilesPrefixProxyEditorModal.tsx
+++ b/src/features/authFiles/components/AuthFilesPrefixProxyEditorModal.tsx
@@ -146,6 +146,15 @@ export function AuthFilesPrefixProxyEditorModal(props: AuthFilesPrefixProxyEdito
                     disabled={disableControls || editor.saving || !editor.json}
                     onChange={(e) => onChange('priority', e.target.value)}
                   />
+                  <Input
+                    label={t('auth_files.selection_weight_label')}
+                    value={editor.selectionWeight}
+                    placeholder={t('auth_files.selection_weight_placeholder')}
+                    hint={t('auth_files.selection_weight_hint')}
+                    error={editor.selectionWeightError ?? undefined}
+                    disabled={disableControls || editor.saving || !editor.json}
+                    onChange={(e) => onChange('selectionWeight', e.target.value)}
+                  />
                   {supportsAuthFileWebsockets(editor.providerKey) && (
                     <div className="form-group">
                       <label>{t('auth_files.websockets_label')}</label>

--- a/src/features/authFiles/hooks/useAuthFilesPrefixProxyEditor.ts
+++ b/src/features/authFiles/hooks/useAuthFilesPrefixProxyEditor.ts
@@ -322,10 +322,10 @@ const buildAuthFileFieldsPatch = (
 
 const buildPrefixProxyUpdatedText = (
   editor: PrefixProxyEditorState | null,
-  resolveHeadersError: (key: AuthFileHeadersErrorKey) => string
+  resolveFieldError: (key: AuthFileFieldsErrorKey) => string
 ): string => {
   if (!editor?.json) return editor?.rawText ?? '';
-  const patch = buildAuthFileFieldsPatch(editor, resolveHeadersError);
+  const patch = buildAuthFileFieldsPatch(editor, resolveFieldError);
   let next: Record<string, unknown> = { ...editor.json };
   if (patch.prefix !== undefined) {
     if (patch.prefix) {

--- a/src/features/authFiles/hooks/useAuthFilesPrefixProxyEditor.ts
+++ b/src/features/authFiles/hooks/useAuthFilesPrefixProxyEditor.ts
@@ -19,6 +19,7 @@ type AuthFileHeadersErrorKey =
   | 'auth_files.headers_invalid_json'
   | 'auth_files.headers_invalid_object'
   | 'auth_files.headers_invalid_value';
+type AuthFileFieldsErrorKey = AuthFileHeadersErrorKey | 'auth_files.selection_weight_invalid';
 type AuthFileContentErrorKey =
   | 'auth_files.prefix_proxy_invalid_json'
   | 'auth_files.prefix_proxy_html_challenge';
@@ -27,6 +28,7 @@ export type PrefixProxyEditorField =
   | 'prefix'
   | 'proxyUrl'
   | 'priority'
+  | 'selectionWeight'
   | 'websockets'
   | 'usingApi'
   | 'note'
@@ -48,6 +50,8 @@ export type PrefixProxyEditorState = {
   prefix: string;
   proxyUrl: string;
   priority: string;
+  selectionWeight: string;
+  selectionWeightError: string | null;
   websockets: boolean;
   websocketsTouched: boolean;
   usingApi: boolean;
@@ -114,6 +118,11 @@ const parseHeadersText = (
 
 const normalizeTextField = (value: unknown): string =>
   typeof value === 'string' ? value.trim() : '';
+
+const parseSelectionWeightValue = (value: unknown): number | undefined => {
+  const parsed = parsePriorityValue(value);
+  return parsed !== undefined && parsed >= 0 ? parsed : undefined;
+};
 
 const INVALID_CONTENT_PREVIEW_LIMIT = 1000;
 
@@ -221,7 +230,7 @@ const applyHeadersPatch = (
 
 const buildAuthFileFieldsPatch = (
   editor: PrefixProxyEditorState,
-  resolveHeadersError: (key: AuthFileHeadersErrorKey) => string
+  resolveError: (key: AuthFileFieldsErrorKey) => string
 ): AuthFileFieldsPatch => {
   const original = editor.json ?? {};
   const patch: AuthFileFieldsPatch = {};
@@ -255,6 +264,21 @@ const buildAuthFileFieldsPatch = (
     }
   }
 
+  const originalSelectionWeight = parseSelectionWeightValue(
+    original.selection_weight ?? original['selection-weight']
+  );
+  const selectionWeightText = editor.selectionWeight.trim();
+  const nextSelectionWeight = parseSelectionWeightValue(selectionWeightText);
+  if (!selectionWeightText) {
+    if (originalSelectionWeight !== undefined) {
+      patch.selection_weight = null;
+    }
+  } else if (nextSelectionWeight === undefined) {
+    throw new Error(resolveError('auth_files.selection_weight_invalid'));
+  } else if (nextSelectionWeight !== originalSelectionWeight) {
+    patch.selection_weight = nextSelectionWeight;
+  }
+
   if (editor.noteTouched) {
     const originalNote = normalizeTextField(original.note);
     const nextNote = editor.note.trim();
@@ -282,7 +306,7 @@ const buildAuthFileFieldsPatch = (
   if (editor.headersTouched) {
     const { value: parsedHeaders, errorKey } = parseHeadersText(editor.headersText);
     if (errorKey) {
-      throw new Error(resolveHeadersError(errorKey));
+      throw new Error(resolveError(errorKey));
     }
     const headersPatch = buildHeadersPatch(
       normalizeHeaders(original.headers),
@@ -326,6 +350,15 @@ const buildPrefixProxyUpdatedText = (
     }
   }
 
+  if (patch.selection_weight !== undefined) {
+    delete next['selection-weight'];
+    if (patch.selection_weight === null) {
+      delete next.selection_weight;
+    } else {
+      next.selection_weight = patch.selection_weight;
+    }
+  }
+
   if (patch.note !== undefined) {
     if (patch.note) {
       next.note = patch.note;
@@ -357,7 +390,8 @@ export function useAuthFilesPrefixProxyEditor(
   const [prefixProxyEditor, setPrefixProxyEditor] = useState<PrefixProxyEditorState | null>(null);
 
   const hasBlockingValidationError = Boolean(
-    prefixProxyEditor?.headersTouched && prefixProxyEditor.headersError
+    (prefixProxyEditor?.headersTouched && prefixProxyEditor.headersError) ||
+    prefixProxyEditor?.selectionWeightError
   );
   const prefixProxyUpdatedText =
     prefixProxyEditor && !hasBlockingValidationError
@@ -399,6 +433,8 @@ export function useAuthFilesPrefixProxyEditor(
       prefix: '',
       proxyUrl: '',
       priority: '',
+      selectionWeight: '',
+      selectionWeightError: null,
       websockets: false,
       websocketsTouched: false,
       usingApi: false,
@@ -447,6 +483,9 @@ export function useAuthFilesPrefixProxyEditor(
       const prefix = typeof json.prefix === 'string' ? json.prefix : '';
       const proxyUrl = typeof json.proxy_url === 'string' ? json.proxy_url : '';
       const priority = parsePriorityValue(json.priority);
+      const selectionWeight = parseSelectionWeightValue(
+        json.selection_weight ?? json['selection-weight']
+      );
       const websockets = supportsAuthFileWebsockets(providerKey)
         ? readAuthFileWebsockets(json)
         : false;
@@ -474,6 +513,8 @@ export function useAuthFilesPrefixProxyEditor(
           prefix,
           proxyUrl,
           priority: priority !== undefined ? String(priority) : '',
+          selectionWeight: selectionWeight !== undefined ? String(selectionWeight) : '',
+          selectionWeightError: null,
           websockets,
           websocketsTouched: false,
           usingApi,
@@ -505,6 +546,15 @@ export function useAuthFilesPrefixProxyEditor(
       if (field === 'prefix') return { ...prev, prefix: String(value) };
       if (field === 'proxyUrl') return { ...prev, proxyUrl: String(value) };
       if (field === 'priority') return { ...prev, priority: String(value) };
+      if (field === 'selectionWeight') {
+        const selectionWeight = String(value);
+        const trimmedSelectionWeight = selectionWeight.trim();
+        const selectionWeightError =
+          trimmedSelectionWeight && parseSelectionWeightValue(trimmedSelectionWeight) === undefined
+            ? t('auth_files.selection_weight_invalid')
+            : null;
+        return { ...prev, selectionWeight, selectionWeightError };
+      }
       if (field === 'websockets') {
         return { ...prev, websockets: Boolean(value), websocketsTouched: true };
       }

--- a/src/features/providers/adapters.ts
+++ b/src/features/providers/adapters.ts
@@ -49,6 +49,9 @@ const collectModelNames = (models?: Array<{ name?: string }>): string[] => {
 const normalizePriority = (priority?: number): number =>
   typeof priority === 'number' && Number.isFinite(priority) ? priority : 0;
 
+const normalizeSelectionWeight = (weight?: number): number | undefined =>
+  typeof weight === 'number' && Number.isInteger(weight) && weight >= 0 ? weight : undefined;
+
 const buildId = (brand: ProviderBrand, index: number, fragment: string) =>
   `${brand}:${index}:${fragment || 'item'}`;
 
@@ -97,6 +100,7 @@ function providerKeyToResource(
     modelCount: config.models?.length ?? 0,
     models: collectModelNames(config.models),
     priority: normalizePriority(config.priority),
+    selectionWeight: normalizeSelectionWeight(config.selectionWeight),
     headerCount: countHeaders(config.headers),
     excludedModelCount: stripDisableAllModelsRule(config.excludedModels).length,
     apiKeyEntryCount: 0,
@@ -150,6 +154,7 @@ export function openaiToResource(config: OpenAIProviderConfig, index: number): P
     modelCount: config.models?.length ?? 0,
     models: collectModelNames(config.models),
     priority: normalizePriority(config.priority),
+    selectionWeight: normalizeSelectionWeight(config.selectionWeight),
     headerCount: countHeaders(config.headers),
     excludedModelCount: 0,
     apiKeyEntryCount: config.apiKeyEntries?.length ?? 0,
@@ -220,10 +225,7 @@ function sponsorRawToResource(
     (raw.claude.length > 0 && !claudeDisabled ? 1 : 0) +
     (raw.gemini.length > 0 && !geminiDisabled ? 1 : 0);
   const allResourcesConfigured =
-    raw.openai.length > 0 ||
-    raw.codex.length > 0 ||
-    raw.claude.length > 0 ||
-    raw.gemini.length > 0;
+    raw.openai.length > 0 || raw.codex.length > 0 || raw.claude.length > 0 || raw.gemini.length > 0;
   const disabled = allResourcesConfigured && enabledCount === 0;
   const models = [
     ...raw.openai.flatMap((item) => collectModelNames(item.config.models)),

--- a/src/features/providers/components/ProviderResourceTable.tsx
+++ b/src/features/providers/components/ProviderResourceTable.tsx
@@ -118,6 +118,14 @@ export function ProviderResourceTable({
       });
       return <div className={styles.metricsCell}>{items}</div>;
     }
+    const selectionWeight =
+      r.selectionWeight !== undefined
+        ? renderMetric(
+            'selection-weight',
+            t('providersPage.table.metrics.selectionWeight'),
+            r.selectionWeight
+          )
+        : null;
     if (r.brand === 'openaiCompatibility') {
       items.push(
         renderMetric('models', t('providersPage.table.metrics.models'), r.modelCount),
@@ -135,6 +143,9 @@ export function ProviderResourceTable({
       if (r.brand === 'claude' && r.flags.cloakEnabled) {
         items.push(renderFlagTag('cloak', t('providersPage.table.cloakTag')));
       }
+    }
+    if (selectionWeight) {
+      items.push(selectionWeight);
     }
     return <div className={styles.metricsCell}>{items}</div>;
   };

--- a/src/features/providers/sheets/ResourceDetailView.tsx
+++ b/src/features/providers/sheets/ResourceDetailView.tsx
@@ -106,6 +106,12 @@ export function ResourceDetailView({ resource, usageByProvider }: ResourceDetail
     ['baseUrl', resource.baseUrl ?? t('providersPage.status.notSet')],
     ['proxyUrl', resource.proxyUrl ?? t('providersPage.status.notSet')],
     ['prefix', resource.prefix ?? t('providersPage.status.none')],
+    [
+      'selectionWeight',
+      resource.selectionWeight !== undefined
+        ? String(resource.selectionWeight)
+        : t('providersPage.status.defaultSuffix'),
+    ],
     ['models', String(resource.modelCount)],
     ['headers', String(resource.headerCount)],
   ];
@@ -156,6 +162,11 @@ export function ResourceDetailView({ resource, usageByProvider }: ResourceDetail
                   <span className={styles.apiKeyEntryKey}>{maskApiKey(entry.apiKey)}</span>
                   {entry.proxyUrl ? (
                     <span className={styles.apiKeyEntryProxy}>{entry.proxyUrl}</span>
+                  ) : null}
+                  {entry.selectionWeight !== undefined ? (
+                    <span className={styles.apiKeyEntryProxy}>
+                      {t('providersPage.form.selectionWeight')}: {entry.selectionWeight}
+                    </span>
                   ) : null}
                   <div className={styles.apiKeyEntryStats}>
                     <span className={`${styles.apiKeyEntryStat} ${styles.apiKeyEntryStatSuccess}`}>

--- a/src/features/providers/sheets/forms/ApiKeyEntriesEditor.tsx
+++ b/src/features/providers/sheets/forms/ApiKeyEntriesEditor.tsx
@@ -131,6 +131,11 @@ export function ApiKeyEntriesEditor({
               >
                 <span>{t('providersPage.form.apiKeyEntry', { index: idx + 1 })}</span>
                 <span className={styles.entrySummary}>
+                  {entry.selectionWeight !== undefined ? (
+                    <span className={styles.entryBadge}>
+                      {t('providersPage.form.selectionWeight')}: {entry.selectionWeight}
+                    </span>
+                  ) : null}
                   {entry.proxyUrl.trim() ? (
                     <span className={styles.entryBadge} title={entry.proxyUrl}>
                       {t('providersPage.form.proxyBadge')}
@@ -236,6 +241,23 @@ export function ApiKeyEntriesEditor({
                     disabled={mutating}
                     placeholder="http://127.0.0.1:7890"
                   />
+                </div>
+                <div className={styles.field}>
+                  <label className={styles.label}>{t('providersPage.form.selectionWeight')}</label>
+                  <input
+                    className={styles.input}
+                    type="number"
+                    min={0}
+                    step={1}
+                    value={entry.selectionWeight ?? ''}
+                    onChange={(e) =>
+                      onUpdate(idx, {
+                        selectionWeight: e.target.value === '' ? undefined : Number(e.target.value),
+                      })
+                    }
+                    disabled={mutating}
+                  />
+                  <div className={styles.hint}>{t('providersPage.form.selectionWeightHint')}</div>
                 </div>
               </div>
             ) : null}

--- a/src/features/providers/sheets/forms/BaseProviderForm.tsx
+++ b/src/features/providers/sheets/forms/BaseProviderForm.tsx
@@ -47,6 +47,9 @@ const emptyApiKeyEntry = (): ApiKeyEntryInput => ({
   proxyUrl: '',
 });
 
+const selectionWeightValid = (value: number | undefined): boolean =>
+  value === undefined || (Number.isInteger(value) && value >= 0);
+
 const stripDisableAllRule = (list?: string[]): string[] =>
   (list ?? []).filter((s) => s.trim() !== '*');
 
@@ -73,6 +76,7 @@ function buildInitialForm(
       disabled: false,
       disableCooling: false,
       priority: undefined,
+      selectionWeight: undefined,
       models: [emptyModel()],
       headers: [emptyHeader()],
       excludedModelsText: '',
@@ -104,6 +108,7 @@ function buildInitialForm(
       disabled: cfg.disabled === true,
       disableCooling: cfg.disableCooling === true,
       priority: cfg.priority,
+      selectionWeight: cfg.selectionWeight,
       models: cfg.models?.length
         ? cfg.models.map((m) => ({
             name: m.name,
@@ -124,6 +129,7 @@ function buildInitialForm(
             apiKey: '',
             existingApiKey: entry.apiKey,
             proxyUrl: entry.proxyUrl ?? '',
+            selectionWeight: entry.selectionWeight,
             authIndex: entry.authIndex,
           }))
         : [emptyApiKeyEntry()],
@@ -146,6 +152,7 @@ function buildInitialForm(
     disabled,
     disableCooling: cfg.disableCooling === true,
     priority: cfg.priority,
+    selectionWeight: cfg.selectionWeight,
     models: cfg.models?.length
       ? cfg.models.map((m) => ({
           name: m.name,
@@ -366,6 +373,12 @@ export function BaseProviderForm({
     if (descriptor.baseUrlRequired && !form.baseUrl.trim()) {
       return t('providersPage.form.validation.baseUrlRequired');
     }
+    if (!selectionWeightValid(form.selectionWeight)) {
+      return t('providersPage.form.validation.selectionWeightInvalid');
+    }
+    if (form.apiKeyEntries?.some((entry) => !selectionWeightValid(entry.selectionWeight))) {
+      return t('providersPage.form.validation.selectionWeightInvalid');
+    }
     return null;
   };
 
@@ -565,6 +578,33 @@ export function BaseProviderForm({
                 />
               </div>
             ) : null}
+          </div>
+        ) : null}
+
+        {descriptor.supportsPriority ? (
+          <div className={styles.field}>
+            <label className={styles.label} htmlFor={`${fid}-selection-weight`}>
+              {t('providersPage.form.selectionWeight')}
+              <span className={styles.labelHint}>
+                {' '}
+                · {t('providersPage.form.selectionWeightHint')}
+              </span>
+            </label>
+            <input
+              id={`${fid}-selection-weight`}
+              type="number"
+              min={0}
+              step={1}
+              className={styles.input}
+              value={form.selectionWeight ?? ''}
+              onChange={(e) =>
+                updateField(
+                  'selectionWeight',
+                  e.target.value === '' ? undefined : Number(e.target.value)
+                )
+              }
+              disabled={mutating}
+            />
           </div>
         ) : null}
 

--- a/src/features/providers/types.ts
+++ b/src/features/providers/types.ts
@@ -89,6 +89,8 @@ export interface ProviderResource {
   models: string[];
   /** 排序用优先级,未配置时为 0 */
   priority: number;
+  /** weighted-round-robin 选择权重,未配置时后端按 1 处理 */
+  selectionWeight?: number;
   headerCount: number;
   excludedModelCount: number;
   /** 仅 OpenAI 有意义,其它 brand 该字段不展示但保留 */
@@ -152,6 +154,7 @@ export interface ApiKeyEntryInput {
   apiKey: string;
   existingApiKey?: string;
   proxyUrl: string;
+  selectionWeight?: number;
   authIndex?: string;
 }
 
@@ -173,6 +176,7 @@ export interface ProviderEntryFormInput {
   disabled: boolean;
   disableCooling?: boolean;
   priority?: number;
+  selectionWeight?: number;
 
   /** 高级折叠区 */
   models: ModelEntryInput[];

--- a/src/features/providers/useProviderWorkbench.ts
+++ b/src/features/providers/useProviderWorkbench.ts
@@ -158,6 +158,7 @@ const buildProviderKeyConfig = (
   const next: ProviderKeyConfig = {
     apiKey: apiKeyChanged ? input.apiKey.trim() : (existing?.apiKey ?? ''),
     priority: input.priority,
+    selectionWeight: input.selectionWeight,
     prefix: input.prefix.trim() || undefined,
     baseUrl: input.baseUrl.trim() || undefined,
     proxyUrl: input.proxyUrl.trim() || undefined,
@@ -211,6 +212,7 @@ const buildOpenAIConfig = (
         return {
           apiKey: entry.apiKey.trim() || fallbackApiKey,
           proxyUrl: entry.proxyUrl.trim() || undefined,
+          selectionWeight: entry.selectionWeight,
           authIndex: entry.authIndex?.trim() || undefined,
         };
       })
@@ -227,6 +229,7 @@ const buildOpenAIConfig = (
     headers: Object.keys(headers).length ? headers : undefined,
     models: models.length ? models : undefined,
     priority: input.priority,
+    selectionWeight: input.selectionWeight,
     testModel: input.testModel?.trim() || undefined,
   };
 };

--- a/src/hooks/useVisualConfig.ts
+++ b/src/hooks/useVisualConfig.ts
@@ -1156,7 +1156,12 @@ export function useVisualConfig() {
         quotaSwitchPreviewModel: Boolean(quotaExceeded?.['switch-preview-model'] ?? true),
         quotaAntigravityCredits: Boolean(quotaExceeded?.['antigravity-credits'] ?? false),
 
-        routingStrategy: routing?.strategy === 'fill-first' ? 'fill-first' : 'round-robin',
+        routingStrategy:
+          routing?.strategy === 'fill-first'
+            ? 'fill-first'
+            : routing?.strategy === 'weighted-round-robin'
+              ? 'weighted-round-robin'
+              : 'round-robin',
         routingSessionAffinity: Boolean(
           routing?.['session-affinity'] ?? routing?.sessionAffinity ?? routing?.['sessionAffinity']
         ),

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -160,8 +160,13 @@
     "request_log_enable": "Enable request logging",
     "request_log_warning": "Keep this off unless you need detailed troubleshooting.",
     "ws_auth_enable": "Require auth for /ws/*",
+    "routing_title": "Routing Strategy",
+    "routing_strategy_label": "Routing strategy:",
+    "routing_strategy_hint": "round-robin cycles through keys; fill-first prioritizes the first available key; weighted-round-robin distributes by selection weight.",
+    "routing_strategy_update": "Update",
     "routing_strategy_round_robin": "round-robin (cycle)",
-    "routing_strategy_fill_first": "fill-first (prioritize)"
+    "routing_strategy_fill_first": "fill-first (prioritize)",
+    "routing_strategy_weighted_round_robin": "weighted-round-robin (weighted)"
   },
   "auth_files": {
     "title": "Auth Files Management",
@@ -223,6 +228,7 @@
     "sort_az": "A-Z Name",
     "sort_priority": "Priority",
     "priority_display": "Priority",
+    "selection_weight_display": "Selection weight",
     "page_size_label": "Per page",
     "view_mode_paged": "Paged",
     "view_mode_all": "Show all",
@@ -280,10 +286,20 @@
     "priority_label": "Priority (priority)",
     "priority_placeholder": "e.g. 10 or -1",
     "priority_hint": "Integers only. Invalid values are ignored. Larger value means higher priority.",
+    "selection_weight_label": "Selection weight (selection_weight)",
+    "selection_weight_placeholder": "e.g. 2",
+    "selection_weight_hint": "Non-negative integers only. Leave empty to use the default weight 1.",
+    "selection_weight_invalid": "Selection weight must be a non-negative integer.",
     "websockets_label": "WebSockets (websockets)",
     "websockets_hint": "Enable Responses API websocket transport for this credential.",
     "using_api_label": "Use official API (using_api)",
     "using_api_hint": "Use the official xAI API when enabled; use Grok CLI chat-proxy when disabled.",
+    "excluded_models_label": "Excluded models (excluded_models)",
+    "excluded_models_placeholder": "Comma or newline separated, e.g. model-a, gpt-5-*, *-preview",
+    "excluded_models_hint": "Saved as an array and normalized by trim/lowercase/dedup/sort.",
+    "disable_cooling_label": "Disable cooling (disable_cooling)",
+    "disable_cooling_placeholder": "e.g. true / false / 1 / 0",
+    "disable_cooling_hint": "Supports booleans, numeric 0/non-0, and strings like true/false/1/0; unparseable values are ignored.",
     "note_label": "Note",
     "note_placeholder": "Enter a note, e.g.: John's account",
     "note_hint": "Optional. Used to describe the purpose or owner of this credential; leave empty to omit.",
@@ -907,7 +923,7 @@
           "stabilize_device_desc": "Pin OS/Arch and stabilize the software fingerprint per credential/API key",
           "beta_features": "Beta Features",
           "codex_identity_confuse": "Codex Identity Confuse",
-          "codex_identity_confuse_desc": "When fill-first routing or session affinity is used, remap Codex prompt_cache_key and installation identity for the selected auth"
+          "codex_identity_confuse_desc": "When fill-first routing, weighted-round-robin, or session affinity is used, remap Codex prompt_cache_key and installation identity for the selected auth"
         },
         "network": {
           "title": "Network Configuration",
@@ -931,6 +947,7 @@
           "routing_strategy_hint": "Select credential selection strategy",
           "strategy_round_robin": "Round Robin",
           "strategy_fill_first": "Fill First",
+          "strategy_weighted_round_robin": "Weighted Round Robin",
           "session_affinity_ttl": "Session Affinity TTL",
           "force_model_prefix": "Force Model Prefix",
           "force_model_prefix_desc": "Unprefixed model requests only use credentials without prefix",
@@ -1343,7 +1360,8 @@
       "metrics": {
         "models": "Models",
         "keys": "Keys",
-        "headers": "Headers"
+        "headers": "Headers",
+        "selectionWeight": "Weight"
       },
       "websocketsTag": "WebSockets",
       "cloakTag": "Cloak",
@@ -1438,7 +1456,8 @@
         "headers": "Headers",
         "authIndex": "Auth Index",
         "excludedModels": "Excluded models",
-        "apiKeyEntries": "API key entries"
+        "apiKeyEntries": "API key entries",
+        "selectionWeight": "Selection weight"
       }
     },
     "form": {
@@ -1453,6 +1472,8 @@
       "proxyUrl": "Proxy URL",
       "prefix": "Prefix",
       "priority": "Priority",
+      "selectionWeight": "Selection weight",
+      "selectionWeightHint": "Used by weighted round-robin; leave empty for the default weight 1.",
       "disabled": "Disable this entry",
       "disabledHint": "Disabled entries won't be used by the gateway",
       "websockets": "Enable WebSockets",
@@ -1494,7 +1515,8 @@
       "validation": {
         "nameRequired": "Name is required",
         "apiKeyRequired": "At least one API key is required",
-        "baseUrlRequired": "Base URL is required"
+        "baseUrlRequired": "Base URL is required",
+        "selectionWeightInvalid": "Selection weight must be a non-negative integer"
       }
     },
     "delete": {

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -159,8 +159,13 @@
     "request_log_enable": "Включить журналирование запросов",
     "request_log_warning": "Оставьте выключенным, если подробная диагностика не нужна.",
     "ws_auth_enable": "Требовать аутентификацию для /ws/*",
+    "routing_title": "Стратегия маршрутизации",
+    "routing_strategy_label": "Стратегия маршрутизации:",
+    "routing_strategy_hint": "round-robin циклически перебирает ключи; fill-first отдаёт приоритет первому доступному ключу; weighted-round-robin распределяет по весу выбора.",
+    "routing_strategy_update": "Обновить",
     "routing_strategy_round_robin": "round-robin (цикл)",
-    "routing_strategy_fill_first": "fill-first (приоритет)"
+    "routing_strategy_fill_first": "fill-first (приоритет)",
+    "routing_strategy_weighted_round_robin": "weighted-round-robin (по весу)"
   },
   "auth_files": {
     "title": "Управление файлами авторизации",
@@ -222,6 +227,7 @@
     "sort_az": "A-Z Имя",
     "sort_priority": "Приоритет",
     "priority_display": "Приоритет",
+    "selection_weight_display": "Вес выбора",
     "page_size_label": "На странице",
     "view_mode_paged": "Постранично",
     "view_mode_all": "Показать все",
@@ -279,10 +285,20 @@
     "priority_label": "Приоритет (priority)",
     "priority_placeholder": "например: 10 или -1",
     "priority_hint": "Только целые числа. Некорректные значения игнорируются. Чем больше число, тем выше приоритет.",
+    "selection_weight_label": "Вес выбора (selection_weight)",
+    "selection_weight_placeholder": "например: 2",
+    "selection_weight_hint": "Только неотрицательные целые числа. Оставьте пустым для веса по умолчанию 1.",
+    "selection_weight_invalid": "Вес выбора должен быть неотрицательным целым числом.",
     "websockets_label": "WebSockets (websockets)",
     "websockets_hint": "Включает websocket-транспорт Responses API для этих учётных данных.",
     "using_api_label": "Использовать официальный API (using_api)",
     "using_api_hint": "Если включено, используется официальный API xAI; если выключено — Grok CLI chat-proxy.",
+    "excluded_models_label": "Исключённые модели (excluded_models)",
+    "excluded_models_placeholder": "Через запятую или с новой строки, например: model-a, gpt-5-*, *-preview",
+    "excluded_models_hint": "Сохраняется как массив; значения trim/нижний регистр/без дублей/с сортировкой.",
+    "disable_cooling_label": "Отключение охлаждения (disable_cooling)",
+    "disable_cooling_placeholder": "например: true / false / 1 / 0",
+    "disable_cooling_hint": "Поддерживает boolean, числа 0/не 0 и строки true/false/1/0; непарсируемые значения игнорируются.",
     "note_label": "Заметка (note)",
     "note_placeholder": "Введите заметку, например: аккаунт Ивана",
     "note_hint": "Необязательно. Используется для описания назначения или владельца учётных данных; оставьте пустым, чтобы не записывать.",
@@ -894,7 +910,7 @@
           "stabilize_device_desc": "Фиксировать OS/Arch и стабилизировать программный отпечаток для учётных данных/API-ключа",
           "beta_features": "Beta Features",
           "codex_identity_confuse": "Codex identity-confuse",
-          "codex_identity_confuse_desc": "При fill-first routing или session affinity переопределяет Codex prompt_cache_key и installation identity под выбранную auth-запись"
+          "codex_identity_confuse_desc": "При fill-first routing, weighted-round-robin или session affinity переопределяет Codex prompt_cache_key и installation identity под выбранную auth-запись"
         },
         "network": {
           "title": "Сетевые настройки",
@@ -918,6 +934,7 @@
           "routing_strategy_hint": "Выберите стратегию подбора учётных данных",
           "strategy_round_robin": "По кругу",
           "strategy_fill_first": "Сначала заполнить",
+          "strategy_weighted_round_robin": "По весу",
           "session_affinity_ttl": "TTL привязки сессии",
           "force_model_prefix": "Принудительный префикс модели",
           "force_model_prefix_desc": "Запросы к моделям без префикса используют только учётные данные без префикса",
@@ -1321,7 +1338,8 @@
       "metrics": {
         "models": "Модели",
         "keys": "Ключи",
-        "headers": "Заголовки"
+        "headers": "Заголовки",
+        "selectionWeight": "Вес"
       },
       "websocketsTag": "WebSockets",
       "cloakTag": "Cloak",
@@ -1416,7 +1434,8 @@
         "headers": "Заголовков",
         "authIndex": "Auth Index",
         "excludedModels": "Исключённых моделей",
-        "apiKeyEntries": "API-ключей"
+        "apiKeyEntries": "API-ключей",
+        "selectionWeight": "Вес выбора"
       }
     },
     "form": {
@@ -1431,6 +1450,8 @@
       "proxyUrl": "Proxy URL",
       "prefix": "Префикс",
       "priority": "Приоритет",
+      "selectionWeight": "Вес выбора",
+      "selectionWeightHint": "Используется weighted round-robin; оставьте пустым для веса по умолчанию 1.",
       "disabled": "Отключить эту запись",
       "disabledHint": "Отключённые записи не используются шлюзом",
       "websockets": "Включить WebSockets",
@@ -1472,7 +1493,8 @@
       "validation": {
         "nameRequired": "Название обязательно",
         "apiKeyRequired": "Нужен хотя бы один API-ключ",
-        "baseUrlRequired": "Base URL обязателен"
+        "baseUrlRequired": "Base URL обязателен",
+        "selectionWeightInvalid": "Вес выбора должен быть неотрицательным целым числом"
       }
     },
     "delete": {

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -160,8 +160,13 @@
     "request_log_enable": "启用请求日志",
     "request_log_warning": "仅在需要排查问题时开启，日常请保持关闭。",
     "ws_auth_enable": "启用 /ws/* 鉴权",
+    "routing_title": "路由策略",
+    "routing_strategy_label": "路由策略:",
+    "routing_strategy_hint": "round-robin 为轮询，fill-first 为优先填充，weighted-round-robin 按选择权重分配。",
+    "routing_strategy_update": "更新",
     "routing_strategy_round_robin": "round-robin (轮询)",
-    "routing_strategy_fill_first": "fill-first (优先填充)"
+    "routing_strategy_fill_first": "fill-first (优先填充)",
+    "routing_strategy_weighted_round_robin": "weighted-round-robin (加权轮询)"
   },
   "auth_files": {
     "title": "认证文件管理",
@@ -223,6 +228,7 @@
     "sort_az": "A-Z 名称",
     "sort_priority": "优先级",
     "priority_display": "优先级",
+    "selection_weight_display": "选择权重",
     "page_size_label": "单页数量",
     "view_mode_paged": "按页显示",
     "view_mode_all": "显示全部",
@@ -280,10 +286,20 @@
     "priority_label": "优先级（priority）",
     "priority_placeholder": "例如: 10 或 -1",
     "priority_hint": "仅支持整数；非法值会被忽略。数值越大优先级越高。",
+    "selection_weight_label": "选择权重（selection_weight）",
+    "selection_weight_placeholder": "例如: 2",
+    "selection_weight_hint": "仅支持非负整数；留空按默认权重 1 处理。",
+    "selection_weight_invalid": "选择权重必须是非负整数。",
     "websockets_label": "WebSockets（websockets）",
     "websockets_hint": "为该凭证开启 Responses API 的 websocket 传输。",
     "using_api_label": "使用官方 API（using_api）",
     "using_api_hint": "开启后使用 xAI 官方 API；关闭时使用 Grok CLI chat-proxy。",
+    "excluded_models_label": "排除模型（excluded_models）",
+    "excluded_models_placeholder": "用逗号或换行分隔，例如: model-a, gpt-5-*, *-preview",
+    "excluded_models_hint": "保存为数组；会自动 trim、小写、去重并排序。",
+    "disable_cooling_label": "禁用冷却（disable_cooling）",
+    "disable_cooling_placeholder": "例如: true / false / 1 / 0",
+    "disable_cooling_hint": "支持布尔值、0/非0 数字或字符串 true/false/1/0；无法解析时忽略。",
     "note_label": "备注（note）",
     "note_placeholder": "输入备注信息，例如：张三的账号",
     "note_hint": "可选，用于标记凭证用途或归属；留空则不写入。",
@@ -907,7 +923,7 @@
           "stabilize_device_desc": "固定 OS/Arch，并按凭据/API Key 稳定软件指纹",
           "beta_features": "Beta Features",
           "codex_identity_confuse": "Codex 身份混淆",
-          "codex_identity_confuse_desc": "在 fill-first 或会话粘性路由下，按所选认证重映射 Codex prompt_cache_key 与安装身份"
+          "codex_identity_confuse_desc": "在 fill-first、weighted-round-robin 或会话粘性路由下，按所选认证重映射 Codex prompt_cache_key 与安装身份"
         },
         "network": {
           "title": "网络配置",
@@ -931,6 +947,7 @@
           "routing_strategy_hint": "选择凭据选择策略",
           "strategy_round_robin": "轮询 (Round Robin)",
           "strategy_fill_first": "填充优先 (Fill First)",
+          "strategy_weighted_round_robin": "加权轮询 (Weighted Round Robin)",
           "session_affinity_ttl": "会话粘性 TTL",
           "force_model_prefix": "强制模型前缀",
           "force_model_prefix_desc": "未带前缀的模型请求只使用无前缀凭据",
@@ -1343,7 +1360,8 @@
       "metrics": {
         "models": "模型",
         "keys": "密钥",
-        "headers": "请求头"
+        "headers": "请求头",
+        "selectionWeight": "权重"
       },
       "websocketsTag": "WebSockets",
       "cloakTag": "Cloak",
@@ -1438,7 +1456,8 @@
         "headers": "请求头数",
         "authIndex": "Auth Index",
         "excludedModels": "排除模型数",
-        "apiKeyEntries": "密钥条目数"
+        "apiKeyEntries": "密钥条目数",
+        "selectionWeight": "选择权重"
       }
     },
     "form": {
@@ -1453,6 +1472,8 @@
       "proxyUrl": "代理 URL",
       "prefix": "前缀",
       "priority": "优先级",
+      "selectionWeight": "选择权重",
+      "selectionWeightHint": "用于 weighted round-robin；留空按默认权重 1 处理。",
       "disabled": "停用此条目",
       "disabledHint": "停用后不会被网关使用",
       "websockets": "启用 WebSockets",
@@ -1494,7 +1515,8 @@
       "validation": {
         "nameRequired": "名称必填",
         "apiKeyRequired": "至少填写一个 API 密钥",
-        "baseUrlRequired": "服务地址必填"
+        "baseUrlRequired": "服务地址必填",
+        "selectionWeightInvalid": "选择权重必须是非负整数"
       }
     },
     "delete": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -160,8 +160,13 @@
     "request_log_enable": "啟用請求記錄",
     "request_log_warning": "僅在需要排查問題時開啟，日常請保持關閉。",
     "ws_auth_enable": "啟用 /ws/* 驗證",
+    "routing_title": "路由策略",
+    "routing_strategy_label": "路由策略:",
+    "routing_strategy_hint": "round-robin 為輪詢，fill-first 為優先填充，weighted-round-robin 按選擇權重分配。",
+    "routing_strategy_update": "更新",
     "routing_strategy_round_robin": "round-robin（輪詢）",
-    "routing_strategy_fill_first": "fill-first（優先填充）"
+    "routing_strategy_fill_first": "fill-first（優先填充）",
+    "routing_strategy_weighted_round_robin": "weighted-round-robin（加權輪詢）"
   },
   "auth_files": {
     "title": "驗證檔案管理",
@@ -223,6 +228,7 @@
     "sort_az": "A-Z 名稱",
     "sort_priority": "優先順序",
     "priority_display": "優先順序",
+    "selection_weight_display": "選擇權重",
     "page_size_label": "單頁數量",
     "view_mode_paged": "分頁顯示",
     "view_mode_all": "顯示全部",
@@ -280,10 +286,20 @@
     "priority_label": "優先順序（priority）",
     "priority_placeholder": "例如: 10 或 -1",
     "priority_hint": "僅支援整數；無效值會被忽略。數值越大優先順序越高。",
+    "selection_weight_label": "選擇權重（selection_weight）",
+    "selection_weight_placeholder": "例如: 2",
+    "selection_weight_hint": "僅支援非負整數；留空按預設權重 1 處理。",
+    "selection_weight_invalid": "選擇權重必須是非負整數。",
     "websockets_label": "WebSockets（websockets）",
     "websockets_hint": "為該憑證開啟 Responses API 的 websocket 傳輸。",
     "using_api_label": "使用官方 API（using_api）",
     "using_api_hint": "開啟後使用 xAI 官方 API；關閉時使用 Grok CLI chat-proxy。",
+    "excluded_models_label": "排除模型（excluded_models）",
+    "excluded_models_placeholder": "用逗號或換行分隔，例如: model-a, gpt-5-*, *-preview",
+    "excluded_models_hint": "儲存為陣列；會自動 trim、小寫、去重並排序。",
+    "disable_cooling_label": "停用冷卻（disable_cooling）",
+    "disable_cooling_placeholder": "例如: true / false / 1 / 0",
+    "disable_cooling_hint": "支援布林值、0/非0 數字或字串 true/false/1/0；無法解析時忽略。",
     "note_label": "備註（note）",
     "note_placeholder": "輸入備註資訊，例如：張三的帳號",
     "note_hint": "選填，用於標記憑證用途或歸屬；留空則不寫入。",
@@ -933,7 +949,7 @@
           "stabilize_device_desc": "固定 OS/Arch，並按憑證/API Key 穩定軟體指紋",
           "beta_features": "Beta Features",
           "codex_identity_confuse": "Codex 身分混淆",
-          "codex_identity_confuse_desc": "在 fill-first 或會話黏性路由下，按所選驗證重映射 Codex prompt_cache_key 與安裝身分"
+          "codex_identity_confuse_desc": "在 fill-first、weighted-round-robin 或會話黏性路由下，按所選驗證重映射 Codex prompt_cache_key 與安裝身分"
         },
         "network": {
           "title": "網路設定",
@@ -957,6 +973,7 @@
           "routing_strategy_hint": "選擇憑證選擇策略",
           "strategy_round_robin": "輪詢（Round Robin）",
           "strategy_fill_first": "填充優先（Fill First）",
+          "strategy_weighted_round_robin": "加權輪詢（Weighted Round Robin）",
           "session_affinity_ttl": "會話黏性 TTL",
           "force_model_prefix": "強制模型前綴",
           "force_model_prefix_desc": "未帶前綴的模型請求只使用無前綴憑證",
@@ -1369,7 +1386,8 @@
       "metrics": {
         "models": "模型",
         "keys": "金鑰",
-        "headers": "請求標頭"
+        "headers": "請求標頭",
+        "selectionWeight": "權重"
       },
       "websocketsTag": "WebSockets",
       "cloakTag": "Cloak",
@@ -1464,7 +1482,8 @@
         "headers": "請求標頭數",
         "authIndex": "Auth Index",
         "excludedModels": "排除模型數",
-        "apiKeyEntries": "金鑰條目數"
+        "apiKeyEntries": "金鑰條目數",
+        "selectionWeight": "選擇權重"
       }
     },
     "form": {
@@ -1479,6 +1498,8 @@
       "proxyUrl": "代理 URL",
       "prefix": "前綴",
       "priority": "優先級",
+      "selectionWeight": "選擇權重",
+      "selectionWeightHint": "用於 weighted round-robin；留空按預設權重 1 處理。",
       "disabled": "停用此條目",
       "disabledHint": "停用後不會被閘道使用",
       "websockets": "啟用 WebSockets",
@@ -1520,7 +1541,8 @@
       "validation": {
         "nameRequired": "名稱必填",
         "apiKeyRequired": "至少填寫一個 API 金鑰",
-        "baseUrlRequired": "服務位址必填"
+        "baseUrlRequired": "服務位址必填",
+        "selectionWeightInvalid": "選擇權重必須是非負整數"
       }
     },
     "delete": {

--- a/src/pages/DashboardPage.module.scss
+++ b/src/pages/DashboardPage.module.scss
@@ -499,6 +499,12 @@
   background: rgba($success-color, 0.12);
 }
 
+.configBadgeWeightedRoundRobin {
+  color: $warning-color;
+  border-color: rgba($warning-color, 0.32);
+  background: rgba($warning-color, 0.12);
+}
+
 .configBadgeUnknown {
   color: var(--text-secondary);
   background: var(--bg-primary);

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -186,14 +186,18 @@ export function DashboardPage() {
       ? t('basic_settings.routing_strategy_round_robin')
       : routingStrategyRaw === 'fill-first'
         ? t('basic_settings.routing_strategy_fill_first')
-        : routingStrategyRaw;
+        : routingStrategyRaw === 'weighted-round-robin'
+          ? t('basic_settings.routing_strategy_weighted_round_robin')
+          : routingStrategyRaw;
   const routingStrategyBadgeClass = !routingStrategyRaw
     ? styles.configBadgeUnknown
     : routingStrategyRaw === 'round-robin'
       ? styles.configBadgeRoundRobin
       : routingStrategyRaw === 'fill-first'
         ? styles.configBadgeFillFirst
-        : styles.configBadgeUnknown;
+        : routingStrategyRaw === 'weighted-round-robin'
+          ? styles.configBadgeWeightedRoundRobin
+          : styles.configBadgeUnknown;
 
   // Derived time-based values
   const greetingKey = `dashboard.greeting_${timeOfDay}`;

--- a/src/pages/QuotaPage.module.scss
+++ b/src/pages/QuotaPage.module.scss
@@ -757,6 +757,26 @@
   line-height: 1.4;
 }
 
+.scheduleMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+
+  span {
+    display: inline-flex;
+    align-items: center;
+    min-height: 22px;
+    padding: 2px 8px;
+    border: 1px solid color-mix(in srgb, var(--border-color) 75%, transparent);
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--bg-secondary) 78%, transparent);
+    color: var(--text-secondary);
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1.2;
+  }
+}
+
 .pagination {
   display: flex;
   justify-content: center;

--- a/src/services/api/authFiles.ts
+++ b/src/services/api/authFiles.ts
@@ -16,6 +16,7 @@ export type AuthFileFieldsPatch = {
   proxy_url?: string;
   headers?: Record<string, string>;
   priority?: number;
+  selection_weight?: number | null;
   websockets?: boolean;
   using_api?: boolean;
   note?: string;

--- a/src/services/api/providers.ts
+++ b/src/services/api/providers.ts
@@ -21,6 +21,7 @@ const RESPONSE_ONLY_FIELDS = ['auth-index'] as const;
 const PROVIDER_COMMON_KEY_FIELDS = [
   'api-key',
   'priority',
+  'selection-weight',
   'prefix',
   'base-url',
   'proxy-url',
@@ -40,6 +41,7 @@ const CLAUDE_KEY_FIELDS = [
 const VERTEX_KEY_FIELDS = [
   'api-key',
   'priority',
+  'selection-weight',
   'prefix',
   'base-url',
   'proxy-url',
@@ -51,6 +53,7 @@ const VERTEX_KEY_FIELDS = [
 const OPENAI_PROVIDER_FIELDS = [
   'name',
   'priority',
+  'selection-weight',
   'disabled',
   'prefix',
   'base-url',
@@ -64,7 +67,7 @@ const OPENAI_PROVIDER_FIELDS = [
 const MODEL_ALIAS_FIELDS = ['name', 'alias', 'priority', 'test-model'] as const;
 const OPENAI_MODEL_ALIAS_FIELDS = [...MODEL_ALIAS_FIELDS, 'image', 'thinking'] as const;
 
-const API_KEY_ENTRY_FIELDS = ['api-key', 'proxy-url'] as const;
+const API_KEY_ENTRY_FIELDS = ['api-key', 'selection-weight', 'proxy-url'] as const;
 
 const CLOAK_FIELDS = ['mode', 'strict-mode', 'sensitive-words', 'cache-user-id'] as const;
 
@@ -313,6 +316,7 @@ const serializeModelAliases = (models?: ModelAlias[], includeOpenAIFields = fals
 
 const serializeApiKeyEntry = (entry: ApiKeyEntry) => {
   const payload: Record<string, unknown> = { 'api-key': entry.apiKey };
+  if (entry.selectionWeight !== undefined) payload['selection-weight'] = entry.selectionWeight;
   if (entry.proxyUrl) payload['proxy-url'] = entry.proxyUrl;
   return payload;
 };
@@ -320,6 +324,7 @@ const serializeApiKeyEntry = (entry: ApiKeyEntry) => {
 const serializeProviderKey = (config: ProviderKeyConfig) => {
   const payload: Record<string, unknown> = { 'api-key': config.apiKey };
   if (config.priority !== undefined) payload.priority = config.priority;
+  if (config.selectionWeight !== undefined) payload['selection-weight'] = config.selectionWeight;
   if (config.prefix?.trim()) payload.prefix = config.prefix.trim();
   if (config.baseUrl) payload['base-url'] = config.baseUrl;
   if (config.websockets !== undefined) payload.websockets = config.websockets;
@@ -369,6 +374,7 @@ const serializeVertexModelAliases = (models?: ModelAlias[]) =>
 const serializeVertexKey = (config: ProviderKeyConfig) => {
   const payload: Record<string, unknown> = { 'api-key': config.apiKey };
   if (config.priority !== undefined) payload.priority = config.priority;
+  if (config.selectionWeight !== undefined) payload['selection-weight'] = config.selectionWeight;
   if (config.prefix?.trim()) payload.prefix = config.prefix.trim();
   if (config.baseUrl) payload['base-url'] = config.baseUrl;
   if (config.proxyUrl) payload['proxy-url'] = config.proxyUrl;
@@ -385,6 +391,7 @@ const serializeVertexKey = (config: ProviderKeyConfig) => {
 const serializeGeminiKey = (config: GeminiKeyConfig) => {
   const payload: Record<string, unknown> = { 'api-key': config.apiKey };
   if (config.priority !== undefined) payload.priority = config.priority;
+  if (config.selectionWeight !== undefined) payload['selection-weight'] = config.selectionWeight;
   if (config.prefix?.trim()) payload.prefix = config.prefix.trim();
   if (config.baseUrl) payload['base-url'] = config.baseUrl;
   if (config.proxyUrl) payload['proxy-url'] = config.proxyUrl;
@@ -414,6 +421,8 @@ const serializeOpenAIProvider = (provider: OpenAIProviderConfig) => {
   const models = serializeModelAliases(provider.models, true);
   if (models && models.length) payload.models = models;
   if (provider.priority !== undefined) payload.priority = provider.priority;
+  if (provider.selectionWeight !== undefined)
+    payload['selection-weight'] = provider.selectionWeight;
   if (provider.testModel) payload['test-model'] = provider.testModel;
   if (provider.disableCooling) payload['disable-cooling'] = true;
   return payload;

--- a/src/services/api/transformers.ts
+++ b/src/services/api/transformers.ts
@@ -101,6 +101,12 @@ const normalizeAuthIndex = (value: unknown): string | undefined => {
   return trimmed ? trimmed : undefined;
 };
 
+const normalizeSelectionWeight = (value: unknown): number | undefined => {
+  if (value === undefined || value === null || String(value).trim() === '') return undefined;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : undefined;
+};
+
 const normalizeApiKeyEntry = (entry: unknown): ApiKeyEntry | null => {
   if (entry === undefined || entry === null) return null;
   const record = isRecord(entry) ? entry : null;
@@ -109,12 +115,14 @@ const normalizeApiKeyEntry = (entry: unknown): ApiKeyEntry | null => {
   if (!trimmed) return null;
 
   const proxyUrl = record?.['proxy-url'];
+  const selectionWeight = normalizeSelectionWeight(record?.['selection-weight']);
   const authIndex = normalizeAuthIndex(record?.['auth-index']);
 
   const result: ApiKeyEntry = {
     apiKey: trimmed,
     proxyUrl: proxyUrl ? String(proxyUrl) : undefined,
   };
+  if (selectionWeight !== undefined) result.selectionWeight = selectionWeight;
   if (authIndex) result.authIndex = authIndex;
   return result;
 };
@@ -134,6 +142,8 @@ const normalizeProviderKeyConfig = (item: unknown): ProviderKeyConfig | null => 
       config.priority = parsed;
     }
   }
+  const selectionWeight = normalizeSelectionWeight(record?.['selection-weight']);
+  if (selectionWeight !== undefined) config.selectionWeight = selectionWeight;
   const prefix = normalizePrefix(record?.prefix);
   if (prefix) config.prefix = prefix;
   const baseUrl = record?.['base-url'];
@@ -202,6 +212,8 @@ const normalizeGeminiKeyConfig = (item: unknown): GeminiKeyConfig | null => {
       config.priority = parsed;
     }
   }
+  const selectionWeight = normalizeSelectionWeight(record?.['selection-weight']);
+  if (selectionWeight !== undefined) config.selectionWeight = selectionWeight;
   const prefix = normalizePrefix(record?.prefix);
   if (prefix) config.prefix = prefix;
   const baseUrl = record?.['base-url'];
@@ -253,6 +265,8 @@ const normalizeOpenAIProvider = (provider: unknown): OpenAIProviderConfig | null
   if (headers) result.headers = headers;
   if (models.length) result.models = models;
   if (priority !== undefined) result.priority = Number(priority);
+  const selectionWeight = normalizeSelectionWeight(provider['selection-weight']);
+  if (selectionWeight !== undefined) result.selectionWeight = selectionWeight;
   if (testModel) result.testModel = String(testModel);
   const authIndex = normalizeAuthIndex(provider['auth-index']);
   if (authIndex) result.authIndex = authIndex;

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -15,6 +15,7 @@ export interface ModelAlias {
 export interface ApiKeyEntry {
   apiKey: string;
   proxyUrl?: string;
+  selectionWeight?: number;
   authIndex?: string;
 }
 
@@ -28,6 +29,7 @@ export interface CloakConfig {
 export interface GeminiKeyConfig {
   apiKey: string;
   priority?: number;
+  selectionWeight?: number;
   prefix?: string;
   baseUrl?: string;
   proxyUrl?: string;
@@ -41,6 +43,7 @@ export interface GeminiKeyConfig {
 export interface ProviderKeyConfig {
   apiKey: string;
   priority?: number;
+  selectionWeight?: number;
   prefix?: string;
   baseUrl?: string;
   websockets?: boolean;
@@ -63,6 +66,7 @@ export interface OpenAIProviderConfig {
   headers?: Record<string, string>;
   models?: ModelAlias[];
   priority?: number;
+  selectionWeight?: number;
   testModel?: string;
   disableCooling?: boolean;
   authIndex?: string;

--- a/src/types/visualConfig.ts
+++ b/src/types/visualConfig.ts
@@ -121,7 +121,7 @@ export type VisualConfigValues = {
   quotaSwitchProject: boolean;
   quotaSwitchPreviewModel: boolean;
   quotaAntigravityCredits: boolean;
-  routingStrategy: 'round-robin' | 'fill-first';
+  routingStrategy: 'round-robin' | 'fill-first' | 'weighted-round-robin';
   routingSessionAffinity: boolean;
   routingSessionAffinityTTL: string;
   wsAuth: boolean;


### PR DESCRIPTION
## Summary

Exposes weighted routing controls in the management UI so operators can configure and inspect `weighted-round-robin` without editing YAML or auth JSON by hand.

The UI now supports selecting `weighted-round-robin` globally, editing provider-level and OpenAI-compatible per-key `selection-weight`, editing auth-file `selection_weight`, and seeing priority/weight metadata where quota and credential decisions are reviewed.

## Backend Compatibility

Requires CLIProxyAPI with weighted routing support from https://github.com/router-for-me/CLIProxyAPI/pull/3935, or a later backend release containing equivalent support, for full functionality. Against older backend builds, the panel can still load, but `weighted-round-robin` and `selection-weight` may be ignored, rejected, or absent from quota/auth-file responses.

## Details

- Adds `weighted-round-robin` to visual config editing, dashboard badges, search metadata, and i18n strings.
- Adds `selection-weight` parsing and serialization for provider lists and OpenAI-compatible API key entries.
- Adds provider/auth-file form controls with non-negative integer validation and default handling.
- Shows priority and selection weight on quota cards so weighted routing can be checked alongside quota state.
- Surfaces invalid auth-file selection weights as backend validation errors instead of silently ignoring the edited value.

## Related

- Companion backend PR: https://github.com/router-for-me/CLIProxyAPI/pull/3935.
- Supports the weighted selection request in https://github.com/router-for-me/CLIProxyAPI/issues/3836 and the converted discussion at https://github.com/router-for-me/CLIProxyAPI/discussions/3929.

## Validation

- `bun run type-check`
- `bun run lint`
- `bun run build`
- `git diff --check`