### PR TITLE
fix(quota): render per-model Claude weekly limits (Fable) from limits[]

### DIFF
--- a/src/components/quota/quotaConfigs.ts
+++ b/src/components/quota/quotaConfigs.ts
@@ -1050,7 +1050,7 @@ const renderCodexItems = (
   return h(Fragment, null, ...nodes);
 };
 
-const buildClaudeQuotaWindows = (
+export const buildClaudeQuotaWindows = (
   payload: ClaudeUsagePayload,
   t: TFunction
 ): ClaudeQuotaWindow[] => {
@@ -1068,6 +1068,35 @@ const buildClaudeQuotaWindows = (
       labelKey,
       usedPercent,
       resetLabel,
+    });
+  }
+
+  // Per-model weekly limits (Fable, and potentially others) are reported in the
+  // `limits` array as `weekly_scoped` entries rather than as top-level keys. The
+  // legacy per-model keys above now come back null, so without this the rows are
+  // silently dropped — and Fable has no legacy key at all.
+  const renderedModels = new Set(
+    windows.map((existing) => existing.id.replace(/^seven-day-/, '').toLowerCase())
+  );
+
+  for (const limit of payload.limits ?? []) {
+    if (!limit || limit.kind !== 'weekly_scoped') continue;
+
+    const displayName = limit.scope?.model?.display_name?.trim();
+    if (!displayName) continue;
+
+    const slug = displayName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+    if (!slug || renderedModels.has(slug)) continue;
+    renderedModels.add(slug);
+
+    windows.push({
+      id: `seven-day-${slug}`,
+      label: t('claude_quota.weekly_scoped', {
+        model: displayName,
+        defaultValue: `7-day ${displayName}`,
+      }),
+      usedPercent: normalizeNumberValue(limit.percent),
+      resetLabel: formatQuotaResetTime(limit.resets_at ?? undefined),
     });
   }
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -355,6 +355,7 @@
     "five_hour": "5-hour limit",
     "seven_day": "7-day limit",
     "seven_day_oauth_apps": "7-day OAuth apps",
+    "weekly_scoped": "7-day {{model}}",
     "seven_day_opus": "7-day Opus",
     "seven_day_sonnet": "7-day Sonnet",
     "seven_day_cowork": "7-day Cowork",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -348,6 +348,7 @@
     "five_hour": "Лимит на 5 часов",
     "seven_day": "Лимит на 7 дней",
     "seven_day_oauth_apps": "7 дней OAuth приложения",
+    "weekly_scoped": "7 дней {{model}}",
     "seven_day_opus": "7 дней Opus",
     "seven_day_sonnet": "7 дней Sonnet",
     "seven_day_cowork": "7 дней Cowork",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -355,6 +355,7 @@
     "five_hour": "5 小时限额",
     "seven_day": "7 天限额",
     "seven_day_oauth_apps": "7 天 OAuth 应用",
+    "weekly_scoped": "7 天 {{model}}",
     "seven_day_opus": "7 天 Opus",
     "seven_day_sonnet": "7 天 Sonnet",
     "seven_day_cowork": "7 天 Cowork",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -355,6 +355,7 @@
     "five_hour": "5 小時限額",
     "seven_day": "7 天限額",
     "seven_day_oauth_apps": "7 天 OAuth 應用",
+    "weekly_scoped": "7 天 {{model}}",
     "seven_day_opus": "7 天 Opus",
     "seven_day_sonnet": "7 天 Sonnet",
     "seven_day_cowork": "7 天 Cowork",

--- a/src/types/quota.ts
+++ b/src/types/quota.ts
@@ -93,6 +93,25 @@ export interface ClaudeUsageWindow {
   resets_at: string;
 }
 
