### PR TITLE
fix(providers): support Anthropic-prefixed model discovery

### DIFF
--- a/src/services/api/models.ts
+++ b/src/services/api/models.ts
@@ -43,13 +43,26 @@ const buildV1ModelsEndpoint = (baseUrl: string): string => {
   return `${trimmed}/v1/models`;
 };
 
-const buildClaudeModelsEndpoint = (baseUrl: string): string => {
+const normalizeClaudeEndpointBase = (baseUrl: string): string => {
   const normalized = normalizeApiBase(baseUrl);
   const fallback = normalized || DEFAULT_CLAUDE_BASE_URL;
   let trimmed = fallback.replace(/\/+$/g, '');
   trimmed = trimmed.replace(/\/v1\/models$/i, '');
   trimmed = trimmed.replace(/\/v1(?:\/.*)?$/i, '');
-  return `${trimmed}/v1/models`;
+  return trimmed;
+};
+
+const buildClaudeModelsEndpoints = (baseUrl: string): string[] => {
+  const endpointBase = normalizeClaudeEndpointBase(baseUrl);
+  const primary = `${endpointBase}/v1/models`;
+  if (!/\/anthropic$/i.test(endpointBase)) {
+    return [primary];
+  }
+
+  // Multi-protocol gateways may expose Messages below /anthropic while keeping
+  // model discovery at the sibling /v1/models endpoint.
+  const sibling = `${endpointBase.replace(/\/anthropic$/i, '')}/v1/models`;
+  return sibling === primary ? [primary] : [primary, sibling];
 };
 
 const buildGeminiModelsEndpoint = (baseUrl: string): string => {
@@ -188,7 +201,8 @@ export const modelsApi = {
     headers: Record<string, string> = {},
     authIndex?: string
   ) {
-    const endpoint = buildClaudeModelsEndpoint(baseUrl);
+    const endpoints = buildClaudeModelsEndpoints(baseUrl);
+    const endpoint = endpoints[0];
     if (!endpoint) {
       throw new Error('Invalid base url');
     }
@@ -209,17 +223,26 @@ export const modelsApi = {
       resolvedHeaders['anthropic-version'] = DEFAULT_ANTHROPIC_VERSION;
     }
 
-    const signature = buildRequestSignature(endpoint, resolvedHeaders, trimmedAuthIndex);
+    const signature = buildRequestSignature(endpoints.join('|'), resolvedHeaders, trimmedAuthIndex);
     const existing = CLAUDE_MODELS_IN_FLIGHT.get(signature);
     if (existing) return existing;
 
     const request = (async () => {
-      const result = await apiCallApi.request({
+      let result = await apiCallApi.request({
         authIndex: trimmedAuthIndex,
         method: 'GET',
         url: endpoint,
         header: Object.keys(resolvedHeaders).length ? resolvedHeaders : undefined,
       });
+
+      if (result.statusCode === 404 && endpoints[1]) {
+        result = await apiCallApi.request({
+          authIndex: trimmedAuthIndex,
+          method: 'GET',
+          url: endpoints[1],
+          header: Object.keys(resolvedHeaders).length ? resolvedHeaders : undefined,
+        });
+      }
 
       if (result.statusCode < 200 || result.statusCode >= 300) {
         throw new Error(getApiCallErrorMessage(result));

--- a/tests/claudeModelDiscovery.test.ts
+++ b/tests/claudeModelDiscovery.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { buildClaudeMessagesEndpoint } from '../src/components/providers/utils';
+import { apiCallApi } from '../src/services/api/apiCall';
+import { modelsApi } from '../src/services/api/models';
+
+const originalApiCallRequest = apiCallApi.request;
+
+afterEach(() => {
+  apiCallApi.request = originalApiCallRequest;
+});
+
+describe('Claude model discovery', () => {
+  test('falls back from an Anthropic protocol prefix to the sibling models endpoint', async () => {
+    const requestedUrls: string[] = [];
+    apiCallApi.request = (async (payload) => {
+      requestedUrls.push(payload.url);
+      if (requestedUrls.length === 1) {
+        return { statusCode: 404, header: {}, bodyText: 'Not Found', body: null };
+      }
+      return {
+        statusCode: 200,
+        header: {},
+        bodyText: '',
+        body: { data: [{ id: 'deepseek-v4-flash' }] },
+      };
+    }) as typeof apiCallApi.request;
+
+    const models = await modelsApi.fetchClaudeModelsViaApiCall(
+      'https://api.deepseek.com/anthropic',
+      'test-key'
+    );
+
+    expect(requestedUrls).toEqual([
+      'https://api.deepseek.com/anthropic/v1/models',
+      'https://api.deepseek.com/v1/models',
+    ]);
+    expect(models).toEqual([{ name: 'deepseek-v4-flash' }]);
+    expect(buildClaudeMessagesEndpoint('https://api.deepseek.com/anthropic')).toBe(
+      'https://api.deepseek.com/anthropic/v1/messages'
+    );
+  });
+
+  test('does not bypass the configured base path for non-404 failures', async () => {
+    const requestedUrls: string[] = [];
+    apiCallApi.request = (async (payload) => {
+      requestedUrls.push(payload.url);
+      return { statusCode: 401, header: {}, bodyText: '', body: null };
+    }) as typeof apiCallApi.request;
+
+    await expect(
+      modelsApi.fetchClaudeModelsViaApiCall('https://gateway.example.com/anthropic', 'test-key')
+    ).rejects.toThrow('HTTP 401');
+
+    expect(requestedUrls).toEqual(['https://gateway.example.com/anthropic/v1/models']);
+  });
+});


### PR DESCRIPTION
## Summary

- Retry Claude model discovery against the sibling `/v1/models` endpoint when an Anthropic-prefixed endpoint returns 404.
- Keep the configured `/anthropic` prefix for Messages connectivity tests.
- Add regression coverage for the DeepSeek endpoint shape and non-404 failures.

## Root cause

Claude provider model discovery always appended `/v1/models` to the configured base URL. With DeepSeek's documented Anthropic base URL, `https://api.deepseek.com/anthropic`, this produced `https://api.deepseek.com/anthropic/v1/models`. DeepSeek exposes model discovery at `https://api.deepseek.com/v1/models`, while the Messages API still requires the `/anthropic` prefix.

## Behavior after this change

The configured endpoint remains the first model-discovery attempt. If it returns 404 and its path ends in `/anthropic`, discovery retries the sibling `/v1/models` URL on the same origin. Authentication and rate-limit failures are returned unchanged and do not trigger fallback.

## Verification

- `bun test tests/claudeModelDiscovery.test.ts`
- `bun run verify` (423 tests, ESLint, TypeScript, and production build)
- `bunx prettier --check src/services/api/models.ts tests/claudeModelDiscovery.test.ts`

No screenshot is included because this change has no visual UI impact.
