### PR TITLE
feat(api-keys): add optional display names for API keys

### DIFF
--- a/src/features/config/components/blocks/ApiKeysCardEditor.tsx
+++ b/src/features/config/components/blocks/ApiKeysCardEditor.tsx
@@ -11,25 +11,29 @@ import { isValidApiKeyCharset } from '@/utils/validation';
 import { ApiKeyStrengthMeter } from './ApiKeyStrengthMeter';
 import styles from './Blocks.module.scss';
 
+const splitLines = (text: string): string[] =>
+  text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+
 export const ApiKeysCardEditor = memo(function ApiKeysCardEditor({
   value,
+  namesValue,
   disabled,
   onChange,
+  onNamesChange,
 }: {
   value: string;
+  namesValue?: string;
   disabled?: boolean;
   onChange: (nextValue: string) => void;
+  onNamesChange?: (nextNames: string) => void;
 }) {
   const { t } = useTranslation();
   const showNotification = useNotificationStore((state) => state.showNotification);
-  const apiKeys = useMemo(
-    () =>
-      value
-        .split('\n')
-        .map((key) => key.trim())
-        .filter(Boolean),
-    [value]
-  );
+  const apiKeys = useMemo(() => splitLines(value), [value]);
+  const apiKeyNames = useMemo(() => splitLines(namesValue ?? ''), [namesValue]);
   const [apiKeyIds, setApiKeyIds] = useState(() => apiKeys.map(() => makeClientId()));
   const renderApiKeyIds = useMemo(() => {
     if (apiKeyIds.length === apiKeys.length) return apiKeyIds;
@@ -41,16 +45,19 @@ export const ApiKeysCardEditor = memo(function ApiKeysCardEditor({
   }, [apiKeyIds, apiKeys.length]);
 
   const apiKeyInputId = useId();
+  const apiKeyNameInputId = useId();
   const apiKeyHintId = `${apiKeyInputId}-hint`;
   const apiKeyErrorId = `${apiKeyInputId}-error`;
   const [modalOpen, setModalOpen] = useState(false);
   const [editingApiKeyId, setEditingApiKeyId] = useState<string | null>(null);
   const [inputValue, setInputValue] = useState('');
+  const [inputNameValue, setInputNameValue] = useState('');
   const [formError, setFormError] = useState('');
 
   const openAddModal = () => {
     setEditingApiKeyId(null);
     setInputValue('');
+    setInputNameValue('');
     setFormError('');
     setModalOpen(true);
   };
@@ -59,6 +66,7 @@ export const ApiKeysCardEditor = memo(function ApiKeysCardEditor({
     const editingIndex = renderApiKeyIds.findIndex((id) => id === apiKeyId);
     setEditingApiKeyId(apiKeyId);
     setInputValue(apiKeys[editingIndex] ?? '');
+    setInputNameValue(apiKeyNames[editingIndex] ?? '');
     setFormError('');
     setModalOpen(true);
   };
@@ -66,6 +74,7 @@ export const ApiKeysCardEditor = memo(function ApiKeysCardEditor({
   const closeModal = () => {
     setModalOpen(false);
     setInputValue('');
+    setInputNameValue('');
     setEditingApiKeyId(null);
     setFormError('');
   };
@@ -74,11 +83,16 @@ export const ApiKeysCardEditor = memo(function ApiKeysCardEditor({
     onChange(nextKeys.join('\n'));
   };
 
+  const updateApiKeyNames = (nextNames: (string | undefined)[]) => {
+    if (onNamesChange) onNamesChange(nextNames.map((n) => n ?? '').join('\n'));
+  };
+
   const handleDelete = (apiKeyId: string) => {
     const index = renderApiKeyIds.findIndex((id) => id === apiKeyId);
     if (index < 0) return;
     setApiKeyIds(renderApiKeyIds.filter((id) => id !== apiKeyId));
     updateApiKeys(apiKeys.filter((_, i) => i !== index));
+    updateApiKeyNames(apiKeyNames.filter((_, i) => i !== index));
   };
 
   const handleSave = () => {
@@ -95,14 +109,20 @@ export const ApiKeysCardEditor = memo(function ApiKeysCardEditor({
     const editingIndex = editingApiKeyId
       ? renderApiKeyIds.findIndex((id) => id === editingApiKeyId)
       : -1;
+    const trimmedName = inputNameValue.trim();
     const nextKeys =
       editingApiKeyId === null
         ? [...apiKeys, trimmed]
         : apiKeys.map((key, idx) => (idx === editingIndex ? trimmed : key));
+    const nextNames: (string | undefined)[] =
+      editingApiKeyId === null
+        ? [...apiKeyNames, trimmedName || undefined]
+        : apiKeyNames.map((name, idx) => (idx === editingIndex ? trimmedName || undefined : name));
     if (editingApiKeyId === null) {
       setApiKeyIds([...renderApiKeyIds, makeClientId()]);
     }
     updateApiKeys(nextKeys);
+    updateApiKeyNames(nextNames);
     closeModal();
   };
 
@@ -132,43 +152,44 @@ export const ApiKeysCardEditor = memo(function ApiKeysCardEditor({
         <div className={styles.emptyState}>{t('config_management.visual.api_keys.empty')}</div>
       ) : (
         <div className="item-list" style={{ marginTop: 4 }}>
-          {apiKeys.map((key, index) => (
-            <div key={renderApiKeyIds[index] ?? `${key}-${index}`} className="item-row">
-              <div className="item-meta">
-                <div className="pill">#{index + 1}</div>
-                <div className="item-title">
-                  {t('config_management.visual.api_keys.input_label')}
+          {apiKeys.map((key, index) => {
+            const name = apiKeyNames[index];
+            return (
+              <div key={renderApiKeyIds[index] ?? `${key}-${index}`} className="item-row">
+                <div className="item-meta">
+                  <div className="pill">#{index + 1}</div>
+                  <div className="item-title">{name || t('config_management.visual.api_keys.input_label')}</div>
+                  <div className="item-subtitle">{maskApiKey(String(key || ''))}</div>
                 </div>
-                <div className="item-subtitle">{maskApiKey(String(key || ''))}</div>
+                <div className="item-actions">
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => handleCopy(key)}
+                    disabled={disabled}
+                  >
+                    {t('common.copy')}
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => openEditModal(renderApiKeyIds[index] ?? '')}
+                    disabled={disabled}
+                  >
+                    {t('config_management.visual.common.edit')}
+                  </Button>
+                  <Button
+                    variant="danger"
+                    size="sm"
+                    onClick={() => handleDelete(renderApiKeyIds[index] ?? '')}
+                    disabled={disabled}
+                  >
+                    {t('config_management.visual.common.delete')}
+                  </Button>
+                </div>
               </div>
-              <div className="item-actions">
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  onClick={() => handleCopy(key)}
-                  disabled={disabled}
-                >
-                  {t('common.copy')}
-                </Button>
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  onClick={() => openEditModal(renderApiKeyIds[index] ?? '')}
-                  disabled={disabled}
-                >
-                  {t('config_management.visual.common.edit')}
-                </Button>
-                <Button
-                  variant="danger"
-                  size="sm"
-                  onClick={() => handleDelete(renderApiKeyIds[index] ?? '')}
-                  disabled={disabled}
-                >
-                  {t('config_management.visual.common.delete')}
-                </Button>
-              </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       )}
 
@@ -196,6 +217,17 @@ export const ApiKeysCardEditor = memo(function ApiKeysCardEditor({
         }
       >
         <div className="form-group">
+          <label htmlFor={apiKeyNameInputId}>
+            {t('config_management.visual.api_keys.name_label')}
+          </label>
+          <input
+            id={apiKeyNameInputId}
+            className="input"
+            placeholder={t('config_management.visual.api_keys.name_placeholder')}
+            value={inputNameValue}
+            onChange={(e) => setInputNameValue(e.target.value)}
+            disabled={disabled}
+          />
           <label htmlFor={apiKeyInputId}>
             {t('config_management.visual.api_keys.input_label')}
           </label>

--- a/src/features/config/components/fields/sharedFields.tsx
+++ b/src/features/config/components/fields/sharedFields.tsx
@@ -72,8 +72,10 @@ export function ApiKeysField({ values, disabled, onChange }: SharedFieldProps) {
       <FieldGroup>
         <ApiKeysCardEditor
           value={values.apiKeysText}
+          namesValue={values.apiKeyNamesText}
           disabled={disabled}
           onChange={(apiKeysText) => onChange({ apiKeysText })}
+          onNamesChange={(apiKeyNamesText) => onChange({ apiKeyNamesText })}
         />
       </FieldGroup>
     </FieldAnchor>

--- a/src/hooks/useVisualConfig.ts
+++ b/src/hooks/useVisualConfig.ts
@@ -70,6 +70,21 @@ function resolveApiKeysText(parsed: Record<string, unknown>): string {
   return parseApiKeysText(configApiKeyProvider['api-keys']);
 }
 
+function resolveApiKeyNamesText(parsed: Record<string, unknown>): string {
+  const names = parsed['api-key-names'];
+  if (!names || typeof names !== 'object' || Array.isArray(names)) return '';
+  const keys = (parsed['api-keys'] as unknown[]) ?? [];
+  if (!Array.isArray(keys)) return '';
+  const nameByKey = names as Record<string, unknown>;
+  const lines: string[] = [];
+  for (const item of keys) {
+    const key = extractApiKeyValue(item);
+    const name = key ? nameByKey[key] : undefined;
+    lines.push(typeof name === 'string' ? name : '');
+  }
+  return lines.join('\n');
+}
+
 type YamlDocument = ReturnType<typeof parseDocument>;
 type YamlPath = string[];
 
@@ -902,6 +917,7 @@ function getNextDirtyFields(
       'rmPanelRepo',
       'authDir',
       'apiKeysText',
+      'apiKeyNamesText',
       'debug',
       'commercialMode',
       'loggingToFile',
@@ -1099,6 +1115,7 @@ export function useVisualConfig() {
 
         authDir: typeof parsed['auth-dir'] === 'string' ? parsed['auth-dir'] : '',
         apiKeysText: resolveApiKeysText(parsed),
+        apiKeyNamesText: resolveApiKeyNamesText(parsed),
         pluginsEnabled: Boolean(plugins?.enabled),
         pluginStoreSources: parseStringList(plugins?.['store-sources']),
         pluginStoreAuth: parsePluginStoreAuthRules(plugins?.['store-auth']),
@@ -1268,7 +1285,7 @@ export function useVisualConfig() {
         }
 
         if (dirtyFields.has('authDir')) setStringInDoc(doc, ['auth-dir'], values.authDir);
-        if (dirtyFields.has('apiKeysText')) {
+        if (dirtyFields.has('apiKeysText') || dirtyFields.has('apiKeyNamesText')) {
           const apiKeys = values.apiKeysText
             .split('\n')
             .map((key) => key.trim())
@@ -1279,6 +1296,19 @@ export function useVisualConfig() {
             doc.deleteIn(['api-keys']);
           }
           deleteLegacyApiKeysProvider(doc);
+
+          // api-key-names: line-per-key, aligned with api-keys order
+          const nameLines = values.apiKeyNamesText.split('\n');
+          const names: Record<string, string> = {};
+          apiKeys.forEach((key, idx) => {
+            const name = (nameLines[idx] ?? '').trim();
+            if (name) names[key] = name;
+          });
+          if (Object.keys(names).length > 0) {
+            doc.setIn(['api-key-names'], names);
+          } else if (docHas(doc, ['api-key-names'])) {
+            doc.deleteIn(['api-key-names']);
+          }
         }
 
         const pluginsDirty =

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1085,7 +1085,9 @@
           "fair": "Fair",
           "good": "Good",
           "strong": "Strong"
-        }
+        },
+        "name_label": "Name",
+        "name_placeholder": "Optional name for this key"
       },
       "payload_rules": {
         "rule": "Rule",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1072,7 +1072,9 @@
           "fair": "Средний",
           "good": "Хороший",
           "strong": "Надёжный"
-        }
+        },
+        "name_label": "Name",
+        "name_placeholder": "Optional name for this key"
       },
       "payload_rules": {
         "rule": "Правило",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1085,7 +1085,9 @@
           "fair": "一般",
           "good": "良好",
           "strong": "很强"
-        }
+        },
+        "name_label": "名称",
+        "name_placeholder": "给这个 Key 起个名字（可选）"
       },
       "payload_rules": {
         "rule": "规则",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1111,7 +1111,9 @@
           "fair": "一般",
           "good": "良好",
           "strong": "很強"
-        }
+        },
+        "name_label": "名称",
+        "name_placeholder": "给这个 Key 起个名字（可选）"
       },
       "payload_rules": {
         "rule": "規則",

--- a/src/types/visualConfig.ts
+++ b/src/types/visualConfig.ts
@@ -95,6 +95,7 @@ export type VisualConfigValues = {
   rmPanelRepo: string;
   authDir: string;
   apiKeysText: string;
+  apiKeyNamesText: string;
   pluginsEnabled: boolean;
   pluginStoreSources: string[];
   pluginStoreAuth: PluginStoreAuthRule[];
@@ -159,6 +160,7 @@ export const DEFAULT_VISUAL_VALUES: VisualConfigValues = {
   rmPanelRepo: '',
   authDir: '',
   apiKeysText: '',
+  apiKeyNamesText: '',
   pluginsEnabled: false,
   pluginStoreSources: [],
   pluginStoreAuth: [],


### PR DESCRIPTION
## Summary

Shows an optional human-readable name for each API key in the API Keys editor, matching the companion backend PR (`CLIProxyAPI` #4940) which adds an `api-key-names` map to the config.

## Changes

- `src/types/visualConfig.ts`: new `apiKeyNamesText` form field (names, one per line, aligned with keys)
- `src/hooks/useVisualConfig.ts`: parse `api-key-names` from config on load; serialize back on save
- `src/features/config/components/blocks/ApiKeysCardEditor.tsx`: list rows show name + masked key; add/edit modal gets an optional name input; names stay aligned on add/delete
- `src/features/config/components/fields/sharedFields.tsx`: wire the new field through
- i18n: `name_label` / `name_placeholder` added to zh-CN, en, zh-TW, ru

## Design notes

- **Backward compatible**: configs without `api-key-names` render exactly as before (raw keys only)
- Names are stored as `api-key-names: { <key>: <name> }` in config.yaml — authentication and routing are untouched

## Verification

- `bun run type-check` passes, `bun run build` produces the single-file panel
- Tested against the patched backend: names display in the list and persist through save

Requires the companion backend PR: router-for-me/CLIProxyAPI#4940