+/**
+ * Entry in the `limits` array returned by /api/oauth/usage.
+ *
+ * Per-model weekly quota is reported here (`kind: 'weekly_scoped'`, with the tier
+ * named by `scope.model.display_name`) rather than via dedicated top-level keys.
+ * Newer tiers such as Fable have no top-level key at all, so this array is the
+ * only place their utilization is exposed.
+ */
+export interface ClaudeUsageScopedLimit {
+  kind?: string | null;
+  group?: string | null;
+  percent?: number | null;
+  resets_at?: string | null;
+  scope?: {
+    model?: { id?: string | null; display_name?: string | null } | null;
+    surface?: string | null;
+  } | null;
+}
+
 export interface ClaudeExtraUsage {
   is_enabled: boolean;
   monthly_limit: number;
@@ -108,6 +127,7 @@ export interface ClaudeUsagePayload {
   seven_day_sonnet?: ClaudeUsageWindow | null;
   seven_day_cowork?: ClaudeUsageWindow | null;
   iguana_necktie?: ClaudeUsageWindow | null;
+  limits?: ClaudeUsageScopedLimit[] | null;
   extra_usage?: ClaudeExtraUsage | null;
 }
 

--- a/tests/claudeScopedQuotaWindows.test.ts
+++ b/tests/claudeScopedQuotaWindows.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from 'bun:test';
+import type { TFunction } from 'i18next';
+import { buildClaudeQuotaWindows } from '../src/components/quota/quotaConfigs';
+import type { ClaudeUsagePayload } from '../src/types/quota';
+
+// Minimal translate stub: echoes the key, honouring defaultValue + {{model}}.
+const t = ((key: string, options?: Record<string, unknown>) => {
+  const fallback = options?.defaultValue;
+  if (typeof fallback === 'string') return fallback;
+  return key;
+}) as unknown as TFunction;
+
+// Shape returned by /api/oauth/usage on a Max plan: the legacy per-model keys are
+// null, and the real per-model utilization lives in `limits`.
+const payloadWithScopedFable: ClaudeUsagePayload = {
+  five_hour: { utilization: 0, resets_at: '2026-08-01T12:00:00Z' },
+  seven_day: { utilization: 73, resets_at: '2026-08-02T03:59:59Z' },
+  seven_day_opus: null,
+  seven_day_sonnet: null,
+  limits: [
+    { kind: 'session', percent: 0, resets_at: null, scope: null },
+    { kind: 'weekly_all', percent: 73, resets_at: '2026-08-02T03:59:59Z', scope: null },
+    {
+      kind: 'weekly_scoped',
+      percent: 100,
+      resets_at: '2026-08-02T03:59:59Z',
+      scope: { model: { id: null, display_name: 'Fable' } },
+    },
+  ],
+};
+
+describe('Claude per-model quota windows', () => {
+  test('renders a weekly_scoped limit that has no legacy top-level key', () => {
+    const windows = buildClaudeQuotaWindows(payloadWithScopedFable, t);
+    const fable = windows.find((w) => w.id === 'seven-day-fable');
+
+    expect(fable).toBeDefined();
+    expect(fable?.usedPercent).toBe(100);
+    expect(fable?.label).toBe('7-day Fable');
+  });
+
+  test('keeps the existing top-level windows intact', () => {
+    const windows = buildClaudeQuotaWindows(payloadWithScopedFable, t);
+
+    expect(windows.find((w) => w.id === 'five-hour')?.usedPercent).toBe(0);
+    expect(windows.find((w) => w.id === 'seven-day')?.usedPercent).toBe(73);
+  });
+
+  test('does not duplicate a model already covered by a legacy key', () => {
+    const windows = buildClaudeQuotaWindows(
+      {
+        seven_day_opus: { utilization: 40, resets_at: '2026-08-02T03:59:59Z' },
+        limits: [
+          {
+            kind: 'weekly_scoped',
+            percent: 40,
+            resets_at: '2026-08-02T03:59:59Z',
+            scope: { model: { id: null, display_name: 'Opus' } },
+          },
+        ],
+      },
+      t
+    );
+
+    expect(windows.filter((w) => w.id === 'seven-day-opus')).toHaveLength(1);
+  });
+
+  test('ignores non-scoped entries and entries without a model name', () => {
+    const windows = buildClaudeQuotaWindows(
+      {
+        limits: [
+          { kind: 'weekly_all', percent: 50, resets_at: null, scope: null },
+          { kind: 'weekly_scoped', percent: 10, resets_at: null, scope: { model: null } },
+          { kind: 'weekly_scoped', percent: 10, resets_at: null, scope: { model: { display_name: '  ' } } },
+        ],
+      },
+      t
+    );
+
+    expect(windows).toHaveLength(0);
+  });
+
+  test('tolerates a missing limits array', () => {
+    const windows = buildClaudeQuotaWindows(
+      { seven_day: { utilization: 12, resets_at: '2026-08-02T03:59:59Z' } },
+      t
+    );
+
+    expect(windows).toHaveLength(1);
+    expect(windows[0]?.id).toBe('seven-day');
+  });
+});


### PR DESCRIPTION
Fixes #359.

### Problem

The Claude quota card never renders per-model weekly limits. Anthropic moved that data out of the legacy top-level keys and into a `limits[]` array; the old keys now come back `null`, so `buildClaudeQuotaWindows`' `utilization` guard drops every per-model row.

Live response from a Max plan (fetched through CPA's own `api-call` proxy, so this is exactly what the panel receives):

```json
{
  "five_hour":  { "utilization": 0.0,  "resets_at": null },
  "seven_day":  { "utilization": 73.0, "resets_at": "2026-08-02T03:59:59Z" },

  "seven_day_opus": null,          // <-- CLAUDE_USAGE_WINDOW_KEYS reads these
  "seven_day_sonnet": null,        // <-- all null now
  "seven_day_cowork": null,
  "iguana_necktie": null,

  "limits": [
    { "kind": "session",       "percent": 0,  "scope": null },
    { "kind": "weekly_all",    "percent": 73, "scope": null,
      "resets_at": "2026-08-02T03:59:59Z" },
    { "kind": "weekly_scoped", "percent": 100,
      "resets_at": "2026-08-02T03:59:59Z",
      "scope": { "model": { "id": null, "display_name": "Fable" } } }
  ]
}
```

Two things worth calling out:

- **Fable has no legacy key at all** — there is no `seven_day_fable`, so `limits[]` is the only way it can ever be surfaced.
- **The card is actively misleading, not just incomplete.** The account above renders a comfortable 73% on the 7-day bar while its Fable sub-limit is at 100% — every Fable request on that credential is being rejected. The page reports headroom that doesn't exist for the model you're actually calling.

### Change

Derive the missing windows from `limits[]` after the existing loop: take `kind === 'weekly_scoped'` entries, label them from `scope.model.display_name`, map `percent` → `usedPercent` and carry `resets_at` through.

- **Additive.** The legacy keys are still read first and still win; nothing about the existing rows changes.
- **De-duplicated.** A model already rendered by a legacy key (e.g. `seven-day-opus`) won't get a second row if it also appears scoped.
- **Forward-compatible.** Because the row is keyed off `display_name`, a future tier appears with no further code change — and the existing `seven_day_opus` / `seven_day_sonnet` descriptors light up again automatically if those are ever scoped.
- **Defensive.** Missing `limits`, null `scope.model`, and blank display names are all skipped.

`buildClaudeQuotaWindows` is now exported so the behaviour can be unit-tested directly; it is otherwise unchanged.

### i18n

Adds `claude_quota.weekly_scoped` (`"7-day {{model}}"`) to all four locales, with a `defaultValue` fallback so an untranslated locale still renders sensibly.

### Tests

Adds `tests/claudeScopedQuotaWindows.test.ts` — 5 cases: scoped row rendered, existing windows untouched, no duplicate against a legacy key, malformed/non-scoped entries ignored, missing `limits` tolerated.

`bun run verify` passes: **72 tests, 0 fail**, lint clean, production build succeeds.

### Verification

Built this branch and installed the resulting `dist/index.html` as the CPA management panel (v7.2.100) against live Max-plan credentials.

Replaying the builder against the real payload above yields:

```
five-hour        usedPercent 0     -> 100% remaining
seven-day        usedPercent 73    ->  27% remaining
seven-day-fable  usedPercent 100   ->   0% remaining   <-- new
```

The first two match the pre-change output exactly, so the existing rows are untouched — that equivalence is pinned by the "keeps the existing top-level windows intact" test rather than left to inspection.
