### PR TITLE
fix(claude): display Fable weekly quota

### DIFF
--- a/src/components/quota/quotaConfigs.ts
+++ b/src/components/quota/quotaConfigs.ts
@@ -1058,7 +1058,8 @@ const findFableUsageLimit = (payload: ClaudeUsagePayload) => {
     const modelName = (normalizeStringValue(limit?.scope?.model?.display_name) ?? '')
       .trim()
       .toLowerCase();
-    return kind === 'weekly_scoped' && (modelName === 'fable' || modelName === 'fable 5');
+    const isFable = modelName === 'fable' || modelName === 'fable 5';
+    return kind === 'weekly_scoped' && isFable && normalizeNumberValue(limit?.percent) !== null;
   });
 
   return candidates.find((limit) => limit.is_active === true) ?? candidates[0] ?? null;

--- a/src/components/quota/quotaConfigs.ts
+++ b/src/components/quota/quotaConfigs.ts
@@ -1050,18 +1050,34 @@ const renderCodexItems = (
   return h(Fragment, null, ...nodes);
 };
 
-const buildClaudeQuotaWindows = (
+const findFableUsageLimit = (payload: ClaudeUsagePayload) => {
+  if (!Array.isArray(payload.limits)) return null;
+
+  const candidates = payload.limits.filter((limit) => {
+    const kind = (normalizeStringValue(limit?.kind) ?? '').trim().toLowerCase();
+    const modelName = (normalizeStringValue(limit?.scope?.model?.display_name) ?? '')
+      .trim()
+      .toLowerCase();
+    return kind === 'weekly_scoped' && (modelName === 'fable' || modelName === 'fable 5');
+  });
+
+  return candidates.find((limit) => limit.is_active === true) ?? candidates[0] ?? null;
+};
+
+export const buildClaudeQuotaWindows = (
   payload: ClaudeUsagePayload,
   t: TFunction
 ): ClaudeQuotaWindow[] => {
   const windows: ClaudeQuotaWindow[] = [];
+  const fableLimit = findFableUsageLimit(payload);
 
   for (const { key, id, labelKey } of CLAUDE_USAGE_WINDOW_KEYS) {
+    if (key === 'iguana_necktie' && fableLimit) continue;
     const window = payload[key as keyof ClaudeUsagePayload];
     if (!window || typeof window !== 'object' || !('utilization' in window)) continue;
-    const typedWindow = window as { utilization: number; resets_at: string };
+    const typedWindow = window as { utilization: number; resets_at: string | null };
     const usedPercent = normalizeNumberValue(typedWindow.utilization);
-    const resetLabel = formatQuotaResetTime(typedWindow.resets_at);
+    const resetLabel = formatQuotaResetTime(typedWindow.resets_at ?? undefined);
     windows.push({
       id,
       label: t(labelKey),
@@ -1069,6 +1085,19 @@ const buildClaudeQuotaWindows = (
       usedPercent,
       resetLabel,
     });
+  }
+
+  if (fableLimit) {
+    const usedPercent = normalizeNumberValue(fableLimit.percent);
+    if (usedPercent !== null) {
+      windows.push({
+        id: 'seven-day-fable',
+        label: t('claude_quota.seven_day_fable'),
+        labelKey: 'claude_quota.seven_day_fable',
+        usedPercent,
+        resetLabel: formatQuotaResetTime(fableLimit.resets_at ?? undefined),
+      });
+    }
   }
 
   return windows;

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -359,6 +359,7 @@
     "seven_day_sonnet": "7-day Sonnet",
     "seven_day_cowork": "7-day Cowork",
     "iguana_necktie": "Iguana Necktie",
+    "seven_day_fable": "7-day Fable 5",
     "extra_usage_label": "Extra Usage",
     "plan_label": "Plan",
     "plan_unknown": "Unknown",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -352,6 +352,7 @@
     "seven_day_sonnet": "7 дней Sonnet",
     "seven_day_cowork": "7 дней Cowork",
     "iguana_necktie": "Iguana Necktie",
+    "seven_day_fable": "7 дней Fable 5",
     "extra_usage_label": "Дополнительное использование",
     "plan_label": "План",
     "plan_unknown": "Неизвестно",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -359,6 +359,7 @@
     "seven_day_sonnet": "7 天 Sonnet",
     "seven_day_cowork": "7 天 Cowork",
     "iguana_necktie": "Iguana Necktie",
+    "seven_day_fable": "7 天 Fable 5",
     "extra_usage_label": "额外用量",
     "plan_label": "套餐",
     "plan_unknown": "未知",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -359,6 +359,7 @@
     "seven_day_sonnet": "7 天 Sonnet",
     "seven_day_cowork": "7 天 Cowork",
     "iguana_necktie": "Iguana Necktie",
+    "seven_day_fable": "7 天 Fable 5",
     "extra_usage_label": "額外用量",
     "plan_label": "方案",
     "plan_unknown": "未知",

--- a/src/types/quota.ts
+++ b/src/types/quota.ts
@@ -90,7 +90,21 @@ export interface CodexUsagePayload {
 // Claude API payload types
 export interface ClaudeUsageWindow {
   utilization: number;
-  resets_at: string;
+  resets_at: string | null;
+}
+
+export interface ClaudeUsageLimit {
+  kind?: string | null;
+  group?: string | null;
+  percent?: number | null;
+  resets_at?: string | null;
+  is_active?: boolean | null;
+  scope?: {
+    model?: {
+      id?: string | null;
+      display_name?: string | null;
+    } | null;
+  } | null;
 }
 
 export interface ClaudeExtraUsage {
@@ -108,6 +122,7 @@ export interface ClaudeUsagePayload {
   seven_day_sonnet?: ClaudeUsageWindow | null;
   seven_day_cowork?: ClaudeUsageWindow | null;
   iguana_necktie?: ClaudeUsageWindow | null;
+  limits?: ClaudeUsageLimit[] | null;
   extra_usage?: ClaudeExtraUsage | null;
 }
 

--- a/src/utils/quota/constants.ts
+++ b/src/utils/quota/constants.ts
@@ -118,7 +118,7 @@ export const CLAUDE_USAGE_WINDOW_KEYS = [
   { key: 'seven_day_opus', id: 'seven-day-opus', labelKey: 'claude_quota.seven_day_opus' },
   { key: 'seven_day_sonnet', id: 'seven-day-sonnet', labelKey: 'claude_quota.seven_day_sonnet' },
   { key: 'seven_day_cowork', id: 'seven-day-cowork', labelKey: 'claude_quota.seven_day_cowork' },
-  { key: 'iguana_necktie', id: 'iguana-necktie', labelKey: 'claude_quota.iguana_necktie' },
+  { key: 'iguana_necktie', id: 'seven-day-fable', labelKey: 'claude_quota.seven_day_fable' },
 ] as const;
 
 // Codex API configuration

--- a/tests/claudeFableQuota.test.ts
+++ b/tests/claudeFableQuota.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from 'bun:test';
+import type { TFunction } from 'i18next';
+import { buildClaudeQuotaWindows } from '@/components/quota/quotaConfigs';
+import type { ClaudeUsagePayload } from '@/types';
+import { formatQuotaResetTime } from '@/utils/quota';
+
+const t = ((key: string) => key) as TFunction;
+const modernReset = '2026-07-27T10:00:00.000000+00:00';
+const legacyReset = '2026-07-28T10:00:00.000000+00:00';
+
+describe('Claude Fable quota', () => {
+  test('builds a Fable window from the modern scoped limits payload', () => {
+    const windows = buildClaudeQuotaWindows(
+      {
+        limits: [
+          {
+            kind: 'weekly_scoped',
+            group: 'weekly',
+            percent: 64,
+            resets_at: modernReset,
+            is_active: true,
+            scope: { model: { id: null, display_name: 'Fable' } },
+          },
+        ],
+      },
+      t
+    );
+
+    expect(windows).toEqual([
+      {
+        id: 'seven-day-fable',
+        label: 'claude_quota.seven_day_fable',
+        labelKey: 'claude_quota.seven_day_fable',
+        usedPercent: 64,
+        resetLabel: formatQuotaResetTime(modernReset),
+      },
+    ]);
+  });
+
+  test('falls back to the legacy Fable field', () => {
+    const windows = buildClaudeQuotaWindows(
+      {
+        iguana_necktie: {
+          utilization: 41,
+          resets_at: legacyReset,
+        },
+      },
+      t
+    );
+
+    expect(windows).toEqual([
+      {
+        id: 'seven-day-fable',
+        label: 'claude_quota.seven_day_fable',
+        labelKey: 'claude_quota.seven_day_fable',
+        usedPercent: 41,
+        resetLabel: formatQuotaResetTime(legacyReset),
+      },
+    ]);
+  });
+
+  test('prefers the active modern field without rendering a duplicate', () => {
+    const windows = buildClaudeQuotaWindows(
+      {
+        iguana_necktie: {
+          utilization: 41,
+          resets_at: legacyReset,
+        },
+        limits: [
+          {
+            kind: 'weekly_scoped',
+            percent: 12,
+            resets_at: legacyReset,
+            is_active: false,
+            scope: { model: { display_name: 'Fable 5' } },
+          },
+          {
+            kind: 'weekly_scoped',
+            percent: 64,
+            resets_at: modernReset,
+            is_active: true,
+            scope: { model: { display_name: 'Fable' } },
+          },
+        ],
+      },
+      t
+    );
+
+    expect(windows).toHaveLength(1);
+    expect(windows[0]).toMatchObject({
+      id: 'seven-day-fable',
+      usedPercent: 64,
+      resetLabel: formatQuotaResetTime(modernReset),
+    });
+  });
+
+  test('ignores malformed and unrelated limits while preserving standard windows', () => {
+    const payload = {
+      five_hour: { utilization: 10, resets_at: null },
+      seven_day: { utilization: 20, resets_at: legacyReset },
+      limits: [
+        null,
+        { kind: 'weekly_scoped', percent: 35, scope: { model: { display_name: 'Sonnet' } } },
+        { kind: 'session', percent: 50, scope: { model: { display_name: 'Fable' } } },
+        { kind: 'weekly_scoped', percent: null, scope: { model: { display_name: 'Fable' } } },
+      ],
+    } as unknown as ClaudeUsagePayload;
+
+    const windows = buildClaudeQuotaWindows(payload, t);
+
+    expect(windows.map(({ id, usedPercent }) => ({ id, usedPercent }))).toEqual([
+      { id: 'five-hour', usedPercent: 10 },
+      { id: 'seven-day', usedPercent: 20 },
+    ]);
+  });
+});

--- a/tests/claudeFableQuota.test.ts
+++ b/tests/claudeFableQuota.test.ts
@@ -59,6 +59,37 @@ describe('Claude Fable quota', () => {
     ]);
   });
 
+  test('falls back to the legacy field when the modern percent is invalid', () => {
+    const windows = buildClaudeQuotaWindows(
+      {
+        iguana_necktie: {
+          utilization: 41,
+          resets_at: legacyReset,
+        },
+        limits: [
+          {
+            kind: 'weekly_scoped',
+            percent: null,
+            resets_at: modernReset,
+            is_active: true,
+            scope: { model: { display_name: 'Fable' } },
+          },
+        ],
+      },
+      t
+    );
+
+    expect(windows).toEqual([
+      {
+        id: 'seven-day-fable',
+        label: 'claude_quota.seven_day_fable',
+        labelKey: 'claude_quota.seven_day_fable',
+        usedPercent: 41,
+        resetLabel: formatQuotaResetTime(legacyReset),
+      },
+    ]);
+  });
+
   test('prefers the active modern field without rendering a duplicate', () => {
     const windows = buildClaudeQuotaWindows(
       {
@@ -92,6 +123,40 @@ describe('Claude Fable quota', () => {
       usedPercent: 64,
       resetLabel: formatQuotaResetTime(modernReset),
     });
+  });
+
+  test('uses a valid modern candidate when the preferred candidate is invalid', () => {
+    const windows = buildClaudeQuotaWindows(
+      {
+        limits: [
+          {
+            kind: 'weekly_scoped',
+            percent: null,
+            resets_at: legacyReset,
+            is_active: true,
+            scope: { model: { display_name: 'Fable' } },
+          },
+          {
+            kind: 'weekly_scoped',
+            percent: 64,
+            resets_at: modernReset,
+            is_active: false,
+            scope: { model: { display_name: 'Fable' } },
+          },
+        ],
+      },
+      t
+    );
+
+    expect(windows).toEqual([
+      {
+        id: 'seven-day-fable',
+        label: 'claude_quota.seven_day_fable',
+        labelKey: 'claude_quota.seven_day_fable',
+        usedPercent: 64,
+        resetLabel: formatQuotaResetTime(modernReset),
+      },
+    ]);
   });
 
   test('ignores malformed and unrelated limits while preserving standard windows', () => {


### PR DESCRIPTION
## Summary

- parse Anthropic current `limits[]` response for active `weekly_scoped` Fable usage
- preserve `iguana_necktie` as a legacy fallback without duplicate quota rows
- label the meter as `7-day Fable 5` in all supported locales
- tolerate null, malformed, and unrelated scoped limits

## Reproduction

Current Claude Max OAuth usage responses return Fable as a `weekly_scoped` entry in `limits[]`. The existing parser only checks top-level usage windows, so this valid meter is omitted.

## Verification

- `bun run verify`
- 71 tests passing
- production single-file build completed
- verified against three active Claude Max OAuth accounts
- verified one Fable row per account with remaining percentage and reset time
- verified no browser console errors