### PR TITLE
fix(auth-files): show Unavailable when OAuth credential is unusable

### DIFF
--- a/src/features/authFiles/components/AuthFileCard.tsx
+++ b/src/features/authFiles/components/AuthFileCard.tsx
@@ -29,6 +29,7 @@ import {
   getThemeSurfaceIconBackground,
   getTypeColor,
   getTypeLabel,
+  isAuthFileUnavailable,
   isRuntimeOnlyAuthFile,
   isThemeSurfaceIconProvider,
   normalizeProviderKey,
@@ -134,6 +135,7 @@ export function AuthFileCard(props: AuthFileCardProps) {
   const rawStatusMessage = getAuthFileStatusMessage(file);
   const hasStatusWarning =
     Boolean(rawStatusMessage) && !HEALTHY_STATUS_MESSAGES.has(rawStatusMessage.toLowerCase());
+  const isUnavailable = isAuthFileUnavailable(file);
 
   const priorityValue = parsePriorityValue(file.priority ?? file['priority']);
   const noteValue = typeof file.note === 'string' ? file.note.trim() : '';
@@ -141,16 +143,18 @@ export function AuthFileCard(props: AuthFileCardProps) {
     ? t('auth_files.type_virtual') || '虚拟认证文件'
     : file.disabled
       ? t('auth_files.health_status_disabled')
-      : hasStatusWarning
-        ? t('auth_files.health_status_warning')
-        : rawStatusMessage
-          ? t('auth_files.health_status_healthy')
-          : t('auth_files.status_toggle_label');
+      : isUnavailable
+        ? t('auth_files.health_status_unavailable')
+        : hasStatusWarning
+          ? t('auth_files.health_status_warning')
+          : rawStatusMessage
+            ? t('auth_files.health_status_healthy')
+            : t('auth_files.status_toggle_label');
   const stateBadgeClass = isRuntimeOnly
     ? styles.stateBadgeVirtual
     : file.disabled
       ? styles.stateBadgeDisabled
-      : hasStatusWarning
+      : isUnavailable || hasStatusWarning
         ? styles.stateBadgeWarning
         : styles.stateBadgeActive;
 

--- a/src/features/authFiles/constants.ts
+++ b/src/features/authFiles/constants.ts
@@ -174,6 +174,8 @@ export const buildOAuthProviderOptions = (values: Iterable<unknown>): string[] =
   return [...OAUTH_PROVIDER_PRESETS, ...extraList];
 };
 
+const UNAVAILABLE_RUNTIME_STATUSES = new Set(['error', 'unavailable', 'failed']);
+
 export const getAuthFileStatusMessage = (file: AuthFileItem): string => {
   const raw = file['status_message'] ?? file.statusMessage;
   if (typeof raw === 'string') return raw.trim();
@@ -181,8 +183,23 @@ export const getAuthFileStatusMessage = (file: AuthFileItem): string => {
   return String(raw).trim();
 };
 
+export const getAuthFileRuntimeStatus = (file: AuthFileItem): string => {
+  const raw = file.status;
+  return typeof raw === 'string' ? raw.trim().toLowerCase() : '';
+};
+
+/** True when the backend marks this credential unusable (cooldown / auth failure). */
+export const isAuthFileUnavailable = (file: AuthFileItem): boolean => {
+  if (file.unavailable === true) return true;
+  return UNAVAILABLE_RUNTIME_STATUSES.has(getAuthFileRuntimeStatus(file));
+};
+
 export const hasAuthFileStatusMessage = (file: AuthFileItem): boolean =>
   getAuthFileStatusMessage(file).length > 0;
+
+/** Problem filter: unavailable runtime state or any non-empty status message. */
+export const isAuthFileProblem = (file: AuthFileItem): boolean =>
+  isAuthFileUnavailable(file) || hasAuthFileStatusMessage(file);
 
 export const getTypeLabel = (t: TFunction, type: string): string => {
   const providerKey = normalizeProviderKey(type);

--- a/src/features/authFiles/hooks/useAuthFilesData.ts
+++ b/src/features/authFiles/hooks/useAuthFilesData.ts
@@ -10,7 +10,7 @@ import { MAX_AUTH_FILE_SIZE } from '@/utils/constants';
 import { downloadBlob } from '@/utils/download';
 import {
   getTypeLabel,
-  hasAuthFileStatusMessage,
+  isAuthFileProblem,
   isRuntimeOnlyAuthFile,
   normalizeProviderKey,
   supportsAuthFileManualRefresh,
@@ -323,7 +323,7 @@ export function useAuthFilesData(): UseAuthFilesDataResult {
                 ) {
                   return false;
                 }
-                if (isProblemOnly && !hasAuthFileStatusMessage(file)) return false;
+                if (isProblemOnly && !isAuthFileProblem(file)) return false;
                 if (isDisabledOnly && file.disabled !== true) return false;
                 if (isEnabledOnly && file.disabled === true) return false;
                 return true;

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -176,6 +176,7 @@
     "health_status_label": "Health",
     "health_status_healthy": "Healthy",
     "health_status_warning": "Warning",
+    "health_status_unavailable": "Unavailable",
     "health_status_disabled": "Disabled",
     "download_button": "Download",
     "manual_refresh_button": "Refresh OAuth credential",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -175,6 +175,7 @@
     "health_status_label": "Состояние",
     "health_status_healthy": "Нормально",
     "health_status_warning": "Предупреждение",
+    "health_status_unavailable": "Недоступно",
     "health_status_disabled": "Отключено",
     "download_button": "Скачать",
     "manual_refresh_button": "Обновить учётные данные OAuth",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -176,6 +176,7 @@
     "health_status_label": "健康状态",
     "health_status_healthy": "健康",
     "health_status_warning": "警告",
+    "health_status_unavailable": "不可用",
     "health_status_disabled": "已停用",
     "download_button": "下载",
     "manual_refresh_button": "刷新 OAuth 凭证",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -176,6 +176,7 @@
     "health_status_label": "健康狀態",
     "health_status_healthy": "健康",
     "health_status_warning": "警告",
+    "health_status_unavailable": "無法使用",
     "health_status_disabled": "已停用",
     "download_button": "下載",
     "manual_refresh_button": "重新整理 OAuth 憑證",

--- a/src/pages/AuthFilesPage.tsx
+++ b/src/pages/AuthFilesPage.tsx
@@ -34,7 +34,7 @@ import {
   getThemeSurfaceIconBackground,
   getTypeColor,
   getTypeLabel,
-  hasAuthFileStatusMessage,
+  isAuthFileProblem,
   isRuntimeOnlyAuthFile,
   isThemeSurfaceIconProvider,
   normalizeProviderKey,
@@ -416,7 +416,7 @@ export function AuthFilesPage() {
       files.filter((file) => {
         if (enabledOnly && file.disabled === true) return false;
         if (disabledOnly && file.disabled !== true) return false;
-        if (problemOnly && !hasAuthFileStatusMessage(file)) return false;
+        if (problemOnly && !isAuthFileProblem(file)) return false;
         return true;
       }),
     [disabledOnly, enabledOnly, files, problemOnly]

--- a/tests/authFileHealthStatus.test.ts
+++ b/tests/authFileHealthStatus.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from 'bun:test';
+import {
+  getAuthFileRuntimeStatus,
+  hasAuthFileStatusMessage,
+  isAuthFileProblem,
+  isAuthFileUnavailable,
+} from '@/features/authFiles/constants';
+import type { AuthFileItem } from '@/types';
+
+const baseFile = (overrides: Partial<AuthFileItem> = {}): AuthFileItem => ({
+  name: 'claude-hello@example.com.json',
+  type: 'claude',
+  disabled: false,
+  ...overrides,
+});
+
+test('isAuthFileUnavailable honors unavailable flag and error status', () => {
+  expect(isAuthFileUnavailable(baseFile({ unavailable: true }))).toBe(true);
+  expect(isAuthFileUnavailable(baseFile({ status: 'error' }))).toBe(true);
+  expect(isAuthFileUnavailable(baseFile({ status: 'Unavailable' }))).toBe(true);
+  expect(isAuthFileUnavailable(baseFile({ status: 'failed' }))).toBe(true);
+  expect(isAuthFileUnavailable(baseFile({ status: 'ok' }))).toBe(false);
+  expect(isAuthFileUnavailable(baseFile())).toBe(false);
+});
+
+test('getAuthFileRuntimeStatus normalizes status text', () => {
+  expect(getAuthFileRuntimeStatus(baseFile({ status: ' Error ' }))).toBe('error');
+  expect(getAuthFileRuntimeStatus(baseFile())).toBe('');
+});
+
+test('isAuthFileProblem includes unavailable credentials without status_message', () => {
+  const unavailableOnly = baseFile({ unavailable: true });
+  expect(hasAuthFileStatusMessage(unavailableOnly)).toBe(false);
+  expect(isAuthFileProblem(unavailableOnly)).toBe(true);
+
+  const messageOnly = baseFile({
+    status_message: '{"type":"error","error":{"message":"Invalid bearer token"}}',
+  });
+  expect(isAuthFileProblem(messageOnly)).toBe(true);
+
+  expect(isAuthFileProblem(baseFile())).toBe(false);
+});


### PR DESCRIPTION
## Summary
Auth Files health badges now look at `unavailable` and `status` (`error` / `unavailable` / `failed`), not just `disabled` + `status_message`. Dead OAuth credentials show **Unavailable** instead of green Active/Enabled.

The Problem filter and bulk-delete-problem paths use the same check, so unavailable files without a `status_message` show up there too.

Also adds `health_status_unavailable` for en / zh-CN / zh-TW / ru, plus a small unit test.

## Motivation
CLIProxyAPI can return something like:

```json
{ "disabled": false, "unavailable": true, "status": "error", "status_message": "...Invalid bearer token..." }
```

The UI ignored `unavailable` / `status`, so a broken Claude OAuth session still looked healthy.

## Test plan
- [x] `bun test tests/authFileHealthStatus.test.ts`
- [ ] Auth Files: credential with `unavailable: true` / `status: error` shows Unavailable (warning style), not Active/Enabled
- [ ] Problem filter includes that credential
- [ ] Healthy, enabled credential still shows Healthy/Enabled