### PR TITLE
feat(quota): add auth file delete action

### DIFF
--- a/src/components/quota/QuotaCard.tsx
+++ b/src/components/quota/QuotaCard.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import type { ReactElement, ReactNode } from 'react';
 import type { TFunction } from 'i18next';
 import { Button } from '@/components/ui/Button';
+import { SelectionCheckbox } from '@/components/ui/SelectionCheckbox';
 import { IconRefreshCw } from '@/components/ui/icons';
 import type { AuthFileItem, ResolvedTheme, ThemeColors } from '@/types';
 import { TYPE_COLORS } from '@/utils/quota';
@@ -67,7 +68,10 @@ interface QuotaCardProps<TState extends QuotaStatusState> {
   defaultType: string;
   canRefresh?: boolean;
   onRefresh?: () => void;
+  selected?: boolean;
+  onToggleSelect?: (name: string, selected: boolean) => void;
   resetQuotaAction?: ReactNode;
+  deleteAuthFileAction?: ReactNode;
   renderQuotaItems: (quota: TState, t: TFunction, helpers: QuotaRenderHelpers) => ReactNode;
 }
 
@@ -81,7 +85,10 @@ export function QuotaCard<TState extends QuotaStatusState>({
   defaultType,
   canRefresh = false,
   onRefresh,
+  selected = false,
+  onToggleSelect,
   resetQuotaAction,
+  deleteAuthFileAction,
   renderQuotaItems,
 }: QuotaCardProps<TState>) {
   const { t } = useTranslation();
@@ -113,6 +120,15 @@ export function QuotaCard<TState extends QuotaStatusState>({
   return (
     <div className={`${styles.fileCard} ${cardClassName}`}>
       <div className={styles.cardHeader}>
+        {onToggleSelect && (
+          <SelectionCheckbox
+            checked={selected}
+            onChange={(value) => onToggleSelect(item.name, value)}
+            className={styles.quotaCardSelection}
+            ariaLabel={selected ? t('auth_files.batch_deselect') : t('auth_files.batch_select_all')}
+            title={selected ? t('auth_files.batch_deselect') : t('auth_files.batch_select_all')}
+          />
+        )}
         <span
           className={styles.typeBadge}
           style={{
@@ -155,7 +171,7 @@ export function QuotaCard<TState extends QuotaStatusState>({
         )}
       </div>
 
-      {(resetQuotaAction || (onRefresh && quotaStatus !== 'idle')) && (
+      {(resetQuotaAction || deleteAuthFileAction || (onRefresh && quotaStatus !== 'idle')) && (
         <div className={styles.quotaCardActions}>
           {resetQuotaAction}
           {onRefresh && quotaStatus !== 'idle' && (
@@ -173,6 +189,7 @@ export function QuotaCard<TState extends QuotaStatusState>({
               {t('auth_files.quota_refresh_single')}
             </Button>
           )}
+          {deleteAuthFileAction}
         </div>
       )}
     </div>

--- a/src/components/quota/QuotaSection.tsx
+++ b/src/components/quota/QuotaSection.tsx
@@ -7,7 +7,9 @@ import { useTranslation } from 'react-i18next';
 import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { EmptyState } from '@/components/ui/EmptyState';
+import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import { triggerHeaderRefresh } from '@/hooks/useHeaderRefresh';
+import { authFilesApi } from '@/services/api';
 import { useNotificationStore, useQuotaStore, useThemeStore } from '@/stores';
 import type { AuthFileItem, ResolvedTheme } from '@/types';
 import { getStatusFromError } from '@/utils/quota';
@@ -16,7 +18,7 @@ import type { QuotaStatusState } from './QuotaCard';
 import { useQuotaLoader } from './useQuotaLoader';
 import type { QuotaConfig } from './quotaConfigs';
 import { useGridColumns } from './useGridColumns';
-import { IconRefreshCw } from '@/components/ui/icons';
+import { IconRefreshCw, IconTrash2 } from '@/components/ui/icons';
 import styles from '@/pages/QuotaPage.module.scss';
 
 type QuotaUpdater<T> = T | ((prev: T) => T);
@@ -27,6 +29,7 @@ type ViewMode = 'paged' | 'all';
 
 const MAX_ITEMS_PER_PAGE = 25;
 const MAX_SHOW_ALL_THRESHOLD = 30;
+const PAGE_ROWS = 5;
 
 interface QuotaPaginationState<T> {
   pageSize: number;
@@ -60,8 +63,11 @@ const useQuotaPagination = <T,>(items: T[], defaultPageSize = 6): QuotaPaginatio
   }, [items, currentPage, pageSize]);
 
   const setPageSize = useCallback((size: number) => {
-    setPageSizeState(size);
-    setPage(1);
+    setPageSizeState((prev) => {
+      if (prev === size) return prev;
+      setPage(1);
+      return size;
+    });
   }, []);
 
   const goToPrev = useCallback(() => {
@@ -117,11 +123,15 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
   const [viewMode, setViewMode] = useState<ViewMode>('paged');
   const [showTooManyWarning, setShowTooManyWarning] = useState(false);
   const [resettingQuotaName, setResettingQuotaName] = useState<string | null>(null);
+  const [deletingFileNames, setDeletingFileNames] = useState<Set<string>>(() => new Set());
+  const [deletedFileNames, setDeletedFileNames] = useState<Set<string>>(() => new Set());
+  const [selectedFileNames, setSelectedFileNames] = useState<Set<string>>(() => new Set());
 
   const filteredFiles = useMemo(
-    () => files.filter((file) => config.filterFn(file)),
-    [files, config]
+    () => files.filter((file) => config.filterFn(file) && !deletedFileNames.has(file.name)),
+    [files, config, deletedFileNames]
   );
+  const selectedCount = selectedFileNames.size;
   const showAllAllowed = filteredFiles.length <= MAX_SHOW_ALL_THRESHOLD;
   const effectiveViewMode: ViewMode = viewMode === 'all' && !showAllAllowed ? 'paged' : viewMode;
 
@@ -158,10 +168,28 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
     if (effectiveViewMode === 'all') {
       setPageSize(Math.max(1, filteredFiles.length));
     } else {
-      // Paged mode: 3 rows * columns, capped to avoid oversized pages.
-      setPageSize(Math.min(columns * 3, MAX_ITEMS_PER_PAGE));
+      // Paged mode: fixed rows * columns, capped to avoid oversized pages.
+      setPageSize(Math.min(columns * PAGE_ROWS, MAX_ITEMS_PER_PAGE));
     }
   }, [effectiveViewMode, columns, filteredFiles.length, setPageSize]);
+
+  useEffect(() => {
+    setDeletedFileNames((prev) => {
+      if (prev.size === 0) return prev;
+      const fileNames = new Set(files.map((file) => file.name));
+      const next = new Set([...prev].filter((name) => fileNames.has(name)));
+      return next.size === prev.size ? prev : next;
+    });
+  }, [files]);
+
+  useEffect(() => {
+    setSelectedFileNames((prev) => {
+      if (prev.size === 0) return prev;
+      const filteredNames = new Set(filteredFiles.map((file) => file.name));
+      const next = new Set([...prev].filter((name) => filteredNames.has(name)));
+      return next.size === prev.size ? prev : next;
+    });
+  }, [filteredFiles]);
 
   const { quota, loadQuota } = useQuotaLoader(config);
 
@@ -273,6 +301,141 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
     [config, disabled, quota, resettingQuotaName, setQuota, showConfirmation, showNotification, t]
   );
 
+  const applyDeletedAuthFiles = useCallback(
+    (names: string[]) => {
+      if (names.length === 0) return;
+      setDeletedFileNames((prev) => {
+        const next = new Set(prev);
+        names.forEach((name) => next.add(name));
+        return next;
+      });
+      setSelectedFileNames((prev) => {
+        if (prev.size === 0) return prev;
+        const next = new Set(prev);
+        names.forEach((name) => next.delete(name));
+        return next;
+      });
+      setQuota((prev) => {
+        const next = { ...prev };
+        names.forEach((name) => {
+          delete next[name];
+        });
+        return next;
+      });
+    },
+    [setQuota]
+  );
+
+  const deleteAuthFile = useCallback(
+    (file: AuthFileItem) => {
+      if (disabled) return;
+      if (deletingFileNames.has(file.name)) return;
+
+      showConfirmation({
+        title: t('auth_files.delete_title', { defaultValue: 'Delete File' }),
+        message: `${t('auth_files.delete_confirm')} "${file.name}" ?`,
+        confirmText: t('common.confirm'),
+        variant: 'danger',
+        onConfirm: async () => {
+          setDeletingFileNames((prev) => new Set(prev).add(file.name));
+          try {
+            const result = await authFilesApi.deleteFile(file.name);
+            applyDeletedAuthFiles(result.files.length > 0 ? result.files : [file.name]);
+            showNotification(t('auth_files.delete_success'), 'success');
+          } catch (err: unknown) {
+            const message = err instanceof Error ? err.message : t('common.unknown_error');
+            showNotification(`${t('notification.delete_failed')}: ${message}`, 'error');
+          } finally {
+            setDeletingFileNames((prev) => {
+              const next = new Set(prev);
+              next.delete(file.name);
+              return next;
+            });
+          }
+        },
+      });
+    },
+    [applyDeletedAuthFiles, deletingFileNames, disabled, showConfirmation, showNotification, t]
+  );
+
+  const toggleSelectedFile = useCallback((name: string, selected: boolean) => {
+    setSelectedFileNames((prev) => {
+      const next = new Set(prev);
+      if (selected) {
+        next.add(name);
+      } else {
+        next.delete(name);
+      }
+      return next;
+    });
+  }, []);
+
+  const deleteSelectedAuthFiles = useCallback(() => {
+    if (disabled || selectedFileNames.size === 0) return;
+    const names = [...selectedFileNames].filter((name) => !deletingFileNames.has(name));
+    if (names.length === 0) return;
+
+    showConfirmation({
+      title: t('auth_files.batch_delete_title'),
+      message: t('auth_files.batch_delete_confirm', { count: names.length }),
+      confirmText: t('common.confirm'),
+      variant: 'danger',
+      onConfirm: async () => {
+        setDeletingFileNames((prev) => {
+          const next = new Set(prev);
+          names.forEach((name) => next.add(name));
+          return next;
+        });
+        try {
+          const result = await authFilesApi.deleteFiles(names);
+          const failedNames = new Set(result.failed.map((item) => item.name));
+          const deletedNames =
+            result.files.length > 0
+              ? result.files
+              : result.failed.length === 0
+                ? names
+                : names.filter((name) => !failedNames.has(name));
+          applyDeletedAuthFiles(deletedNames);
+          if (result.failed.length > 0) {
+            showNotification(
+              t('auth_files.delete_filtered_result_partial', {
+                success: deletedNames.length,
+                failed: result.failed.length,
+              }),
+              'warning'
+            );
+          } else {
+            showNotification(
+              t('auth_files.delete_filtered_result_success', { count: deletedNames.length }),
+              'success'
+            );
+          }
+        } catch (err: unknown) {
+          const message = err instanceof Error ? err.message : t('common.unknown_error');
+          showNotification(`${t('notification.delete_failed')}: ${message}`, 'error');
+        } finally {
+          setDeletingFileNames((prev) => {
+            const next = new Set(prev);
+            names.forEach((name) => next.delete(name));
+            return next;
+          });
+        }
+      },
+    });
+  }, [
+    applyDeletedAuthFiles,
+    deletingFileNames,
+    disabled,
+    selectedFileNames,
+    showConfirmation,
+    showNotification,
+    t,
+  ]);
+
+  const clearSelectedFiles = useCallback(() => {
+    setSelectedFileNames(new Set());
+  }, []);
+
   const titleNode = (
     <div className={styles.titleWrapper}>
       <span>{t(`${config.i18nPrefix}.title`)}</span>
@@ -330,6 +493,20 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
             {!isRefreshing && <IconRefreshCw size={16} />}
             {t('quota_management.refresh_all_credentials')}
           </Button>
+          {selectedCount > 0 && (
+            <div className={styles.quotaBatchActions}>
+              <span className={styles.quotaBatchSelected}>
+                {t('auth_files.batch_selected', { count: selectedCount })}
+              </span>
+              <Button variant="danger" size="sm" onClick={deleteSelectedAuthFiles} disabled={disabled}>
+                <IconTrash2 size={16} />
+                {t('auth_files.delete_button')}
+              </Button>
+              <Button variant="secondary" size="sm" onClick={clearSelectedFiles}>
+                {t('auth_files.batch_deselect')}
+              </Button>
+            </div>
+          )}
         </div>
       }
     >
@@ -344,8 +521,10 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
             {pageItems.map((item) => {
               const itemQuota = quota[item.name];
               const isResettingQuota = resettingQuotaName === item.name;
+              const isDeletingFile = deletingFileNames.has(item.name);
               const canUseQuotaAction =
-                !disabled && !item.disabled && itemQuota?.status !== 'loading';
+                !disabled && !item.disabled && itemQuota?.status !== 'loading' && !isDeletingFile;
+              const canDeleteAuthFile = !disabled && !isDeletingFile;
               const showResetQuotaAction =
                 itemQuota !== undefined && Boolean(config.canResetQuota?.(itemQuota));
               const resetQuotaAction =
@@ -365,6 +544,20 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
                     {t('codex_quota.reset_button')}
                   </Button>
                 ) : undefined;
+              const deleteAuthFileAction = (
+                <Button
+                  type="button"
+                  variant="danger"
+                  size="sm"
+                  className={styles.quotaDeleteAuthFileButton}
+                  onClick={() => deleteAuthFile(item)}
+                  disabled={!canDeleteAuthFile}
+                  title={t('auth_files.delete_button')}
+                  aria-label={t('auth_files.delete_button')}
+                >
+                  {isDeletingFile ? <LoadingSpinner size={14} /> : <IconTrash2 size={16} />}
+                </Button>
+              );
 
               return (
                 <QuotaCard
@@ -378,7 +571,10 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
                   defaultType={config.type}
                   canRefresh={canUseQuotaAction && !isResettingQuota}
                   onRefresh={() => void refreshQuotaForFile(item)}
+                  selected={selectedFileNames.has(item.name)}
+                  onToggleSelect={toggleSelectedFile}
                   resetQuotaAction={resetQuotaAction}
+                  deleteAuthFileAction={deleteAuthFileAction}
                   renderQuotaItems={config.renderQuotaItems}
                 />
               );

--- a/src/pages/QuotaPage.module.scss
+++ b/src/pages/QuotaPage.module.scss
@@ -424,6 +424,35 @@
   padding-top: $spacing-xs;
 }
 
+.quotaCardSelection {
+  flex: 0 0 auto;
+}
+
+.quotaBatchActions {
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-xs;
+  padding: 3px;
+  border: 1px solid color-mix(in srgb, var(--danger-color) 22%, var(--border-color));
+  border-radius: $radius-md;
+  background: color-mix(in srgb, var(--danger-color) 7%, var(--bg-secondary));
+
+  :global(.btn.btn-sm) > span {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    white-space: nowrap;
+  }
+}
+
+.quotaBatchSelected {
+  padding-inline: 8px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
 .quotaResetCreditButton:global(.btn.btn-sm),
 .quotaRefreshButton:global(.btn.btn-sm) {
   border-radius: 999px;
@@ -435,6 +464,12 @@
     gap: 6px;
     white-space: nowrap;
   }
+}
+
+.quotaDeleteAuthFileButton:global(.btn.btn-sm) {
+  width: 34px;
+  padding-inline: 0;
+  border-radius: $radius-sm;
 }
 
 .quotaError {


### PR DESCRIPTION
## 目标

在配额管理页面添加”删除“和”批量删除“按钮（勾选后删除），便于在认证文件401无效时删除对应认证文件，不用跳到认证文件页面再删除。

### 概要
- 在配额管理卡片中新增删除认证文件按钮。
- 复用现有认证文件删除相关文案，但配额卡片 UI 和逻辑保持独立。
- 删除成功后清理对应文件的配额缓存，并刷新认证文件列表。
- 删除按钮使用方形小圆角样式。

### 测试
- bun run build

删除按钮：
<img width="3000" height="1662" alt="image" src="https://github.com/user-attachments/assets/22f08a96-f1ad-4d5b-9a0c-bc26abfd0ecc" />

点击删除按钮：
<img width="3000" height="1662" alt="image" src="https://github.com/user-attachments/assets/f51d2e26-720f-491d-aacf-73c70d327c9d" />

删除成功：
<img width="3000" height="1662" alt="image" src="https://github.com/user-attachments/assets/7f423666-d622-46da-b212-57e075d30200" />

批量勾选：
<img width="3000" height="1662" alt="image" src="https://github.com/user-attachments/assets/adadd057-781a-459a-99dd-6e892902da89" />

删除提示：
<img width="706" height="292" alt="image" src="https://github.com/user-attachments/assets/87920ec8-543a-49d2-b491-d4ea4da67b45" />

删除成功：
<img width="3000" height="1662" alt="image" src="https://github.com/user-attachments/assets/10fe754b-1f67-4c64-a129-e29a38ece771" />

