### PR TITLE
fix(quota): explain inactive Claude 5-hour windows

### DIFF
--- a/src/features/quota/providers/claude/data.ts
+++ b/src/features/quota/providers/claude/data.ts
@@ -65,7 +65,10 @@ export const buildClaudeQuotaWindows = (
     if (!window || typeof window !== 'object' || !('utilization' in window)) continue;
     const typedWindow = window as { utilization: number; resets_at: string | null };
     const usedPercent = normalizeNumberValue(typedWindow.utilization);
-    const resetLabel = formatQuotaResetTime(typedWindow.resets_at ?? undefined);
+    const resetLabel =
+      key === 'five_hour' && usedPercent === 0 && !typedWindow.resets_at
+        ? t('claude_quota.five_hour_starts_on_use')
+        : formatQuotaResetTime(typedWindow.resets_at ?? undefined);
     windows.push({
       id,
       label: t(labelKey),

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -415,6 +415,7 @@
     "refresh_button": "Refresh Quota",
     "fetch_all": "Fetch All",
     "five_hour": "5-hour limit",
+    "five_hour_starts_on_use": "starts on use",
     "seven_day": "7-day limit",
     "seven_day_oauth_apps": "7-day OAuth apps",
     "seven_day_opus": "7-day Opus",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -408,6 +408,7 @@
     "refresh_button": "Обновить квоту",
     "fetch_all": "Получить все",
     "five_hour": "Лимит на 5 часов",
+    "five_hour_starts_on_use": "начнётся при использовании",
     "seven_day": "Лимит на 7 дней",
     "seven_day_oauth_apps": "7 дней OAuth приложения",
     "seven_day_opus": "7 дней Opus",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -415,6 +415,7 @@
     "refresh_button": "刷新额度",
     "fetch_all": "获取全部",
     "five_hour": "5 小时限额",
+    "five_hour_starts_on_use": "使用后开始计时",
     "seven_day": "7 天限额",
     "seven_day_oauth_apps": "7 天 OAuth 应用",
     "seven_day_opus": "7 天 Opus",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -415,6 +415,7 @@
     "refresh_button": "重新整理配額",
     "fetch_all": "取得全部",
     "five_hour": "5 小時限額",
+    "five_hour_starts_on_use": "使用後開始計時",
     "seven_day": "7 天限額",
     "seven_day_oauth_apps": "7 天 OAuth 應用",
     "seven_day_opus": "7 天 Opus",

--- a/tests/claudeFableQuota.test.ts
+++ b/tests/claudeFableQuota.test.ts
@@ -9,6 +9,36 @@ const modernReset = '2026-07-27T10:00:00.000000+00:00';
 const legacyReset = '2026-07-28T10:00:00.000000+00:00';
 
 describe('Claude Fable quota', () => {
+  test('explains an untouched five-hour window instead of leaving its reset blank', () => {
+    const windows = buildClaudeQuotaWindows(
+      {
+        five_hour: { utilization: 0, resets_at: null },
+        seven_day: { utilization: 20, resets_at: legacyReset },
+      },
+      t
+    );
+
+    expect(windows[0]).toMatchObject({
+      id: 'five-hour',
+      usedPercent: 0,
+      resetLabel: 'claude_quota.five_hour_starts_on_use',
+      resetAtMs: null,
+      periodHours: 5,
+    });
+  });
+
+  test('does not invent a reset hint when a used five-hour window lacks a timestamp', () => {
+    const windows = buildClaudeQuotaWindows(
+      {
+        five_hour: { utilization: 10, resets_at: null },
+        seven_day: { utilization: 20, resets_at: legacyReset },
+      },
+      t
+    );
+
+    expect(windows[0]?.resetLabel).toBe('-');
+  });
+
   test('builds a Fable window from the modern scoped limits payload', () => {
     const windows = buildClaudeQuotaWindows(
       {


### PR DESCRIPTION
## Summary

- show a localized “starts on use” hint when Claude reports a fully unused 5-hour window with `resets_at: null`
- keep real reset timestamps unchanged for active windows
- avoid inventing a hint for malformed used windows that lack a timestamp

Claude does not expose a reset instant until this rolling window begins. The previous blank row looked like a failed quota refresh even though the payload was valid.

## Verification

- `bun test tests/claudeFableQuota.test.ts`
- `bun run verify` (423 tests, lint, TypeScript compile, production build)