### PR TITLE
fix(authFiles): default to priority sorting

### DIFF
--- a/src/features/authFiles/AuthFilesPage.tsx
+++ b/src/features/authFiles/AuthFilesPage.tsx
@@ -45,6 +45,7 @@ import {
   isAuthFilesSortMode,
   readAuthFilesUiState,
   readPersistedAuthFilesCompactMode,
+  resolveAuthFilesSortMode,
   writeAuthFilesUiState,
   writePersistedAuthFilesCompactMode,
   type AuthFilesStatusFilterMode,
@@ -93,7 +94,8 @@ export function AuthFilesPage() {
   });
   const [pageSizeInput, setPageSizeInput] = useState('9');
   const [viewMode, setViewMode] = useState<'diagram' | 'list'>('list');
-  const [sortMode, setSortMode] = useState<AuthFilesSortMode>('default');
+  // Weekly keeper writes the routing order into priority; make that order visible by default.
+  const [sortMode, setSortMode] = useState<AuthFilesSortMode>('priority');
   const [uiStateHydrated, setUiStateHydrated] = useState(false);
 
   const {
@@ -240,7 +242,7 @@ export function AuthFilesPage() {
         compact: compactPageSize,
       });
       if (isAuthFilesSortMode(persisted.sortMode)) {
-        setSortMode(persisted.sortMode);
+        setSortMode(resolveAuthFilesSortMode(persisted.sortMode));
       }
     }
 

--- a/src/features/authFiles/uiState.ts
+++ b/src/features/authFiles/uiState.ts
@@ -33,6 +33,11 @@ const AUTH_FILES_STATUS_FILTER_MODE_SET = new Set<AuthFilesStatusFilterMode>(
 export const isAuthFilesSortMode = (value: unknown): value is AuthFilesSortMode =>
   typeof value === 'string' && AUTH_FILES_SORT_MODE_SET.has(value as AuthFilesSortMode);
 
+export const resolveAuthFilesSortMode = (value: unknown): AuthFilesSortMode => {
+  if (!isAuthFilesSortMode(value) || value === 'default') return 'priority';
+  return value;
+};
+
 export const isAuthFilesStatusFilterMode = (value: unknown): value is AuthFilesStatusFilterMode =>
   typeof value === 'string' &&
   AUTH_FILES_STATUS_FILTER_MODE_SET.has(value as AuthFilesStatusFilterMode);

--- a/tests/authFilesListLogic.test.ts
+++ b/tests/authFilesListLogic.test.ts
@@ -141,6 +141,22 @@ describe('sortAuthFiles', () => {
     ]);
   });
 
+  test("'priority' renders weekly Antigravity routing order ahead of file-name order", () => {
+    const files = [
+      authFile({ name: 'antigravity-ntbptest1.json', type: 'antigravity', priority: 105 }),
+      authFile({ name: 'antigravity-ntbptest2.json', type: 'antigravity', priority: 101 }),
+      authFile({ name: 'antigravity-ntbptest6.json', type: 'antigravity', priority: 107 }),
+      authFile({ name: 'antigravity-ntbptest9.json', type: 'antigravity', priority: 106 }),
+    ];
+
+    expect(sortAuthFiles(files, 'priority').map((file) => file.priority)).toEqual([
+      107,
+      106,
+      105,
+      101,
+    ]);
+  });
+
   test('returns a new array and leaves the input untouched', () => {
     const files = [authFile({ name: 'b.json' }), authFile({ name: 'a.json' })];
     const result = sortAuthFiles(files, 'az');

--- a/tests/authFilesUiState.test.ts
+++ b/tests/authFilesUiState.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'bun:test';
+
+import { resolveAuthFilesSortMode } from '@/features/authFiles/uiState';
+
+describe('resolveAuthFilesSortMode', () => {
+  test('uses priority for a fresh browser', () => {
+    expect(resolveAuthFilesSortMode(undefined)).toBe('priority');
+  });
+
+  test('migrates the former implicit default to priority', () => {
+    expect(resolveAuthFilesSortMode('default')).toBe('priority');
+  });
+
+  test('keeps explicit A-Z and priority choices', () => {
+    expect(resolveAuthFilesSortMode('az')).toBe('az');
+    expect(resolveAuthFilesSortMode('priority')).toBe('priority');
+  });
+});


### PR DESCRIPTION
Summary:
- show operational credential Priority order by default
- migrate the former persisted Default sort state to Priority
- preserve explicit A-Z and Priority selections
- add regression coverage for UI-state migration and Antigravity priority ordering

Validation:
- `bun run verify`: 291 tests passed, ESLint passed, TypeScript/Vite build passed
- focused tests: 23 passed
- production E2E on cpa.9zma.com, cpa.k3s.9zma.com, and nocache.cpa.k3s.9zma.com showed Sort=Priority and correct descending Antigravity order