### PR TITLE
feat(quota): add OpenCode Go usage support

### DIFF
--- a/src/features/authFiles/components/AuthFileCard.tsx
+++ b/src/features/authFiles/components/AuthFileCard.tsx
@@ -99,7 +99,7 @@ export function AuthFileCard(props: AuthFileCardProps) {
 
   const quotaType =
     quotaFilterType && resolveQuotaType(file) === quotaFilterType ? quotaFilterType : null;
-  const showQuotaLayout = Boolean(quotaType) && !isRuntimeOnly && !compact;
+  const showQuotaLayout = Boolean(quotaType) && !compact;
 
   const successCount = file.successCount ?? 0;
   const failureCount = file.failureCount ?? 0;

--- a/src/features/authFiles/components/AuthFileCard.tsx
+++ b/src/features/authFiles/components/AuthFileCard.tsx
@@ -14,11 +14,9 @@ import {
 } from '@/components/ui/icons';
 import { ProviderStatusBar } from '@/components/providers/ProviderStatusBar';
 import type { AuthFileItem } from '@/types';
-import { resolveAuthProvider } from '@/utils/quota';
 import { statusBarDataFromRecentRequests } from '@/utils/recentRequests';
 import { formatFileSize } from '@/utils/format';
 import {
-  QUOTA_PROVIDER_TYPES,
   formatModified,
   getAuthFileIcon,
   getAuthFileStatusMessage,
@@ -33,6 +31,7 @@ import {
   type QuotaProviderType,
   type ResolvedTheme,
 } from '@/features/authFiles/constants';
+import { resolveQuotaProviderType } from '@/features/quota/logic';
 import { deriveAuthFileIdentity } from '@/features/authFiles/identity';
 import type { AuthFileStatusBarData } from '@/features/authFiles/hooks/useAuthFilesStatusBarCache';
 import { AuthFileQuotaSection } from '@/features/authFiles/components/AuthFileQuotaSection';
@@ -60,11 +59,8 @@ export type AuthFileCardProps = {
   onToggleSelect: (name: string) => void;
 };
 
-const resolveQuotaType = (file: AuthFileItem): QuotaProviderType | null => {
-  const provider = resolveAuthProvider(file);
-  if (!QUOTA_PROVIDER_TYPES.has(provider as QuotaProviderType)) return null;
-  return provider as QuotaProviderType;
-};
+const resolveQuotaType = (file: AuthFileItem): QuotaProviderType | null =>
+  resolveQuotaProviderType(file);
 
 export function AuthFileCard(props: AuthFileCardProps) {
   const { t } = useTranslation();

--- a/src/features/authFiles/components/AuthFileQuotaSection.tsx
+++ b/src/features/authFiles/components/AuthFileQuotaSection.tsx
@@ -58,7 +58,6 @@ export function AuthFileQuotaSection(props: AuthFileQuotaSectionProps) {
 
   const refreshQuotaForFile = useCallback(async () => {
     if (disableControls) return;
-    if (isRuntimeOnlyAuthFile(file)) return;
     if (file.disabled) return;
     if (quota?.status === 'loading') return;
 

--- a/src/features/authFiles/components/AuthFileQuotaSection.tsx
+++ b/src/features/authFiles/components/AuthFileQuotaSection.tsx
@@ -47,6 +47,8 @@ export function AuthFileQuotaSection(props: AuthFileQuotaSectionProps) {
     if (quotaType === 'codex') return state.codexQuota[file.name] as QuotaCardState | undefined;
     if (quotaType === 'kimi') return state.kimiQuota[file.name] as QuotaCardState | undefined;
     if (quotaType === 'xai') return state.xaiQuota[file.name] as QuotaCardState | undefined;
+    if (quotaType === 'opencode')
+      return state.opencodeQuota[file.name] as QuotaCardState | undefined;
     return assertNever(quotaType);
   });
 

--- a/src/features/authFiles/constants.ts
+++ b/src/features/authFiles/constants.ts
@@ -10,6 +10,8 @@ import iconKimiDark from '@/assets/icons/kimi-dark.svg';
 import iconKimiLight from '@/assets/icons/kimi-light.svg';
 import iconQwen from '@/assets/icons/qwen.svg';
 import iconVertex from '@/assets/icons/vertex.svg';
+import iconOpenaiDark from '@/assets/icons/openai-dark.svg';
+import iconOpenaiLight from '@/assets/icons/openai-light.svg';
 import type { AuthFileItem, ResolvedTheme, ThemeColors } from '@/types';
 import { normalizeOAuthProviderKey } from '@/utils/providerKeys';
 import { parseTimestamp } from '@/utils/timestamp';
@@ -24,7 +26,7 @@ export type AuthFileModelItem = {
 };
 export type AuthFileIconAsset = string | { light: string; dark: string };
 
-export type QuotaProviderType = 'antigravity' | 'claude' | 'codex' | 'kimi' | 'xai';
+export type QuotaProviderType = 'antigravity' | 'claude' | 'codex' | 'kimi' | 'xai' | 'opencode';
 export type OAuthConfigLoadError = 'loading' | 'unsupported' | 'load' | null;
 
 export const QUOTA_PROVIDER_TYPES = new Set<QuotaProviderType>([
@@ -33,6 +35,7 @@ export const QUOTA_PROVIDER_TYPES = new Set<QuotaProviderType>([
   'codex',
   'kimi',
   'xai',
+  'opencode',
 ]);
 
 export const OAUTH_PROVIDER_PRESETS = [
@@ -77,6 +80,7 @@ export const AUTH_FILE_ICONS: Record<string, AuthFileIconAsset> = {
   kimi: { light: iconKimiDark, dark: iconKimiLight },
   qwen: iconQwen,
   vertex: iconVertex,
+  opencode: { light: iconOpenaiLight, dark: iconOpenaiDark },
 };
 
 export const clampCardPageSize = (value: number) =>
@@ -162,7 +166,7 @@ export const getAuthFileIcon = (type: string, resolvedTheme: ResolvedTheme): str
 
 // 与 AI 提供商界面（PROVIDER_LOGOS 的 themeSurface）保持一致：
 // 这些提供商的图标底座颜色随主题切换（浅色主题黑底，深色主题白底）
-export const THEME_SURFACE_ICON_PROVIDERS = new Set(['kimi']);
+export const THEME_SURFACE_ICON_PROVIDERS = new Set(['kimi', 'opencode']);
 
 export const isThemeSurfaceIconProvider = (type: string): boolean =>
   THEME_SURFACE_ICON_PROVIDERS.has(normalizeProviderKey(type));

--- a/src/features/authFiles/hooks/useAuthFilesData.ts
+++ b/src/features/authFiles/hooks/useAuthFilesData.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState, type ChangeEvent, type RefObject } from 'react';
 import { useTranslation } from 'react-i18next';
-import { authFilesApi } from '@/services/api';
+import { authFilesApi, providersApi } from '@/services/api';
+import { attachOpenAICompatBaseUrls } from '@/utils/quota';
 import { notifyAuthFilesChanged } from '@/features/authFiles/authFilesEvents';
 import { useNotificationStore } from '@/stores';
 import type { AuthFileItem } from '@/types';
@@ -200,9 +201,13 @@ export function useAuthFilesData(options?: UseAuthFilesDataOptions): UseAuthFile
       }
 
       try {
-        const data = await authFilesApi.list();
+        const [data, openaiCompat] = await Promise.all([
+          authFilesApi.list(),
+          providersApi.getOpenAIProviders().catch(() => []),
+        ]);
         if (requestId !== loadRequestIdRef.current) return; // 已被更新的请求/变更取代
-        setFiles(data?.files || []);
+        // /auth-files omits openai-compat Attributes.base_url; join via auth_index.
+        setFiles(attachOpenAICompatBaseUrls(data?.files || [], openaiCompat || []));
         setError('');
       } catch (err: unknown) {
         if (requestId !== loadRequestIdRef.current) return;

--- a/src/features/authFiles/hooks/useAuthFilesData.ts
+++ b/src/features/authFiles/hooks/useAuthFilesData.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState, type ChangeEvent, type RefObject } from 'react';
 import { useTranslation } from 'react-i18next';
 import { authFilesApi, providersApi } from '@/services/api';
-import { attachOpenAICompatBaseUrls } from '@/utils/quota';
+import { mergeOpenCodeCompatAuthFiles } from '@/utils/quota';
 import { notifyAuthFilesChanged } from '@/features/authFiles/authFilesEvents';
 import { useNotificationStore } from '@/stores';
 import type { AuthFileItem } from '@/types';
@@ -206,8 +206,9 @@ export function useAuthFilesData(options?: UseAuthFilesDataOptions): UseAuthFile
           providersApi.getOpenAIProviders().catch(() => []),
         ]);
         if (requestId !== loadRequestIdRef.current) return; // 已被更新的请求/变更取代
-        // /auth-files omits openai-compat Attributes.base_url; join via auth_index.
-        setFiles(attachOpenAICompatBaseUrls(data?.files || [], openaiCompat || []));
+        // Join openai-compat base URLs and synthesize OpenCode Go API-key rows
+        // when they are absent from /auth-files.
+        setFiles(mergeOpenCodeCompatAuthFiles(data?.files || [], openaiCompat || []));
         setError('');
       } catch (err: unknown) {
         if (requestId !== loadRequestIdRef.current) return;

--- a/src/features/quota/QuotaPage.tsx
+++ b/src/features/quota/QuotaPage.tsx
@@ -10,7 +10,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { authFilesApi } from '@/services/api';
+import { authFilesApi, providersApi } from '@/services/api';
 import { Button } from '@/components/ui/Button';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { Select } from '@/components/ui/Select';
@@ -20,6 +20,7 @@ import { useNow } from '@/hooks/useNow';
 import { useRevealGroup } from '@/hooks/motion';
 import { useAuthStore, useQuotaStore, useThemeStore } from '@/stores';
 import type { AuthFileItem, ResolvedTheme } from '@/types';
+import { attachOpenAICompatBaseUrls } from '@/utils/quota';
 import { ProviderTabs } from '@/features/authFiles/components/ProviderTabs';
 import { QuotaHeader } from './components/QuotaHeader';
 import { QuotaCard } from './components/QuotaCard';
@@ -81,8 +82,13 @@ export function QuotaPage() {
     setLoading(true);
     setError('');
     try {
-      const data = await authFilesApi.list();
-      setFiles(data?.files || []);
+      const [data, openaiCompat] = await Promise.all([
+        authFilesApi.list(),
+        providersApi.getOpenAIProviders().catch(() => []),
+      ]);
+      const rawFiles = data?.files || [];
+      // /auth-files omits openai-compat Attributes.base_url; join via auth_index.
+      setFiles(attachOpenAICompatBaseUrls(rawFiles, openaiCompat || []));
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : t('notification.refresh_failed');
       setError(message);
@@ -105,6 +111,7 @@ export function QuotaPage() {
   const codexQuota = useQuotaStore((state) => state.codexQuota);
   const kimiQuota = useQuotaStore((state) => state.kimiQuota);
   const xaiQuota = useQuotaStore((state) => state.xaiQuota);
+  const opencodeQuota = useQuotaStore((state) => state.opencodeQuota);
 
   const quotaByType = useMemo<Record<QuotaProviderType, Record<string, QuotaCardState>>>(
     () =>
@@ -114,8 +121,9 @@ export function QuotaPage() {
         codex: codexQuota,
         kimi: kimiQuota,
         xai: xaiQuota,
+        opencode: opencodeQuota,
       }) as unknown as Record<QuotaProviderType, Record<string, QuotaCardState>>,
-    [antigravityQuota, claudeQuota, codexQuota, kimiQuota, xaiQuota]
+    [antigravityQuota, claudeQuota, codexQuota, kimiQuota, xaiQuota, opencodeQuota]
   );
 
   const getQuota = useCallback(

--- a/src/features/quota/QuotaPage.tsx
+++ b/src/features/quota/QuotaPage.tsx
@@ -20,7 +20,7 @@ import { useNow } from '@/hooks/useNow';
 import { useRevealGroup } from '@/hooks/motion';
 import { useAuthStore, useQuotaStore, useThemeStore } from '@/stores';
 import type { AuthFileItem, ResolvedTheme } from '@/types';
-import { attachOpenAICompatBaseUrls } from '@/utils/quota';
+import { mergeOpenCodeCompatAuthFiles } from '@/utils/quota';
 import { ProviderTabs } from '@/features/authFiles/components/ProviderTabs';
 import { QuotaHeader } from './components/QuotaHeader';
 import { QuotaCard } from './components/QuotaCard';
@@ -87,8 +87,9 @@ export function QuotaPage() {
         providersApi.getOpenAIProviders().catch(() => []),
       ]);
       const rawFiles = data?.files || [];
-      // /auth-files omits openai-compat Attributes.base_url; join via auth_index.
-      setFiles(attachOpenAICompatBaseUrls(rawFiles, openaiCompat || []));
+      // Join openai-compat base URLs and synthesize OpenCode Go API-key rows
+      // when they are absent from /auth-files.
+      setFiles(mergeOpenCodeCompatAuthFiles(rawFiles, openaiCompat || []));
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : t('notification.refresh_failed');
       setError(message);

--- a/src/features/quota/constants.ts
+++ b/src/features/quota/constants.ts
@@ -7,6 +7,7 @@ export const QUOTA_TAB_ORDER: readonly QuotaProviderType[] = [
   'codex',
   'xai',
   'kimi',
+  'opencode',
 ];
 
 export type QuotaTabId = 'all' | QuotaProviderType;

--- a/src/features/quota/logic.ts
+++ b/src/features/quota/logic.ts
@@ -9,6 +9,7 @@ import { CLAUDE_CONFIG } from './providers/claude/data';
 import { CODEX_CONFIG } from './providers/codex/data';
 import { KIMI_CONFIG } from './providers/kimi/data';
 import { XAI_CONFIG } from './providers/xai/data';
+import { OPENCODE_CONFIG } from './providers/opencode/data';
 import type { QuotaProviderType } from './providers/types';
 import { QUOTA_TAB_ORDER, type QuotaSortMode, type QuotaTabId } from './constants';
 
@@ -18,6 +19,7 @@ const QUOTA_FILTER_MAP: Record<QuotaProviderType, (file: AuthFileItem) => boolea
   codex: CODEX_CONFIG.filterFn,
   kimi: KIMI_CONFIG.filterFn,
   xai: XAI_CONFIG.filterFn,
+  opencode: OPENCODE_CONFIG.filterFn,
 };
 
 export interface QuotaFileEntry {

--- a/src/features/quota/providers/index.ts
+++ b/src/features/quota/providers/index.ts
@@ -21,6 +21,8 @@ import { KIMI_CONFIG } from './kimi/data';
 import { KimiQuotaBody } from './kimi/KimiQuotaBody';
 import { XAI_CONFIG } from './xai/data';
 import { XaiQuotaBody } from './xai/XaiQuotaBody';
+import { OPENCODE_CONFIG } from './opencode/data';
+import { OpenCodeQuotaBody } from './opencode/OpenCodeQuotaBody';
 
 /** 所有 provider 额度状态的公共骨架（各 *QuotaState 的结构子集）。 */
 export interface QuotaCardState {
@@ -53,6 +55,7 @@ export const QUOTA_ADAPTERS: Record<QuotaProviderType, QuotaAdapter> = {
   codex: { ...CODEX_CONFIG, Body: CodexQuotaBody } as unknown as QuotaAdapter,
   kimi: { ...KIMI_CONFIG, Body: KimiQuotaBody } as unknown as QuotaAdapter,
   xai: { ...XAI_CONFIG, Body: XaiQuotaBody } as unknown as QuotaAdapter,
+  opencode: { ...OPENCODE_CONFIG, Body: OpenCodeQuotaBody } as unknown as QuotaAdapter,
 };
 
 export type QuotaMapUpdater = (

--- a/src/features/quota/providers/opencode/OpenCodeQuotaBody.tsx
+++ b/src/features/quota/providers/opencode/OpenCodeQuotaBody.tsx
@@ -1,0 +1,63 @@
+/**
+ * OpenCode Go quota body: fixed 5H / Week / Month meters.
+ */
+
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { OpenCodeQuotaState } from '@/types';
+import { buildResetDisplay } from '@/utils/quota';
+import { useNow } from '@/hooks/useNow';
+import { QuotaMeter } from '../../components/QuotaMeter';
+import { QuotaResetLabel } from '../../components/QuotaResetLabel';
+import { collectQuotaRowInstants, pickUrgentRowId } from '../../resetSchedule';
+import type { QuotaBodyProps } from '../../types';
+
+export function OpenCodeQuotaBody({ quota, classes }: QuotaBodyProps<OpenCodeQuotaState>) {
+  const { t, i18n } = useTranslation();
+  const now = useNow();
+  const soonestRowId = useMemo(
+    () => pickUrgentRowId(collectQuotaRowInstants('opencode', quota), now),
+    [quota, now]
+  );
+  const windows = quota.windows ?? [];
+
+  if (windows.length === 0) {
+    return <div className={classes.quotaMessage}>{t('opencode_quota.empty_data')}</div>;
+  }
+
+  return (
+    <>
+      {windows.map((window, index) => {
+        const remaining = window.remainingPercent;
+        const percentLabel = remaining === null ? '--' : `${Math.round(remaining)}%`;
+        const windowLabel = t(window.labelKey);
+        const resetDisplay = buildResetDisplay(
+          window.resetLabel || null,
+          window.resetAtMs,
+          now,
+          i18n.resolvedLanguage
+        );
+        const soon = window.id === soonestRowId;
+
+        return (
+          <div
+            key={window.id}
+            className={classes.quotaRow}
+            title={soon ? t('quota_management.soonest_row_hint') : undefined}
+          >
+            <div className={classes.quotaRowHeader}>
+              <span className={classes.quotaModel}>{windowLabel}</span>
+              <div className={classes.quotaMeta}>
+                <span className={classes.quotaPercent}>{percentLabel}</span>
+                {resetDisplay && (
+                  <QuotaResetLabel display={resetDisplay} classes={classes} soon={soon} />
+                )}
+              </div>
+            </div>
+            <QuotaMeter percent={remaining} classes={classes} index={index} />
+          </div>
+        );
+      })}
+    </>
+  );
+}

--- a/src/features/quota/providers/opencode/data.ts
+++ b/src/features/quota/providers/opencode/data.ts
@@ -1,0 +1,97 @@
+/**
+ * OpenCode Go quota data layer. React-free / SCSS-free.
+ */
+
+import type { TFunction } from 'i18next';
+import type { AuthFileItem, OpenCodeQuotaState, OpenCodeQuotaWindow } from '@/types';
+import { apiCallApi, getApiCallErrorMessage } from '@/services/api';
+import {
+  OPENCODE_REQUEST_HEADERS,
+  OPENCODE_USAGE_URL,
+  buildOpenCodeQuotaWindows,
+  createStatusError,
+  isDisabledAuthFile,
+  isOpenCodeGoFile,
+  parseOpenCodeUsagePayload,
+} from '@/utils/quota';
+import { normalizeAuthIndex } from '@/utils/authIndex';
+import type { QuotaProviderData } from '../types';
+
+export type OpenCodeQuotaData = {
+  windows: OpenCodeQuotaWindow[];
+  useBalance: boolean | null;
+};
+
+const mapStatusError = (status: number, fallback: string, t: TFunction) => {
+  if (status === 401) return t('opencode_quota.unauthorized');
+  if (status === 403) return t('opencode_quota.subscription_required');
+  if (status === 429) return t('opencode_quota.rate_limited');
+  if (status >= 500) return t('opencode_quota.upstream_unavailable');
+  return fallback;
+};
+
+const fetchOpenCodeQuota = async (
+  file: AuthFileItem,
+  t: TFunction
+): Promise<OpenCodeQuotaData> => {
+  const rawAuthIndex = file['auth_index'] ?? file.authIndex;
+  const authIndex = normalizeAuthIndex(rawAuthIndex);
+  if (!authIndex) {
+    throw new Error(t('opencode_quota.missing_auth_index'));
+  }
+
+  let result;
+  try {
+    result = await apiCallApi.request({
+      authIndex,
+      method: 'GET',
+      url: OPENCODE_USAGE_URL,
+      header: { ...OPENCODE_REQUEST_HEADERS },
+    });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : t('opencode_quota.request_failed');
+    throw createStatusError(t('opencode_quota.request_failed_with_message', { message }), undefined);
+  }
+
+  if (result.statusCode < 200 || result.statusCode >= 300) {
+    const fallback = getApiCallErrorMessage(result);
+    const message = mapStatusError(result.statusCode, fallback, t);
+    throw createStatusError(message, result.statusCode);
+  }
+
+  const payload = parseOpenCodeUsagePayload(result.body ?? result.bodyText);
+  if (!payload) {
+    throw new Error(t('opencode_quota.invalid_response'));
+  }
+
+  const windows = buildOpenCodeQuotaWindows(payload);
+  if (!windows.some((window) => window.usedPercent !== null || window.resetAtMs != null)) {
+    throw new Error(t('opencode_quota.empty_data'));
+  }
+
+  const useBalanceRaw = payload.useBalance ?? payload.use_balance;
+  const useBalance = typeof useBalanceRaw === 'boolean' ? useBalanceRaw : null;
+
+  return { windows, useBalance };
+};
+
+export const OPENCODE_CONFIG: QuotaProviderData<OpenCodeQuotaState, OpenCodeQuotaData> = {
+  type: 'opencode',
+  i18nPrefix: 'opencode_quota',
+  filterFn: (file) => isOpenCodeGoFile(file) && !isDisabledAuthFile(file),
+  fetchQuota: fetchOpenCodeQuota,
+  storeSelector: (state) => state.opencodeQuota,
+  storeSetter: 'setOpencodeQuota',
+  buildLoadingState: () => ({ status: 'loading', windows: [] }),
+  buildSuccessState: (data) => ({
+    status: 'success',
+    windows: data.windows,
+    useBalance: data.useBalance,
+  }),
+  buildErrorState: (message, status) => ({
+    status: 'error',
+    windows: [],
+    error: message,
+    errorStatus: status,
+  }),
+};

--- a/src/features/quota/providers/types.ts
+++ b/src/features/quota/providers/types.ts
@@ -12,12 +12,13 @@ import type {
   ClaudeQuotaState,
   CodexQuotaState,
   KimiQuotaState,
+  OpenCodeQuotaState,
   XaiQuotaState,
 } from '@/types';
 
 export type QuotaUpdater<T> = T | ((prev: T) => T);
 
-export type QuotaProviderType = 'antigravity' | 'claude' | 'codex' | 'kimi' | 'xai';
+export type QuotaProviderType = 'antigravity' | 'claude' | 'codex' | 'kimi' | 'xai' | 'opencode';
 
 /** useQuotaStore 的结构契约（storeSelector/storeSetter 依赖）。 */
 export interface QuotaStore {
@@ -26,11 +27,13 @@ export interface QuotaStore {
   codexQuota: Record<string, CodexQuotaState>;
   kimiQuota: Record<string, KimiQuotaState>;
   xaiQuota: Record<string, XaiQuotaState>;
+  opencodeQuota: Record<string, OpenCodeQuotaState>;
   setAntigravityQuota: (updater: QuotaUpdater<Record<string, AntigravityQuotaState>>) => void;
   setClaudeQuota: (updater: QuotaUpdater<Record<string, ClaudeQuotaState>>) => void;
   setCodexQuota: (updater: QuotaUpdater<Record<string, CodexQuotaState>>) => void;
   setKimiQuota: (updater: QuotaUpdater<Record<string, KimiQuotaState>>) => void;
   setXaiQuota: (updater: QuotaUpdater<Record<string, XaiQuotaState>>) => void;
+  setOpencodeQuota: (updater: QuotaUpdater<Record<string, OpenCodeQuotaState>>) => void;
   clearQuotaCache: () => void;
 }
 

--- a/src/features/quota/quotaTimelineModel.ts
+++ b/src/features/quota/quotaTimelineModel.ts
@@ -349,7 +349,7 @@ export function buildTimelineLane(input: TimelineLaneInput): TimelineLane {
 
   if (!quota || quota.status !== 'success') return empty;
 
-  if (provider === 'claude' || provider === 'codex') {
+  if (provider === 'claude' || provider === 'codex' || provider === 'opencode') {
     const windows = ((quota as { windows?: WindowLike[] }).windows ?? []).filter(
       (window) => typeof window.resetAtMs === 'number'
     );

--- a/src/features/quota/resetSchedule.ts
+++ b/src/features/quota/resetSchedule.ts
@@ -90,9 +90,9 @@ export function collectQuotaRowInstants(
   const state = quota as { status?: string } | undefined;
   if (!state || state.status !== 'success') return [];
 
-  if (provider === 'claude' || provider === 'codex') {
+  if (provider === 'claude' || provider === 'codex' || provider === 'opencode') {
     const windows = collectRows((quota as { windows?: WindowLike[] }).windows ?? [], 'window');
-    if (provider !== 'codex') return windows;
+    if (provider !== 'codex') return windows; // opencode / claude: windows only
 
     const credits = (
       (quota as { rateLimitResetCredits?: ResetCreditLike[] }).rateLimitResetCredits ?? []

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -365,7 +365,8 @@
     "quota_refresh_single": "Refresh quota",
     "quota_refresh_hint": "Refresh quota only for this credential",
     "quota_refresh_success": "Quota refreshed for \"{{name}}\"",
-    "quota_refresh_failed": "Failed to refresh quota for \"{{name}}\": {{message}}"
+    "quota_refresh_failed": "Failed to refresh quota for \"{{name}}\": {{message}}",
+    "filter_opencode": "OpenCode Go"
   },
   "antigravity_subscription": {
     "plan_unknown": "Unknown",
@@ -1157,7 +1158,7 @@
   },
   "quota_management": {
     "title": "Quota Management",
-    "description": "Monitor OAuth quota status for Antigravity, Codex, Claude, Kimi, and xAI credentials.",
+    "description": "Monitor OAuth and OpenCode Go quota status for Antigravity, Codex, Claude, Kimi, xAI, and OpenCode Go credentials.",
     "refresh_all_credentials": "Refresh all credentials",
     "sort_label": "Sort",
     "sort_default": "Default",
@@ -1166,7 +1167,7 @@
     "meta_loaded": "{{count}} loaded",
     "meta_attention": "{{count}} need attention",
     "empty_title": "No quota-capable credentials",
-    "empty_desc": "Connect an Antigravity, Claude, Codex, xAI, or Kimi credential to track its quota here.",
+    "empty_desc": "Connect an Antigravity, Claude, Codex, xAI, Kimi, or OpenCode Go credential to track its quota here.",
     "windows_title": "Quota windows",
     "windows_span_weekly": "two weeks",
     "windows_span_session": "three days",
@@ -1720,5 +1721,27 @@
     "modelCatalog": {
       "notLoaded": "Not loaded"
     }
+  },
+  "opencode_quota": {
+    "title": "OpenCode Go Quota",
+    "empty_title": "No OpenCode Go credentials",
+    "empty_desc": "Add an openai-compatibility provider whose base URL is https://opencode.ai/zen/go to track OpenCode Go usage here.",
+    "idle": "Click here to refresh quota",
+    "loading": "Loading quota...",
+    "load_failed": "Failed to load quota: {{message}}",
+    "missing_auth_index": "Auth file missing auth_index",
+    "empty_data": "No quota data available",
+    "invalid_response": "Invalid OpenCode Go usage response",
+    "unauthorized": "OpenCode Go credential unauthorized",
+    "subscription_required": "OpenCode Go subscription required",
+    "rate_limited": "OpenCode Go upstream rate limited",
+    "upstream_unavailable": "OpenCode Go upstream unavailable",
+    "request_failed": "OpenCode Go quota request failed",
+    "request_failed_with_message": "OpenCode Go quota request failed: {{message}}",
+    "refresh_button": "Refresh Quota",
+    "fetch_all": "Fetch All",
+    "window_5h": "5H",
+    "window_week": "Week",
+    "window_month": "Month"
   }
 }

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -358,7 +358,8 @@
     "quota_refresh_single": "Обновить квоту",
     "quota_refresh_hint": "Обновить квоту только для этих учётных данных",
     "quota_refresh_success": "Квота для \"{{name}}\" обновлена",
-    "quota_refresh_failed": "Не удалось обновить квоту для \"{{name}}\": {{message}}"
+    "quota_refresh_failed": "Не удалось обновить квоту для \"{{name}}\": {{message}}",
+    "filter_opencode": "OpenCode Go"
   },
   "antigravity_subscription": {
     "plan_unknown": "Неизвестно",
@@ -1144,7 +1145,7 @@
   },
   "quota_management": {
     "title": "Управление квотами",
-    "description": "Следите за статусом квот OAuth для учётных данных Antigravity, Codex, Claude, Kimi и xAI.",
+    "description": "Мониторинг квот Antigravity, Codex, Claude, Kimi, xAI и OpenCode Go.",
     "refresh_all_credentials": "Обновить все учётные данные",
     "sort_label": "Сортировка",
     "sort_default": "По умолчанию",
@@ -1153,7 +1154,7 @@
     "meta_loaded": "{{count}} загружено",
     "meta_attention": "{{count}} требуют внимания",
     "empty_title": "Нет учётных данных с квотами",
-    "empty_desc": "Подключите учётные данные Antigravity, Claude, Codex, xAI или Kimi, чтобы отслеживать квоту здесь.",
+    "empty_desc": "Подключите Antigravity, Claude, Codex, xAI, Kimi или OpenCode Go, чтобы отслеживать квоту здесь.",
     "windows_title": "Окна квот",
     "windows_span_weekly": "две недели",
     "windows_span_session": "три дня",
@@ -1698,5 +1699,27 @@
     "modelCatalog": {
       "notLoaded": "Не загружено"
     }
+  },
+  "opencode_quota": {
+    "title": "Квота OpenCode Go",
+    "empty_title": "Нет учётных данных OpenCode Go",
+    "empty_desc": "Добавьте openai-compatibility провайдера с base URL https://opencode.ai/zen/go, чтобы отслеживать usage OpenCode Go.",
+    "idle": "Нажмите, чтобы обновить квоту",
+    "loading": "Загрузка квоты...",
+    "load_failed": "Не удалось загрузить квоту: {{message}}",
+    "missing_auth_index": "В файле авторизации нет auth_index",
+    "empty_data": "Нет данных о квоте",
+    "invalid_response": "Некорректный ответ usage OpenCode Go",
+    "unauthorized": "Учётные данные OpenCode Go не авторизованы",
+    "subscription_required": "Требуется подписка OpenCode Go",
+    "rate_limited": "Upstream OpenCode Go ограничил частоту запросов",
+    "upstream_unavailable": "Upstream OpenCode Go недоступен",
+    "request_failed": "Запрос квоты OpenCode Go не выполнен",
+    "request_failed_with_message": "Запрос квоты OpenCode Go не выполнен: {{message}}",
+    "refresh_button": "Обновить квоту",
+    "fetch_all": "Загрузить все",
+    "window_5h": "5H",
+    "window_week": "Week",
+    "window_month": "Month"
   }
 }

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -365,7 +365,8 @@
     "quota_refresh_single": "刷新额度",
     "quota_refresh_hint": "仅刷新该认证文件的额度",
     "quota_refresh_success": "已刷新 \"{{name}}\" 的额度",
-    "quota_refresh_failed": "刷新 \"{{name}}\" 的额度失败：{{message}}"
+    "quota_refresh_failed": "刷新 \"{{name}}\" 的额度失败：{{message}}",
+    "filter_opencode": "OpenCode Go"
   },
   "antigravity_subscription": {
     "plan_unknown": "未知",
@@ -1157,7 +1158,7 @@
   },
   "quota_management": {
     "title": "配额管理",
-    "description": "集中查看 OAuth 额度与剩余情况",
+    "description": "监控 Antigravity、Codex、Claude、Kimi、xAI 与 OpenCode Go 凭证的额度状态。",
     "refresh_all_credentials": "刷新全部凭证",
     "sort_label": "排序",
     "sort_default": "默认",
@@ -1166,7 +1167,7 @@
     "meta_loaded": "{{count}} 个已加载",
     "meta_attention": "{{count}} 个需关注",
     "empty_title": "暂无可查额度的凭证",
-    "empty_desc": "接入 Antigravity、Claude、Codex、xAI 或 Kimi 凭证后即可在此查看额度。",
+    "empty_desc": "连接 Antigravity、Claude、Codex、xAI、Kimi 或 OpenCode Go 凭证后可在此跟踪额度。",
     "windows_title": "配额窗口",
     "windows_span_weekly": "两周",
     "windows_span_session": "三天",
@@ -1720,5 +1721,27 @@
     "modelCatalog": {
       "notLoaded": "未加载"
     }
+  },
+  "opencode_quota": {
+    "title": "OpenCode Go 额度",
+    "empty_title": "没有 OpenCode Go 凭证",
+    "empty_desc": "添加 base URL 为 https://opencode.ai/zen/go 的 openai-compatibility 提供商后，可在此查看 OpenCode Go 用量。",
+    "idle": "点击此处刷新额度",
+    "loading": "正在加载额度...",
+    "load_failed": "加载额度失败：{{message}}",
+    "missing_auth_index": "认证文件缺少 auth_index",
+    "empty_data": "暂无额度数据",
+    "invalid_response": "OpenCode Go 用量响应无效",
+    "unauthorized": "OpenCode Go 凭证未授权",
+    "subscription_required": "需要 OpenCode Go 订阅",
+    "rate_limited": "OpenCode Go 上游限流",
+    "upstream_unavailable": "OpenCode Go 上游不可用",
+    "request_failed": "OpenCode Go 额度请求失败",
+    "request_failed_with_message": "OpenCode Go 额度请求失败：{{message}}",
+    "refresh_button": "刷新额度",
+    "fetch_all": "全部获取",
+    "window_5h": "5H",
+    "window_week": "Week",
+    "window_month": "Month"
   }
 }

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -365,7 +365,8 @@
     "quota_refresh_single": "重新整理配額",
     "quota_refresh_hint": "僅重新整理該驗證檔案的配額",
     "quota_refresh_success": "已重新整理「{{name}}」的配額",
-    "quota_refresh_failed": "重新整理「{{name}}」的配額失敗：{{message}}"
+    "quota_refresh_failed": "重新整理「{{name}}」的配額失敗：{{message}}",
+    "filter_opencode": "OpenCode Go"
   },
   "antigravity_subscription": {
     "plan_unknown": "未知",
@@ -1183,7 +1184,7 @@
   },
   "quota_management": {
     "title": "配額管理",
-    "description": "集中查看 OAuth 配額與剩餘情況",
+    "description": "監控 Antigravity、Codex、Claude、Kimi、xAI 與 OpenCode Go 憑證的額度狀態。",
     "refresh_all_credentials": "重新整理全部憑證",
     "sort_label": "排序",
     "sort_default": "預設",
@@ -1192,7 +1193,7 @@
     "meta_loaded": "{{count}} 個已載入",
     "meta_attention": "{{count}} 個需關注",
     "empty_title": "暫無可查配額的憑證",
-    "empty_desc": "接入 Antigravity、Claude、Codex、xAI 或 Kimi 憑證後即可在此查看配額。",
+    "empty_desc": "連接 Antigravity、Claude、Codex、xAI、Kimi 或 OpenCode Go 憑證後可在此追蹤額度。",
     "windows_title": "配額視窗",
     "windows_span_weekly": "兩週",
     "windows_span_session": "三天",
@@ -1746,5 +1747,27 @@
     "modelCatalog": {
       "notLoaded": "未載入"
     }
+  },
+  "opencode_quota": {
+    "title": "OpenCode Go 額度",
+    "empty_title": "沒有 OpenCode Go 憑證",
+    "empty_desc": "新增 base URL 為 https://opencode.ai/zen/go 的 openai-compatibility 提供者後，可在此查看 OpenCode Go 用量。",
+    "idle": "點此重新整理額度",
+    "loading": "正在載入額度...",
+    "load_failed": "載入額度失敗：{{message}}",
+    "missing_auth_index": "認證檔缺少 auth_index",
+    "empty_data": "暫無額度資料",
+    "invalid_response": "OpenCode Go 用量回應無效",
+    "unauthorized": "OpenCode Go 憑證未授權",
+    "subscription_required": "需要 OpenCode Go 訂閱",
+    "rate_limited": "OpenCode Go 上游限流",
+    "upstream_unavailable": "OpenCode Go 上游無法使用",
+    "request_failed": "OpenCode Go 額度請求失敗",
+    "request_failed_with_message": "OpenCode Go 額度請求失敗：{{message}}",
+    "refresh_button": "重新整理額度",
+    "fetch_all": "全部取得",
+    "window_5h": "5H",
+    "window_week": "Week",
+    "window_month": "Month"
   }
 }

--- a/src/stores/useQuotaStore.ts
+++ b/src/stores/useQuotaStore.ts
@@ -8,6 +8,7 @@ import type {
   ClaudeQuotaState,
   CodexQuotaState,
   KimiQuotaState,
+  OpenCodeQuotaState,
   XaiQuotaState,
 } from '@/types';
 
@@ -20,11 +21,13 @@ interface QuotaStoreState {
   codexQuota: Record<string, CodexQuotaState>;
   kimiQuota: Record<string, KimiQuotaState>;
   xaiQuota: Record<string, XaiQuotaState>;
+  opencodeQuota: Record<string, OpenCodeQuotaState>;
   setAntigravityQuota: (updater: QuotaUpdater<Record<string, AntigravityQuotaState>>) => void;
   setClaudeQuota: (updater: QuotaUpdater<Record<string, ClaudeQuotaState>>) => void;
   setCodexQuota: (updater: QuotaUpdater<Record<string, CodexQuotaState>>) => void;
   setKimiQuota: (updater: QuotaUpdater<Record<string, KimiQuotaState>>) => void;
   setXaiQuota: (updater: QuotaUpdater<Record<string, XaiQuotaState>>) => void;
+  setOpencodeQuota: (updater: QuotaUpdater<Record<string, OpenCodeQuotaState>>) => void;
   clearQuotaCache: () => void;
 }
 
@@ -42,6 +45,7 @@ export const useQuotaStore = create<QuotaStoreState>((set) => ({
   codexQuota: {},
   kimiQuota: {},
   xaiQuota: {},
+  opencodeQuota: {},
   setAntigravityQuota: (updater) =>
     set((state) => ({
       antigravityQuota: resolveUpdater(updater, state.antigravityQuota),
@@ -62,6 +66,10 @@ export const useQuotaStore = create<QuotaStoreState>((set) => ({
     set((state) => ({
       xaiQuota: resolveUpdater(updater, state.xaiQuota),
     })),
+  setOpencodeQuota: (updater) =>
+    set((state) => ({
+      opencodeQuota: resolveUpdater(updater, state.opencodeQuota),
+    })),
   clearQuotaCache: () =>
     set((state) => ({
       cacheGeneration: state.cacheGeneration + 1,
@@ -70,6 +78,7 @@ export const useQuotaStore = create<QuotaStoreState>((set) => ({
       codexQuota: {},
       kimiQuota: {},
       xaiQuota: {},
+      opencodeQuota: {},
     })),
 }));
 

--- a/src/types/quota.ts
+++ b/src/types/quota.ts
@@ -310,6 +310,43 @@ export interface KimiQuotaState {
   errorStatus?: number;
 }
 
+
+
+// OpenCode Go usage payload / state types
+export interface OpenCodeUsageBucket {
+  percent?: number | string | null;
+  resetsAt?: string | null;
+  resets_at?: string | null;
+}
+
+export interface OpenCodeUsagePayload {
+  useBalance?: boolean | null;
+  use_balance?: boolean | null;
+  rollingUsage?: OpenCodeUsageBucket | null;
+  rolling_usage?: OpenCodeUsageBucket | null;
+  weeklyUsage?: OpenCodeUsageBucket | null;
+  weekly_usage?: OpenCodeUsageBucket | null;
+  monthlyUsage?: OpenCodeUsageBucket | null;
+  monthly_usage?: OpenCodeUsageBucket | null;
+}
+
+export interface OpenCodeQuotaWindow {
+  id: '5h' | 'weekly' | 'monthly';
+  labelKey: string;
+  usedPercent: number | null;
+  remainingPercent: number | null;
+  resetAtMs?: number | null;
+  resetLabel: string;
+}
+
+export interface OpenCodeQuotaState {
+  status: 'idle' | 'loading' | 'success' | 'error';
+  windows: OpenCodeQuotaWindow[];
+  useBalance?: boolean | null;
+  error?: string;
+  errorStatus?: number;
+}
+
 // xAI/Grok API payload types
 export interface XaiBillingCent {
   val?: number | string;

--- a/src/utils/quota/constants.ts
+++ b/src/utils/quota/constants.ts
@@ -46,6 +46,10 @@ export const TYPE_COLORS: Record<string, TypeColorSet> = {
     light: { bg: '#e4edfd', text: '#2b5fbc' },
     dark: { bg: '#1a3d80', text: '#89b3f7' },
   },
+  opencode: {
+    light: { bg: '#e8f5e9', text: '#1b5e20' },
+    dark: { bg: '#1b5e20', text: '#a5d6a7' },
+  },
   empty: {
     light: { bg: '#f5f5f5', text: '#616161' },
     dark: { bg: '#424242', text: '#bdbdbd' },

--- a/src/utils/quota/index.ts
+++ b/src/utils/quota/index.ts
@@ -14,3 +14,4 @@ export * from './validators';
 export * from './builders';
 export * from './resetCredits';
 export * from './xaiPaid';
+export * from './opencode';

--- a/src/utils/quota/opencode.ts
+++ b/src/utils/quota/opencode.ts
@@ -1,0 +1,227 @@
+/**
+ * OpenCode Go quota helpers: strict base-URL matching and usage payload parsing.
+ * React-free / SCSS-free — safe for bun:test.
+ */
+
+import type { AuthFileItem, OpenCodeQuotaWindow, OpenCodeUsagePayload } from '@/types';
+import { parseIsoToMs } from './resetInstants';
+
+export const OPENCODE_USAGE_URL = 'https://opencode.ai/zen/go/v1/usage';
+
+export const OPENCODE_REQUEST_HEADERS = {
+  Authorization: 'Bearer $TOKEN$',
+  Accept: 'application/json',
+} as const;
+
+/** Optional provider-name hints only — never sufficient alone. */
+export const OPENCODE_NAME_HINTS = new Set(['opencode', 'opencode-go', 'opencode-zen']);
+
+const OPENCODE_WINDOW_SPECS = [
+  { key: 'rollingUsage' as const, id: '5h' as const, labelKey: 'opencode_quota.window_5h' },
+  { key: 'weeklyUsage' as const, id: 'weekly' as const, labelKey: 'opencode_quota.window_week' },
+  {
+    key: 'monthlyUsage' as const,
+    id: 'monthly' as const,
+    labelKey: 'opencode_quota.window_month',
+  },
+];
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+
+const readString = (value: unknown): string =>
+  typeof value === 'string' ? value.trim() : value == null ? '' : String(value).trim();
+
+/**
+ * Normalize a candidate base URL for OpenCode Go matching.
+ * Returns null when the value is not a parseable absolute URL.
+ */
+export function normalizeOpenCodeCandidateUrl(value: unknown): string | null {
+  const raw = readString(value);
+  if (!raw) return null;
+  try {
+    const parsed = new URL(raw);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+    // Drop credentials, query, hash, and default ports; keep lower-case host/path.
+    parsed.username = '';
+    parsed.password = '';
+    parsed.hash = '';
+    parsed.search = '';
+    parsed.hostname = parsed.hostname.toLowerCase();
+    // Collapse trailing slashes on path (keep root as empty → later treated as /).
+    let path = parsed.pathname.replace(/\/+$/, '');
+    if (!path) path = '';
+    parsed.pathname = path;
+    return parsed.toString().replace(/\/$/, '') || `${parsed.protocol}//${parsed.host}`;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Strict OpenCode Go base-URL matcher.
+ *
+ * Accepts only host `opencode.ai` with path `/zen/go` or `/zen/go/v1`
+ * (with optional trailing slash, already normalized).
+ */
+export function isOpenCodeGoBaseUrl(value: unknown): boolean {
+  const raw = readString(value);
+  if (!raw) return false;
+  try {
+    const parsed = new URL(raw.includes('://') ? raw : `https://${raw}`);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
+    const host = parsed.hostname.toLowerCase();
+    if (host !== 'opencode.ai') return false;
+    const path = parsed.pathname.replace(/\/+$/, '') || '';
+    return path === '/zen/go' || path === '/zen/go/v1';
+  } catch {
+    return false;
+  }
+}
+
+/** Read base URL fields commonly attached to auth-file list entries. */
+export function extractAuthFileBaseUrl(file: AuthFileItem | Record<string, unknown>): string {
+  const record = file as Record<string, unknown>;
+  const candidates = [
+    record.baseUrl,
+    record['base-url'],
+    record.base_url,
+    record.BaseURL,
+  ];
+  for (const candidate of candidates) {
+    const text = readString(candidate);
+    if (text) return text;
+  }
+  return '';
+}
+
+/** Optional name hints (provider / type / label / compat_name). Never decisive alone. */
+export function extractOpenCodeNameHint(file: AuthFileItem | Record<string, unknown>): string {
+  const record = file as Record<string, unknown>;
+  const candidates = [
+    record.provider,
+    record.type,
+    record.label,
+    record.compat_name,
+    record.compatName,
+    record.name,
+  ];
+  for (const candidate of candidates) {
+    const key = readString(candidate).toLowerCase().replace(/_/g, '-');
+    if (!key) continue;
+    // openai-compatible-opencode-go → opencode-go
+    const stripped = key.startsWith('openai-compatible-')
+      ? key.slice('openai-compatible-'.length)
+      : key;
+    if (OPENCODE_NAME_HINTS.has(stripped) || OPENCODE_NAME_HINTS.has(key)) {
+      return stripped;
+    }
+  }
+  return '';
+}
+
+/**
+ * An auth file is OpenCode Go only when its base URL strictly matches.
+ * Name hints are ignored without a matching base URL.
+ */
+export function isOpenCodeGoFile(file: AuthFileItem): boolean {
+  const baseUrl = extractAuthFileBaseUrl(file);
+  return isOpenCodeGoBaseUrl(baseUrl);
+}
+
+export function clampPercent(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.max(0, Math.min(100, value));
+  }
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return Math.max(0, Math.min(100, parsed));
+  }
+  return null;
+}
+
+export function remainingFromUsedPercent(usedPercent: number | null): number | null {
+  if (usedPercent === null) return null;
+  return Math.max(0, Math.min(100, 100 - usedPercent));
+}
+
+export function parseOpenCodeUsagePayload(input: unknown): OpenCodeUsagePayload | null {
+  if (!isRecord(input)) return null;
+  // Accept either the authoritative shape or a JSON string body.
+  const rolling = input.rollingUsage ?? input.rolling_usage;
+  const weekly = input.weeklyUsage ?? input.weekly_usage;
+  const monthly = input.monthlyUsage ?? input.monthly_usage;
+  if (!isRecord(rolling) && !isRecord(weekly) && !isRecord(monthly)) {
+    return null;
+  }
+  return input as OpenCodeUsagePayload;
+}
+
+const readUsageWindow = (
+  payload: OpenCodeUsagePayload,
+  key: 'rollingUsage' | 'weeklyUsage' | 'monthlyUsage'
+): { percent: number | null; resetsAt: string | null } => {
+  const snake =
+    key === 'rollingUsage' ? 'rolling_usage' : key === 'weeklyUsage' ? 'weekly_usage' : 'monthly_usage';
+  const raw = (payload as Record<string, unknown>)[key] ?? (payload as Record<string, unknown>)[snake];
+  if (!isRecord(raw)) return { percent: null, resetsAt: null };
+  const percent = clampPercent(raw.percent);
+  const resetsAt = readString(raw.resetsAt ?? raw.resets_at) || null;
+  return { percent, resetsAt };
+};
+
+/**
+ * Build fixed-order 5H / Week / Month windows from the official usage payload.
+ */
+export function buildOpenCodeQuotaWindows(payload: OpenCodeUsagePayload): OpenCodeQuotaWindow[] {
+  return OPENCODE_WINDOW_SPECS.map((spec) => {
+    const window = readUsageWindow(payload, spec.key);
+    const usedPercent = window.percent;
+    const remainingPercent = remainingFromUsedPercent(usedPercent);
+    const resetAtMs = parseIsoToMs(window.resetsAt);
+    return {
+      id: spec.id,
+      labelKey: spec.labelKey,
+      usedPercent,
+      remainingPercent,
+      resetAtMs,
+      resetLabel: window.resetsAt ?? '',
+    };
+  });
+}
+
+/**
+ * Attach openai-compatibility base URLs onto auth-file entries by auth_index.
+ * Required because /auth-files does not expose Attributes.base_url.
+ */
+export function attachOpenAICompatBaseUrls(
+  files: AuthFileItem[],
+  compatProviders: Array<{ baseUrl?: string; apiKeyEntries?: Array<{ authIndex?: string }> }>
+): AuthFileItem[] {
+  const byAuthIndex = new Map<string, string>();
+  for (const provider of compatProviders) {
+    const baseUrl = readString(provider.baseUrl);
+    if (!baseUrl) continue;
+    for (const entry of provider.apiKeyEntries ?? []) {
+      const authIndex = readString(entry.authIndex);
+      if (!authIndex) continue;
+      byAuthIndex.set(authIndex, baseUrl);
+    }
+  }
+
+  if (byAuthIndex.size === 0) return files;
+
+  return files.map((file) => {
+    const existing = extractAuthFileBaseUrl(file);
+    if (existing) return file;
+    const authIndex = readString(file.authIndex ?? file['auth_index']);
+    if (!authIndex) return file;
+    const baseUrl = byAuthIndex.get(authIndex);
+    if (!baseUrl) return file;
+    return {
+      ...file,
+      baseUrl,
+      'base-url': baseUrl,
+    };
+  });
+}

--- a/src/utils/quota/opencode.ts
+++ b/src/utils/quota/opencode.ts
@@ -310,6 +310,8 @@ export function mergeOpenCodeCompatAuthFiles(
         label: providerName,
         disabled: false,
         source: 'openai-compatibility',
+        runtime_only: true,
+        runtimeOnly: true,
       } as AuthFileItem);
       existingAuthIndexes.add(authIndex);
     }

--- a/src/utils/quota/opencode.ts
+++ b/src/utils/quota/opencode.ts
@@ -145,16 +145,47 @@ export function remainingFromUsedPercent(usedPercent: number | null): number | n
   return Math.max(0, Math.min(100, 100 - usedPercent));
 }
 
+/**
+ * Live OpenCode Go `/usage` may return either:
+ * 1) flat: { rollingUsage, weeklyUsage, monthlyUsage }
+ * 2) nested: { usage: { rolling, weekly, monthly } }
+ * Normalize both into the flat shape used by the adapter.
+ */
 export function parseOpenCodeUsagePayload(input: unknown): OpenCodeUsagePayload | null {
   if (!isRecord(input)) return null;
-  // Accept either the authoritative shape or a JSON string body.
-  const rolling = input.rollingUsage ?? input.rolling_usage;
-  const weekly = input.weeklyUsage ?? input.weekly_usage;
-  const monthly = input.monthlyUsage ?? input.monthly_usage;
+
+  const nestedUsage = isRecord(input.usage) ? input.usage : null;
+  const rolling =
+    input.rollingUsage ??
+    input.rolling_usage ??
+    nestedUsage?.rollingUsage ??
+    nestedUsage?.rolling_usage ??
+    nestedUsage?.rolling;
+  const weekly =
+    input.weeklyUsage ??
+    input.weekly_usage ??
+    nestedUsage?.weeklyUsage ??
+    nestedUsage?.weekly_usage ??
+    nestedUsage?.weekly;
+  const monthly =
+    input.monthlyUsage ??
+    input.monthly_usage ??
+    nestedUsage?.monthlyUsage ??
+    nestedUsage?.monthly_usage ??
+    nestedUsage?.monthly;
+
   if (!isRecord(rolling) && !isRecord(weekly) && !isRecord(monthly)) {
     return null;
   }
-  return input as OpenCodeUsagePayload;
+
+  const useBalanceRaw = input.useBalance ?? input.use_balance;
+  const normalized: OpenCodeUsagePayload = {
+    useBalance: typeof useBalanceRaw === 'boolean' ? useBalanceRaw : null,
+    rollingUsage: isRecord(rolling) ? (rolling as OpenCodeUsagePayload['rollingUsage']) : null,
+    weeklyUsage: isRecord(weekly) ? (weekly as OpenCodeUsagePayload['weeklyUsage']) : null,
+    monthlyUsage: isRecord(monthly) ? (monthly as OpenCodeUsagePayload['monthlyUsage']) : null,
+  };
+  return normalized;
 }
 
 const readUsageWindow = (
@@ -163,7 +194,16 @@ const readUsageWindow = (
 ): { percent: number | null; resetsAt: string | null } => {
   const snake =
     key === 'rollingUsage' ? 'rolling_usage' : key === 'weeklyUsage' ? 'weekly_usage' : 'monthly_usage';
-  const raw = (payload as Record<string, unknown>)[key] ?? (payload as Record<string, unknown>)[snake];
+  const short = key === 'rollingUsage' ? 'rolling' : key === 'weeklyUsage' ? 'weekly' : 'monthly';
+  const nestedUsage = isRecord((payload as Record<string, unknown>).usage)
+    ? ((payload as Record<string, unknown>).usage as Record<string, unknown>)
+    : null;
+  const raw =
+    (payload as Record<string, unknown>)[key] ??
+    (payload as Record<string, unknown>)[snake] ??
+    nestedUsage?.[key] ??
+    nestedUsage?.[snake] ??
+    nestedUsage?.[short];
   if (!isRecord(raw)) return { percent: null, resetsAt: null };
   const percent = clampPercent(raw.percent);
   const resetsAt = readString(raw.resetsAt ?? raw.resets_at) || null;
@@ -194,9 +234,16 @@ export function buildOpenCodeQuotaWindows(payload: OpenCodeUsagePayload): OpenCo
  * Attach openai-compatibility base URLs onto auth-file entries by auth_index.
  * Required because /auth-files does not expose Attributes.base_url.
  */
+type OpenAICompatProviderLike = {
+  name?: string;
+  baseUrl?: string;
+  disabled?: boolean;
+  apiKeyEntries?: Array<{ authIndex?: string; apiKey?: string }>;
+};
+
 export function attachOpenAICompatBaseUrls(
   files: AuthFileItem[],
-  compatProviders: Array<{ baseUrl?: string; apiKeyEntries?: Array<{ authIndex?: string }> }>
+  compatProviders: OpenAICompatProviderLike[]
 ): AuthFileItem[] {
   const byAuthIndex = new Map<string, string>();
   for (const provider of compatProviders) {
@@ -224,4 +271,49 @@ export function attachOpenAICompatBaseUrls(
       'base-url': baseUrl,
     };
   });
+}
+
+/**
+ * OpenAI-compatibility API-key credentials (e.g. OpenCode Go) may not appear in
+ * /auth-files. Synthesize stable virtual auth-file rows for OpenCode Go only so
+ * Quota / AuthFile quota cards can load via auth_index + api-call.
+ */
+export function mergeOpenCodeCompatAuthFiles(
+  files: AuthFileItem[],
+  compatProviders: OpenAICompatProviderLike[]
+): AuthFileItem[] {
+  const withBase = attachOpenAICompatBaseUrls(files, compatProviders);
+  const existingAuthIndexes = new Set<string>();
+  for (const file of withBase) {
+    const authIndex = readString(file.authIndex ?? file['auth_index']);
+    if (authIndex) existingAuthIndexes.add(authIndex);
+  }
+
+  const synthesized: AuthFileItem[] = [];
+  for (const provider of compatProviders) {
+    const baseUrl = readString(provider.baseUrl);
+    if (!isOpenCodeGoBaseUrl(baseUrl)) continue;
+    if (provider.disabled === true) continue;
+    const providerName = readString(provider.name) || 'OpenCode Go';
+    for (const entry of provider.apiKeyEntries ?? []) {
+      const authIndex = readString(entry.authIndex);
+      if (!authIndex || existingAuthIndexes.has(authIndex)) continue;
+      const name = `openai-compat:${providerName}:${authIndex}`;
+      synthesized.push({
+        name,
+        authIndex,
+        auth_index: authIndex,
+        baseUrl,
+        'base-url': baseUrl,
+        provider: 'openai-compatible',
+        type: 'openai-compatible',
+        label: providerName,
+        disabled: false,
+        source: 'openai-compatibility',
+      } as AuthFileItem);
+      existingAuthIndexes.add(authIndex);
+    }
+  }
+
+  return synthesized.length ? [...withBase, ...synthesized] : withBase;
 }

--- a/src/utils/quota/validators.ts
+++ b/src/utils/quota/validators.ts
@@ -38,3 +38,6 @@ export function isDisabledAuthFile(file: AuthFileItem): boolean {
   if (typeof raw === 'string') return raw.trim().toLowerCase() === 'true';
   return false;
 }
+
+// OpenCode Go detector (strict base-URL match).
+export { isOpenCodeGoFile } from './opencode';

--- a/tests/opencodeQuota.test.ts
+++ b/tests/opencodeQuota.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from 'bun:test';
+import type { AuthFileItem, OpenCodeUsagePayload } from '@/types';
+import {
+  attachOpenAICompatBaseUrls,
+  buildOpenCodeQuotaWindows,
+  clampPercent,
+  extractAuthFileBaseUrl,
+  isOpenCodeGoBaseUrl,
+  isOpenCodeGoFile,
+  parseOpenCodeUsagePayload,
+  remainingFromUsedPercent,
+} from '@/utils/quota/opencode';
+import { classifyQuotaFiles, resolveQuotaProviderType } from '@/features/quota/logic';
+import { QUOTA_TAB_ORDER } from '@/features/quota/constants';
+import { QUOTA_ADAPTERS } from '@/features/quota/providers';
+
+const file = (name: string, extra: Partial<AuthFileItem> = {}): AuthFileItem =>
+  ({ name, ...extra }) as AuthFileItem;
+
+describe('OpenCode Go strict URL matcher', () => {
+  test('accepts official base URLs with normalization', () => {
+    const positives = [
+      'https://opencode.ai/zen/go',
+      'https://opencode.ai/zen/go/',
+      'https://opencode.ai/zen/go/v1',
+      'https://opencode.ai/zen/go/v1/',
+      'HTTPS://OpenCode.AI/zen/go/v1/',
+      'https://opencode.ai/zen/go/v1/?ignored=1',
+    ];
+    for (const url of positives) {
+      expect(isOpenCodeGoBaseUrl(url)).toBe(true);
+    }
+  });
+
+  test('rejects spoofed, generic, and misleading URLs', () => {
+    const negatives = [
+      'https://openrouter.ai/api/v1',
+      'https://api.openai.com/v1',
+      'https://example.com/v1',
+      'https://opencode.ai.example.com/zen/go',
+      'https://evil.com/zen/go?host=opencode.ai',
+      'https://example.com/path/opencode.ai/zen/go',
+      'https://opencode.ai/zen',
+      'https://opencode.ai/zen/go/v2',
+      'https://opencode.ai/not-zen/go',
+      '',
+      'not-a-url',
+    ];
+    for (const url of negatives) {
+      expect(isOpenCodeGoBaseUrl(url)).toBe(false);
+    }
+  });
+});
+
+describe('OpenCode Go file detection', () => {
+  test('requires strict base URL and ignores name-only hints', () => {
+    expect(
+      isOpenCodeGoFile(file('a', { provider: 'opencode-go', baseUrl: 'https://opencode.ai/zen/go/v1' }))
+    ).toBe(true);
+    expect(isOpenCodeGoFile(file('b', { provider: 'opencode-go' }))).toBe(false);
+    expect(
+      isOpenCodeGoFile(
+        file('c', { provider: 'opencode-go', baseUrl: 'https://openrouter.ai/api/v1' })
+      )
+    ).toBe(false);
+    expect(
+      isOpenCodeGoFile(
+        file('d', {
+          provider: 'openai-compatible-custom',
+          'base-url': 'https://opencode.ai/zen/go',
+        })
+      )
+    ).toBe(true);
+  });
+
+  test('attachOpenAICompatBaseUrls joins auth_index to base URL', () => {
+    const files = [
+      file('oc-1', { authIndex: 'idx-1', provider: 'openai-compatible-opencode-go' }),
+      file('other', { authIndex: 'idx-2', provider: 'openai-compatible-openrouter' }),
+    ];
+    const enriched = attachOpenAICompatBaseUrls(files, [
+      {
+        baseUrl: 'https://opencode.ai/zen/go/v1',
+        apiKeyEntries: [{ authIndex: 'idx-1' }],
+      },
+      {
+        baseUrl: 'https://openrouter.ai/api/v1',
+        apiKeyEntries: [{ authIndex: 'idx-2' }],
+      },
+    ]);
+    expect(extractAuthFileBaseUrl(enriched[0]!)).toBe('https://opencode.ai/zen/go/v1');
+    expect(isOpenCodeGoFile(enriched[0]!)).toBe(true);
+    expect(isOpenCodeGoFile(enriched[1]!)).toBe(false);
+  });
+});
+
+describe('OpenCode Go payload parsing', () => {
+  const payload: OpenCodeUsagePayload = {
+    useBalance: false,
+    rollingUsage: { percent: 12.5, resetsAt: '2026-08-16T10:00:00.000Z' },
+    weeklyUsage: { percent: 40, resetsAt: '2026-08-18T00:00:00.000Z' },
+    monthlyUsage: { percent: 70, resetsAt: '2026-09-01T00:00:00.000Z' },
+  };
+
+  test('maps rolling/weekly/monthly to fixed 5H → Week → Month order', () => {
+    const windows = buildOpenCodeQuotaWindows(payload);
+    expect(windows.map((w) => w.id)).toEqual(['5h', 'weekly', 'monthly']);
+    expect(windows.map((w) => w.labelKey)).toEqual([
+      'opencode_quota.window_5h',
+      'opencode_quota.window_week',
+      'opencode_quota.window_month',
+    ]);
+    expect(windows[0]?.usedPercent).toBe(12.5);
+    expect(windows[0]?.remainingPercent).toBe(87.5);
+    expect(windows[1]?.remainingPercent).toBe(60);
+    expect(windows[2]?.remainingPercent).toBe(30);
+  });
+
+  test('clamps percent bounds and handles unexpected values', () => {
+    expect(clampPercent(-5)).toBe(0);
+    expect(clampPercent(0)).toBe(0);
+    expect(clampPercent(100)).toBe(100);
+    expect(clampPercent(140)).toBe(100);
+    expect(clampPercent('nope')).toBeNull();
+    expect(remainingFromUsedPercent(0)).toBe(100);
+    expect(remainingFromUsedPercent(100)).toBe(0);
+    expect(remainingFromUsedPercent(null)).toBeNull();
+  });
+
+  test('rejects malformed payloads', () => {
+    expect(parseOpenCodeUsagePayload(null)).toBeNull();
+    expect(parseOpenCodeUsagePayload({})).toBeNull();
+    expect(parseOpenCodeUsagePayload({ foo: 1 })).toBeNull();
+    expect(parseOpenCodeUsagePayload(payload)).not.toBeNull();
+  });
+});
+
+describe('OpenCode Go adapter registration / classification', () => {
+  test('registers opencode in tab order and adapters', () => {
+    expect(QUOTA_TAB_ORDER).toContain('opencode');
+    expect(QUOTA_ADAPTERS.opencode.type).toBe('opencode');
+    expect(QUOTA_ADAPTERS.opencode.i18nPrefix).toBe('opencode_quota');
+  });
+
+  test('classifies only OpenCode Go base-url credentials and keeps multi-account isolation keys', () => {
+    const files: AuthFileItem[] = [
+      file('oc-a', { provider: 'openai-compatible-opencode-go', baseUrl: 'https://opencode.ai/zen/go/v1' }),
+      file('oc-b', { provider: 'openai-compatible-opencode-go', baseUrl: 'https://opencode.ai/zen/go' }),
+      file('or-a', { provider: 'openai-compatible-openrouter', baseUrl: 'https://openrouter.ai/api/v1' }),
+      file('codex-a', { provider: 'codex' }),
+      file('oc-off', {
+        provider: 'openai-compatible-opencode-go',
+        baseUrl: 'https://opencode.ai/zen/go/v1',
+        disabled: true,
+      }),
+    ];
+    const entries = classifyQuotaFiles(files);
+    const opencode = entries.filter((e) => e.type === 'opencode');
+    expect(opencode.map((e) => e.file.name)).toEqual(['oc-a', 'oc-b']);
+    expect(resolveQuotaProviderType(files[0]!)).toBe('opencode');
+    expect(resolveQuotaProviderType(files[2]!)).toBeNull();
+    expect(resolveQuotaProviderType(files[3]!)).toBe('codex');
+  });
+
+  test('does not reclassify existing providers', () => {
+    expect(resolveQuotaProviderType(file('c', { provider: 'claude' }))).toBe('claude');
+    expect(resolveQuotaProviderType(file('x', { provider: 'xai' }))).toBe('xai');
+    expect(resolveQuotaProviderType(file('k', { provider: 'kimi' }))).toBe('kimi');
+    expect(resolveQuotaProviderType(file('a', { provider: 'antigravity' }))).toBe('antigravity');
+    expect(resolveQuotaProviderType(file('d', { provider: 'codex' }))).toBe('codex');
+  });
+});

--- a/tests/opencodeQuota.test.ts
+++ b/tests/opencodeQuota.test.ts
@@ -7,6 +7,7 @@ import {
   extractAuthFileBaseUrl,
   isOpenCodeGoBaseUrl,
   isOpenCodeGoFile,
+  mergeOpenCodeCompatAuthFiles,
   parseOpenCodeUsagePayload,
   remainingFromUsedPercent,
 } from '@/utils/quota/opencode';
@@ -73,6 +74,28 @@ describe('OpenCode Go file detection', () => {
     ).toBe(true);
   });
 
+  test('mergeOpenCodeCompatAuthFiles synthesizes missing OpenCode Go API-key rows', () => {
+    const files = [file('codex-a', { authIndex: 'codex-1', provider: 'codex' })];
+    const merged = mergeOpenCodeCompatAuthFiles(files, [
+      {
+        name: 'OpenCode Go',
+        baseUrl: 'https://opencode.ai/zen/go/v1',
+        apiKeyEntries: [{ authIndex: 'oc-auth-1' }],
+      },
+      {
+        name: 'OpenRouter',
+        baseUrl: 'https://openrouter.ai/api/v1',
+        apiKeyEntries: [{ authIndex: 'or-1' }],
+      },
+    ]);
+    const oc = merged.filter((f) => isOpenCodeGoFile(f));
+    expect(oc).toHaveLength(1);
+    expect(oc[0]?.authIndex).toBe('oc-auth-1');
+    expect(extractAuthFileBaseUrl(oc[0]!)).toBe('https://opencode.ai/zen/go/v1');
+    // non-OpenCode compat providers are not synthesized
+    expect(merged.some((f) => f.authIndex === 'or-1')).toBe(false);
+  });
+
   test('attachOpenAICompatBaseUrls joins auth_index to base URL', () => {
     const files = [
       file('oc-1', { authIndex: 'idx-1', provider: 'openai-compatible-opencode-go' }),
@@ -132,6 +155,24 @@ describe('OpenCode Go payload parsing', () => {
     expect(parseOpenCodeUsagePayload({})).toBeNull();
     expect(parseOpenCodeUsagePayload({ foo: 1 })).toBeNull();
     expect(parseOpenCodeUsagePayload(payload)).not.toBeNull();
+  });
+
+  test('accepts nested usage.rolling shape from live OpenCode Go endpoint', () => {
+    const nested = {
+      usage: {
+        rolling: { status: 'ok', percent: 2, resetsAt: '2026-08-15T18:05:45.783Z' },
+        weekly: { status: 'ok', percent: 16, resetsAt: '2026-08-17T00:00:00.783Z' },
+        monthly: { status: 'ok', percent: 54, resetsAt: '2026-09-03T11:42:09.783Z' },
+      },
+    };
+    const parsed = parseOpenCodeUsagePayload(nested);
+    expect(parsed).not.toBeNull();
+    const windows = buildOpenCodeQuotaWindows(parsed!);
+    expect(windows.map((w) => w.id)).toEqual(['5h', 'weekly', 'monthly']);
+    expect(windows[0]?.usedPercent).toBe(2);
+    expect(windows[0]?.remainingPercent).toBe(98);
+    expect(windows[1]?.remainingPercent).toBe(84);
+    expect(windows[2]?.remainingPercent).toBe(46);
   });
 });
 

--- a/tests/opencodeQuota.test.ts
+++ b/tests/opencodeQuota.test.ts
@@ -14,6 +14,7 @@ import {
 import { classifyQuotaFiles, resolveQuotaProviderType } from '@/features/quota/logic';
 import { QUOTA_TAB_ORDER } from '@/features/quota/constants';
 import { QUOTA_ADAPTERS } from '@/features/quota/providers';
+import { OPENCODE_CONFIG } from '@/features/quota/providers/opencode/data';
 
 const file = (name: string, extra: Partial<AuthFileItem> = {}): AuthFileItem =>
   ({ name, ...extra }) as AuthFileItem;
@@ -74,7 +75,7 @@ describe('OpenCode Go file detection', () => {
     ).toBe(true);
   });
 
-  test('mergeOpenCodeCompatAuthFiles synthesizes missing OpenCode Go API-key rows', () => {
+  test('mergeOpenCodeCompatAuthFiles synthesizes missing OpenCode Go API-key rows with runtime_only flag', () => {
     const files = [file('codex-a', { authIndex: 'codex-1', provider: 'codex' })];
     const merged = mergeOpenCodeCompatAuthFiles(files, [
       {
@@ -92,8 +93,43 @@ describe('OpenCode Go file detection', () => {
     expect(oc).toHaveLength(1);
     expect(oc[0]?.authIndex).toBe('oc-auth-1');
     expect(extractAuthFileBaseUrl(oc[0]!)).toBe('https://opencode.ai/zen/go/v1');
+    expect(oc[0]?.runtime_only).toBe(true);
     // non-OpenCode compat providers are not synthesized
     expect(merged.some((f) => f.authIndex === 'or-1')).toBe(false);
+  });
+
+  test('multi-key isolation: synthesizes distinct rows for multiple keys under one OpenCode Go config', () => {
+    const compatConfig = [
+      {
+        name: 'OpenCode Go Team',
+        baseUrl: 'https://opencode.ai/zen/go/v1',
+        apiKeyEntries: [
+          { authIndex: 'oc-key-alpha' },
+          { authIndex: 'oc-key-beta' },
+        ],
+      },
+    ];
+    const merged = mergeOpenCodeCompatAuthFiles([], compatConfig);
+    const ocEntries = merged.filter((f) => isOpenCodeGoFile(f));
+    expect(ocEntries).toHaveLength(2);
+
+    const [first, second] = ocEntries;
+    expect(first?.authIndex).toBe('oc-key-alpha');
+    expect(second?.authIndex).toBe('oc-key-beta');
+    expect(first?.name).not.toEqual(second?.name);
+    expect(first?.name).toBe('openai-compat:OpenCode Go Team:oc-key-alpha');
+    expect(second?.name).toBe('openai-compat:OpenCode Go Team:oc-key-beta');
+
+    // Classification should assign both to opencode provider with distinct card identities
+    const classified = classifyQuotaFiles(merged);
+    const opencodeCards = classified.filter((e) => e.type === 'opencode');
+    expect(opencodeCards).toHaveLength(2);
+    expect(opencodeCards[0]?.file.name).toBe('openai-compat:OpenCode Go Team:oc-key-alpha');
+    expect(opencodeCards[1]?.file.name).toBe('openai-compat:OpenCode Go Team:oc-key-beta');
+
+    // Runtime-only flag set on both to suppress destructive file operations
+    expect(first?.runtime_only).toBe(true);
+    expect(second?.runtime_only).toBe(true);
   });
 
   test('attachOpenAICompatBaseUrls joins auth_index to base URL', () => {
@@ -209,5 +245,34 @@ describe('OpenCode Go adapter registration / classification', () => {
     expect(resolveQuotaProviderType(file('k', { provider: 'kimi' }))).toBe('kimi');
     expect(resolveQuotaProviderType(file('a', { provider: 'antigravity' }))).toBe('antigravity');
     expect(resolveQuotaProviderType(file('d', { provider: 'codex' }))).toBe('codex');
+  });
+});
+
+describe('Synthetic vs native auth file behavior', () => {
+  test('synthetic OpenCode row marks runtime_only to suppress file actions while preserving quota identity', () => {
+    const synthetic = mergeOpenCodeCompatAuthFiles([], [
+      {
+        name: 'OpenCode Go',
+        baseUrl: 'https://opencode.ai/zen/go/v1',
+        apiKeyEntries: [{ authIndex: 'oc-live-1' }],
+      },
+    ])[0]!;
+
+    expect(synthetic.runtime_only).toBe(true);
+    expect(isOpenCodeGoFile(synthetic)).toBe(true);
+    expect(resolveQuotaProviderType(synthetic)).toBe('opencode');
+    expect(OPENCODE_CONFIG.filterFn(synthetic)).toBe(true);
+  });
+
+  test('native auth file rows keep runtime_only false and support file actions', () => {
+    const nativeFile = file('claude-work.json', {
+      provider: 'claude',
+      type: 'claude',
+      authIndex: 'claude-idx-1',
+    });
+
+    expect(nativeFile.runtime_only).toBeUndefined();
+    expect(resolveQuotaProviderType(nativeFile)).toBe('claude');
+    expect(isOpenCodeGoFile(nativeFile)).toBe(false);
   });
 });

--- a/tests/quotaPageLogic.test.ts
+++ b/tests/quotaPageLogic.test.ts
@@ -57,6 +57,7 @@ describe('buildTabCounts', () => {
       codex: 2,
       xai: 1,
       kimi: 1,
+      opencode: 0,
     });
   });
 });


### PR DESCRIPTION
## Summary

Add OpenCode Go subscription quota support to the Management Center.

OpenCode Go credentials configured through `openai-compatibility` are detected by their normalized upstream URL and displayed in the existing quota UI.

The adapter queries the official OpenCode Go usage endpoint through the existing Management API proxy, so API keys are never exposed to the browser.


## What it adds

- Detect OpenCode Go configured through `openai-compatibility`
- Display:
  - 5H
  - Week
  - Month
- Display remaining percentage and reset schedule
- Support both observed OpenCode usage response shapes (flat and nested)
- Support multiple API-key entries independently
- Surface OpenCode Go virtual credentials in Auth Files
- Suppress filesystem-only actions for virtual credentials
- Add localized UI strings (en, zh-CN, zh-TW, ru)
- Keep telemetry completely separate from inference routing


## Upstream

Official usage endpoint:

GET https://opencode.ai/zen/go/v1/usage

Requests are proxied through the existing:

POST /v0/management/api-call

using the existing `$TOKEN$` substitution mechanism.


## Provider detection

OpenCode Go remains an OpenAI-compatible provider.

Detection requires:

host:
opencode.ai

path:
- /zen/go
- /zen/go/v1

Provider name alone is not sufficient.

This avoids classifying arbitrary OpenAI-compatible providers as OpenCode Go.


## Usage mapping

rolling usage → 5H
weekly usage → Week
monthly usage → Month

remaining = clamp(100 - percent, 0, 100)


## Compatibility

No changes are required in CLIProxyAPI backend.

This PR does NOT change:

- runtime quota routing
- QuotaState
- credential schema
- inference provider selection
- account switching
- CLIProxyAPI backend


## Validation

- 436 tests passed (62 test files)
- typecheck passed (`tsc --noEmit`)
- lint passed (`eslint`)
- build passed (`vite build` single-file)

Live-tested against an existing OpenCode Go configuration through CLIProxyAPI Management API:
- Official upstream returned HTTP 200
- 5H / Week / Month rendered correctly
- Auth Files quota refresh works
- API key is not exposed to the frontend
- Inference remained healthy before and after quota refresh


## Notes

OpenCode Go entries from `openai-compatibility` are represented as virtual auth-file rows for quota display.

Filesystem-only actions such as Download/Delete are intentionally hidden for these virtual rows.


## Out of scope

- backend quota cache / stale fallback
- quota-aware routing
- automatic account switching
- native OpenCode Go runtime provider
