### PR TITLE
feat(quota): add Cursor as a quota provider

### DIFF
--- a/src/assets/icons/cursor.svg
+++ b/src/assets/icons/cursor.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path d="M12 1.8 21.6 7.2v9.6L12 22.2 2.4 16.8V7.2L12 1.8Z" fill="currentColor" fill-opacity=".18"/>
+  <path d="M12 1.8 21.6 7.2 12 12.6 2.4 7.2 12 1.8Z" fill="currentColor" fill-opacity=".55"/>
+  <path d="M21.6 7.2v9.6L12 22.2V12.6l9.6-5.4Z" fill="currentColor" fill-opacity=".8"/>
+  <path d="M12 1.8 21.6 7.2v9.6L12 22.2 2.4 16.8V7.2L12 1.8Z" stroke="currentColor" stroke-width="1.1" stroke-linejoin="round"/>
+</svg>

--- a/src/features/authFiles/components/AuthFileQuotaSection.tsx
+++ b/src/features/authFiles/components/AuthFileQuotaSection.tsx
@@ -45,6 +45,7 @@ export function AuthFileQuotaSection(props: AuthFileQuotaSectionProps) {
       return state.antigravityQuota[file.name] as QuotaCardState | undefined;
     if (quotaType === 'claude') return state.claudeQuota[file.name] as QuotaCardState | undefined;
     if (quotaType === 'codex') return state.codexQuota[file.name] as QuotaCardState | undefined;
+    if (quotaType === 'cursor') return state.cursorQuota[file.name] as QuotaCardState | undefined;
     if (quotaType === 'kimi') return state.kimiQuota[file.name] as QuotaCardState | undefined;
     if (quotaType === 'xai') return state.xaiQuota[file.name] as QuotaCardState | undefined;
     return assertNever(quotaType);

--- a/src/features/authFiles/constants.ts
+++ b/src/features/authFiles/constants.ts
@@ -2,6 +2,7 @@ import type { TFunction } from 'i18next';
 import iconAntigravity from '@/assets/icons/antigravity.svg';
 import iconClaude from '@/assets/icons/claude.svg';
 import iconCodex from '@/assets/icons/codex.svg';
+import iconCursor from '@/assets/icons/cursor.svg';
 import iconGemini from '@/assets/icons/gemini.svg';
 import iconGrok from '@/assets/icons/grok.svg';
 import iconGrokDark from '@/assets/icons/grok-dark.svg';
@@ -24,13 +25,14 @@ export type AuthFileModelItem = {
 };
 export type AuthFileIconAsset = string | { light: string; dark: string };
 
-export type QuotaProviderType = 'antigravity' | 'claude' | 'codex' | 'kimi' | 'xai';
+export type QuotaProviderType = 'antigravity' | 'claude' | 'codex' | 'cursor' | 'kimi' | 'xai';
 export type OAuthConfigLoadError = 'loading' | 'unsupported' | 'load' | null;
 
 export const QUOTA_PROVIDER_TYPES = new Set<QuotaProviderType>([
   'antigravity',
   'claude',
   'codex',
+  'cursor',
   'kimi',
   'xai',
 ]);
@@ -59,6 +61,7 @@ export const AUTH_FILE_MANUAL_REFRESH_PROVIDERS = new Set([
   'antigravity',
   'claude',
   'codex',
+  'cursor',
   'kimi',
   'xai',
 ]);
@@ -71,6 +74,7 @@ export const AUTH_FILE_ICONS: Record<string, AuthFileIconAsset> = {
   aistudio: iconGemini,
   claude: iconClaude,
   codex: iconCodex,
+  cursor: iconCursor,
   gemini: iconGemini,
   xai: { light: iconGrok, dark: iconGrokDark },
   iflow: iconIflow,

--- a/src/features/quota/QuotaPage.tsx
+++ b/src/features/quota/QuotaPage.tsx
@@ -103,6 +103,7 @@ export function QuotaPage() {
   const antigravityQuota = useQuotaStore((state) => state.antigravityQuota);
   const claudeQuota = useQuotaStore((state) => state.claudeQuota);
   const codexQuota = useQuotaStore((state) => state.codexQuota);
+  const cursorQuota = useQuotaStore((state) => state.cursorQuota);
   const kimiQuota = useQuotaStore((state) => state.kimiQuota);
   const xaiQuota = useQuotaStore((state) => state.xaiQuota);
 
@@ -112,10 +113,11 @@ export function QuotaPage() {
         antigravity: antigravityQuota,
         claude: claudeQuota,
         codex: codexQuota,
+        cursor: cursorQuota,
         kimi: kimiQuota,
         xai: xaiQuota,
       }) as unknown as Record<QuotaProviderType, Record<string, QuotaCardState>>,
-    [antigravityQuota, claudeQuota, codexQuota, kimiQuota, xaiQuota]
+    [antigravityQuota, claudeQuota, codexQuota, cursorQuota, kimiQuota, xaiQuota]
   );
 
   const getQuota = useCallback(

--- a/src/features/quota/constants.ts
+++ b/src/features/quota/constants.ts
@@ -7,6 +7,7 @@ export const QUOTA_TAB_ORDER: readonly QuotaProviderType[] = [
   'codex',
   'xai',
   'kimi',
+  'cursor',
 ];
 
 export type QuotaTabId = 'all' | QuotaProviderType;

--- a/src/features/quota/logic.ts
+++ b/src/features/quota/logic.ts
@@ -7,6 +7,7 @@ import type { AuthFileItem } from '@/types';
 import { ANTIGRAVITY_CONFIG } from './providers/antigravity/data';
 import { CLAUDE_CONFIG } from './providers/claude/data';
 import { CODEX_CONFIG } from './providers/codex/data';
+import { CURSOR_CONFIG } from './providers/cursor/data';
 import { KIMI_CONFIG } from './providers/kimi/data';
 import { XAI_CONFIG } from './providers/xai/data';
 import type { QuotaProviderType } from './providers/types';
@@ -16,6 +17,7 @@ const QUOTA_FILTER_MAP: Record<QuotaProviderType, (file: AuthFileItem) => boolea
   antigravity: ANTIGRAVITY_CONFIG.filterFn,
   claude: CLAUDE_CONFIG.filterFn,
   codex: CODEX_CONFIG.filterFn,
+  cursor: CURSOR_CONFIG.filterFn,
   kimi: KIMI_CONFIG.filterFn,
   xai: XAI_CONFIG.filterFn,
 };

--- a/src/features/quota/providers/cursor/CursorQuotaBody.tsx
+++ b/src/features/quota/providers/cursor/CursorQuotaBody.tsx
@@ -9,7 +9,12 @@ import { buildResetDisplay, formatCursorCents, formatQuotaResetTime } from '@/ut
 import { useNow } from '@/hooks/useNow';
 import { QuotaMeter } from '../../components/QuotaMeter';
 import { QuotaResetLabel } from '../../components/QuotaResetLabel';
-import { CURSOR_INCLUDED_ROW_ID, collectQuotaRowInstants, pickUrgentRowId } from '../../resetSchedule';
+import {
+  CURSOR_AGENT_ROW_ID,
+  CURSOR_INCLUDED_ROW_ID,
+  collectQuotaRowInstants,
+  pickUrgentRowId,
+} from '../../resetSchedule';
 import type { QuotaBodyProps } from '../../types';
 
 /**
@@ -27,10 +32,12 @@ export function CursorQuotaBody({ quota, classes }: QuotaBodyProps<CursorQuotaSt
   const { t, i18n } = useTranslation();
   // Ahead of the early return below — hooks cannot be conditional.
   const now = useNow();
-  const includedSoon = useMemo(
-    () => pickUrgentRowId(collectQuotaRowInstants('cursor', quota), now) === CURSOR_INCLUDED_ROW_ID,
+  const urgentRowId = useMemo(
+    () => pickUrgentRowId(collectQuotaRowInstants('cursor', quota), now),
     [quota, now]
   );
+  const includedSoon = urgentRowId === CURSOR_INCLUDED_ROW_ID;
+  const agentSoon = urgentRowId === CURSOR_AGENT_ROW_ID;
 
   const summary = quota.summary;
   if (!summary) {
@@ -48,6 +55,16 @@ export function CursorQuotaBody({ quota, classes }: QuotaBodyProps<CursorQuotaSt
   const resetDisplay = buildResetDisplay(
     resetLabel === '-' ? null : t('cursor_quota.reset_at', { time: resetLabel }),
     summary.cycleEndMs,
+    now,
+    i18n.resolvedLanguage
+  );
+
+  const agentResetLabel = formatQuotaResetTime(
+    summary.agent?.resetAtMs == null ? undefined : new Date(summary.agent.resetAtMs).toISOString()
+  );
+  const agentResetDisplay = buildResetDisplay(
+    agentResetLabel === '-' ? null : t('cursor_quota.reset_at', { time: agentResetLabel }),
+    summary.agent?.resetAtMs ?? null,
     now,
     i18n.resolvedLanguage
   );
@@ -90,7 +107,30 @@ export function CursorQuotaBody({ quota, classes }: QuotaBodyProps<CursorQuotaSt
         </div>
       )}
 
-      {(summary.autoPercentUsed !== null || summary.apiPercentUsed !== null) && (
+      {summary.agent && (
+        <div
+          className={classes.quotaRow}
+          title={agentSoon ? t('quota_management.soonest_row_hint') : undefined}
+        >
+          <div className={classes.quotaRowHeader}>
+            <span className={classes.quotaModel}>{t('cursor_quota.agent_usage')}</span>
+            <div className={classes.quotaMeta}>
+              <span className={classes.quotaPercent}>
+                {formatPercent(summary.agent.remainingPercent)}
+              </span>
+              {agentResetDisplay && (
+                <QuotaResetLabel display={agentResetDisplay} classes={classes} soon={agentSoon} />
+              )}
+            </div>
+          </div>
+          <QuotaMeter percent={summary.agent.remainingPercent} classes={classes} index={1} />
+          {summary.agent.exhausted && (
+            <div className={classes.quotaMessage}>{t('cursor_quota.agent_exhausted')}</div>
+          )}
+        </div>
+      )}
+
+      {(summary.autoPercentUsed !== null || summary.apiPercentUsed !== null || summary.fastRequestQuota !== null) && (
         <div className={classes.codexPlan}>
           {summary.autoPercentUsed !== null && (
             <span className={classes.codexPlanItem}>
@@ -102,6 +142,14 @@ export function CursorQuotaBody({ quota, classes }: QuotaBodyProps<CursorQuotaSt
             <span className={classes.codexPlanItem}>
               <span className={classes.codexPlanLabel}>{t('cursor_quota.api_used')}</span>
               <span className={classes.codexPlanValue}>{formatPercent(summary.apiPercentUsed)}</span>
+            </span>
+          )}
+          {summary.fastRequestQuota !== null && (
+            <span className={classes.codexPlanItem}>
+              <span className={classes.codexPlanLabel}>{t('cursor_quota.fast_requests')}</span>
+              <span className={classes.codexPlanValue}>
+                {summary.fastRequestQuota.toLocaleString()}
+              </span>
             </span>
           )}
         </div>

--- a/src/features/quota/providers/cursor/CursorQuotaBody.tsx
+++ b/src/features/quota/providers/cursor/CursorQuotaBody.tsx
@@ -1,0 +1,125 @@
+/**
+ * Cursor 额度渲染体：套餐 chip 行、包含额度水位条、按模型消费明细。
+ */
+
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { CursorQuotaState } from '@/types';
+import { buildResetDisplay, formatCursorCents, formatQuotaResetTime } from '@/utils/quota';
+import { useNow } from '@/hooks/useNow';
+import { QuotaMeter } from '../../components/QuotaMeter';
+import { QuotaResetLabel } from '../../components/QuotaResetLabel';
+import { CURSOR_INCLUDED_ROW_ID, collectQuotaRowInstants, pickUrgentRowId } from '../../resetSchedule';
+import type { QuotaBodyProps } from '../../types';
+
+/**
+ * Cursor's plan-level percentages arrive as fractions of a percent, small
+ * enough that rounding to whole numbers erases them entirely. One decimal is
+ * kept below 10% so a real number never renders as a flat zero.
+ */
+const formatPercent = (value: number | null): string => {
+  if (value === null) return '--';
+  if (value > 0 && value < 10) return `${value.toFixed(1)}%`;
+  return `${Math.round(value)}%`;
+};
+
+export function CursorQuotaBody({ quota, classes }: QuotaBodyProps<CursorQuotaState>) {
+  const { t, i18n } = useTranslation();
+  // Ahead of the early return below — hooks cannot be conditional.
+  const now = useNow();
+  const includedSoon = useMemo(
+    () => pickUrgentRowId(collectQuotaRowInstants('cursor', quota), now) === CURSOR_INCLUDED_ROW_ID,
+    [quota, now]
+  );
+
+  const summary = quota.summary;
+  if (!summary) {
+    return <div className={classes.quotaMessage}>{t('cursor_quota.empty_data')}</div>;
+  }
+
+  const amountLabel =
+    summary.limitCents === null
+      ? formatCursorCents(summary.remainingCents)
+      : `${formatCursorCents(summary.remainingCents ?? (summary.limitCents - (summary.usedCents ?? 0)))} / ${formatCursorCents(summary.limitCents)}`;
+
+  const resetLabel = formatQuotaResetTime(
+    summary.cycleEndMs === null ? undefined : new Date(summary.cycleEndMs).toISOString()
+  );
+  const resetDisplay = buildResetDisplay(
+    resetLabel === '-' ? null : t('cursor_quota.reset_at', { time: resetLabel }),
+    summary.cycleEndMs,
+    now,
+    i18n.resolvedLanguage
+  );
+
+  const hasIncluded = summary.limitCents !== null || summary.usedCents !== null;
+
+  return (
+    <>
+      {summary.planName && (
+        <div className={classes.codexPlan}>
+          <span className={classes.codexPlanItem}>
+            <span className={classes.codexPlanLabel}>{t('cursor_quota.plan_label')}</span>
+            <span className={classes.codexPlanValue}>{summary.planName}</span>
+          </span>
+          {summary.planPrice && (
+            <span className={classes.codexPlanItem}>
+              <span className={classes.codexPlanLabel}>{t('cursor_quota.price_label')}</span>
+              <span className={classes.codexPlanValue}>{summary.planPrice}</span>
+            </span>
+          )}
+        </div>
+      )}
+
+      {hasIncluded && (
+        <div
+          className={classes.quotaRow}
+          title={includedSoon ? t('quota_management.soonest_row_hint') : undefined}
+        >
+          <div className={classes.quotaRowHeader}>
+            <span className={classes.quotaModel}>{t('cursor_quota.included_usage')}</span>
+            <div className={classes.quotaMeta}>
+              <span className={classes.quotaPercent}>{formatPercent(summary.remainingPercent)}</span>
+              {resetDisplay && (
+                <QuotaResetLabel display={resetDisplay} classes={classes} soon={includedSoon} />
+              )}
+            </div>
+          </div>
+          <QuotaMeter percent={summary.remainingPercent} classes={classes} index={0} />
+          <div className={classes.quotaAmount}>{amountLabel}</div>
+        </div>
+      )}
+
+      {(summary.autoPercentUsed !== null || summary.apiPercentUsed !== null) && (
+        <div className={classes.codexPlan}>
+          {summary.autoPercentUsed !== null && (
+            <span className={classes.codexPlanItem}>
+              <span className={classes.codexPlanLabel}>{t('cursor_quota.auto_used')}</span>
+              <span className={classes.codexPlanValue}>{formatPercent(summary.autoPercentUsed)}</span>
+            </span>
+          )}
+          {summary.apiPercentUsed !== null && (
+            <span className={classes.codexPlanItem}>
+              <span className={classes.codexPlanLabel}>{t('cursor_quota.api_used')}</span>
+              <span className={classes.codexPlanValue}>{formatPercent(summary.apiPercentUsed)}</span>
+            </span>
+          )}
+        </div>
+      )}
+
+      {summary.models.length > 0 && (
+        <>
+          <div className={classes.codexResetCreditsTitle}>
+            {t('cursor_quota.by_model', { amount: formatCursorCents(summary.totalSpendCents) })}
+          </div>
+          {summary.models.map((model) => (
+            <div key={model.model} className={classes.codexResetCreditRow}>
+              <span className={classes.codexResetCreditLabel}>{model.model}</span>
+              <span className={classes.codexResetCreditTime}>{formatCursorCents(model.cents)}</span>
+            </div>
+          ))}
+        </>
+      )}
+    </>
+  );
+}

--- a/src/features/quota/providers/cursor/data.ts
+++ b/src/features/quota/providers/cursor/data.ts
@@ -1,0 +1,94 @@
+/**
+ * Cursor 额度数据层。React-free / SCSS-free。
+ */
+
+import type { TFunction } from 'i18next';
+import type {
+  AuthFileItem,
+  CursorAggregatedUsage,
+  CursorCurrentPeriodUsage,
+  CursorPlanInfo,
+  CursorQuotaState,
+  CursorQuotaSummary,
+} from '@/types';
+import { apiCallApi, getApiCallErrorMessage } from '@/services/api';
+import {
+  CURSOR_AGGREGATED_USAGE_URL,
+  CURSOR_PERIOD_USAGE_URL,
+  CURSOR_PLAN_INFO_URL,
+  CURSOR_REQUEST_HEADERS,
+  buildCursorQuotaSummary,
+  createStatusError,
+  isCursorFile,
+  isDisabledAuthFile,
+  parseCursorPayload,
+} from '@/utils/quota';
+import { normalizeAuthIndex } from '@/utils/authIndex';
+import type { QuotaProviderData } from '../types';
+
+/**
+ * One DashboardService read.
+ *
+ * `required` separates the two reads that carry the allowance from the model
+ * breakdown, which is enrichment: an account whose usage aggregation fails
+ * still has a quota worth showing, but one whose period read fails has nothing
+ * and must say so rather than render an empty meter.
+ */
+const read = async <T>(authIndex: string, url: string, required: boolean): Promise<T | null> => {
+  const result = await apiCallApi.request({
+    authIndex,
+    method: 'POST',
+    url,
+    header: { ...CURSOR_REQUEST_HEADERS },
+    data: '{}',
+  });
+
+  if (result.statusCode < 200 || result.statusCode >= 300) {
+    if (!required) return null;
+    throw createStatusError(getApiCallErrorMessage(result), result.statusCode);
+  }
+
+  return parseCursorPayload<T>(result.body ?? result.bodyText);
+};
+
+const fetchCursorQuota = async (file: AuthFileItem, t: TFunction): Promise<CursorQuotaSummary> => {
+  const rawAuthIndex = file['auth_index'] ?? file.authIndex;
+  const authIndex = normalizeAuthIndex(rawAuthIndex);
+  if (!authIndex) {
+    throw new Error(t('cursor_quota.missing_auth_index'));
+  }
+
+  const [plan, period, usage] = await Promise.all([
+    read<CursorPlanInfo>(authIndex, CURSOR_PLAN_INFO_URL, false),
+    read<CursorCurrentPeriodUsage>(authIndex, CURSOR_PERIOD_USAGE_URL, true),
+    read<CursorAggregatedUsage>(authIndex, CURSOR_AGGREGATED_USAGE_URL, false),
+  ]);
+
+  if (!period) {
+    throw new Error(t('cursor_quota.empty_data'));
+  }
+
+  const summary = buildCursorQuotaSummary(plan, period, usage);
+  if (summary.limitCents === null && summary.usedCents === null) {
+    throw new Error(t('cursor_quota.empty_data'));
+  }
+
+  return summary;
+};
+
+export const CURSOR_CONFIG: QuotaProviderData<CursorQuotaState, CursorQuotaSummary> = {
+  type: 'cursor',
+  i18nPrefix: 'cursor_quota',
+  filterFn: (file) => isCursorFile(file) && !isDisabledAuthFile(file),
+  fetchQuota: fetchCursorQuota,
+  storeSelector: (state) => state.cursorQuota,
+  storeSetter: 'setCursorQuota',
+  buildLoadingState: () => ({ status: 'loading', summary: null }),
+  buildSuccessState: (summary) => ({ status: 'success', summary }),
+  buildErrorState: (message, status) => ({
+    status: 'error',
+    summary: null,
+    error: message,
+    errorStatus: status,
+  }),
+};

--- a/src/features/quota/providers/cursor/data.ts
+++ b/src/features/quota/providers/cursor/data.ts
@@ -5,15 +5,19 @@
 import type { TFunction } from 'i18next';
 import type {
   AuthFileItem,
+  CursorAgentUsage,
   CursorAggregatedUsage,
   CursorCurrentPeriodUsage,
+  CursorFastRequests,
   CursorPlanInfo,
   CursorQuotaState,
   CursorQuotaSummary,
 } from '@/types';
 import { apiCallApi, getApiCallErrorMessage } from '@/services/api';
 import {
+  CURSOR_AGENT_USAGE_URL,
   CURSOR_AGGREGATED_USAGE_URL,
+  CURSOR_FAST_REQUESTS_URL,
   CURSOR_PERIOD_USAGE_URL,
   CURSOR_PLAN_INFO_URL,
   CURSOR_REQUEST_HEADERS,
@@ -58,17 +62,19 @@ const fetchCursorQuota = async (file: AuthFileItem, t: TFunction): Promise<Curso
     throw new Error(t('cursor_quota.missing_auth_index'));
   }
 
-  const [plan, period, usage] = await Promise.all([
+  const [plan, period, usage, agent, fast] = await Promise.all([
     read<CursorPlanInfo>(authIndex, CURSOR_PLAN_INFO_URL, false),
     read<CursorCurrentPeriodUsage>(authIndex, CURSOR_PERIOD_USAGE_URL, true),
     read<CursorAggregatedUsage>(authIndex, CURSOR_AGGREGATED_USAGE_URL, false),
+    read<CursorAgentUsage>(authIndex, CURSOR_AGENT_USAGE_URL, false),
+    read<CursorFastRequests>(authIndex, CURSOR_FAST_REQUESTS_URL, false),
   ]);
 
   if (!period) {
     throw new Error(t('cursor_quota.empty_data'));
   }
 
-  const summary = buildCursorQuotaSummary(plan, period, usage);
+  const summary = buildCursorQuotaSummary(plan, period, usage, agent, fast);
   if (summary.limitCents === null && summary.usedCents === null) {
     throw new Error(t('cursor_quota.empty_data'));
   }

--- a/src/features/quota/providers/index.ts
+++ b/src/features/quota/providers/index.ts
@@ -17,6 +17,8 @@ import { CLAUDE_CONFIG } from './claude/data';
 import { ClaudeQuotaBody } from './claude/ClaudeQuotaBody';
 import { CODEX_CONFIG } from './codex/data';
 import { CodexQuotaBody } from './codex/CodexQuotaBody';
+import { CURSOR_CONFIG } from './cursor/data';
+import { CursorQuotaBody } from './cursor/CursorQuotaBody';
 import { KIMI_CONFIG } from './kimi/data';
 import { KimiQuotaBody } from './kimi/KimiQuotaBody';
 import { XAI_CONFIG } from './xai/data';
@@ -51,6 +53,7 @@ export const QUOTA_ADAPTERS: Record<QuotaProviderType, QuotaAdapter> = {
   } as unknown as QuotaAdapter,
   claude: { ...CLAUDE_CONFIG, Body: ClaudeQuotaBody } as unknown as QuotaAdapter,
   codex: { ...CODEX_CONFIG, Body: CodexQuotaBody } as unknown as QuotaAdapter,
+  cursor: { ...CURSOR_CONFIG, Body: CursorQuotaBody } as unknown as QuotaAdapter,
   kimi: { ...KIMI_CONFIG, Body: KimiQuotaBody } as unknown as QuotaAdapter,
   xai: { ...XAI_CONFIG, Body: XaiQuotaBody } as unknown as QuotaAdapter,
 };

--- a/src/features/quota/providers/types.ts
+++ b/src/features/quota/providers/types.ts
@@ -11,24 +11,27 @@ import type {
   AuthFileItem,
   ClaudeQuotaState,
   CodexQuotaState,
+  CursorQuotaState,
   KimiQuotaState,
   XaiQuotaState,
 } from '@/types';
 
 export type QuotaUpdater<T> = T | ((prev: T) => T);
 
-export type QuotaProviderType = 'antigravity' | 'claude' | 'codex' | 'kimi' | 'xai';
+export type QuotaProviderType = 'antigravity' | 'claude' | 'codex' | 'cursor' | 'kimi' | 'xai';
 
 /** useQuotaStore 的结构契约（storeSelector/storeSetter 依赖）。 */
 export interface QuotaStore {
   antigravityQuota: Record<string, AntigravityQuotaState>;
   claudeQuota: Record<string, ClaudeQuotaState>;
   codexQuota: Record<string, CodexQuotaState>;
+  cursorQuota: Record<string, CursorQuotaState>;
   kimiQuota: Record<string, KimiQuotaState>;
   xaiQuota: Record<string, XaiQuotaState>;
   setAntigravityQuota: (updater: QuotaUpdater<Record<string, AntigravityQuotaState>>) => void;
   setClaudeQuota: (updater: QuotaUpdater<Record<string, ClaudeQuotaState>>) => void;
   setCodexQuota: (updater: QuotaUpdater<Record<string, CodexQuotaState>>) => void;
+  setCursorQuota: (updater: QuotaUpdater<Record<string, CursorQuotaState>>) => void;
   setKimiQuota: (updater: QuotaUpdater<Record<string, KimiQuotaState>>) => void;
   setXaiQuota: (updater: QuotaUpdater<Record<string, XaiQuotaState>>) => void;
   clearQuotaCache: () => void;

--- a/src/features/quota/quotaTimelineModel.ts
+++ b/src/features/quota/quotaTimelineModel.ts
@@ -466,6 +466,36 @@ export function buildTimelineLane(input: TimelineLaneInput): TimelineLane {
     };
   }
 
+  if (provider === 'cursor') {
+    const summary = (
+      quota as {
+        summary?: {
+          cycleEndMs?: number | null;
+          periodHours?: number | null;
+          remainingPercent?: number | null;
+        } | null;
+      }
+    ).summary;
+    if (!summary) return empty;
+    if (typeof summary.cycleEndMs !== 'number' || !Number.isFinite(summary.cycleEndMs)) return empty;
+
+    const remaining =
+      typeof summary.remainingPercent === 'number' ? clampPercent(summary.remainingPercent) : null;
+
+    return {
+      ...empty,
+      anchorMs: summary.cycleEndMs,
+      // A cycle that reported no start cannot state its own length; Cursor
+      // bills monthly, so 30 days is the shape, not a guess at the boundary.
+      periodHours:
+        typeof summary.periodHours === 'number' && summary.periodHours > 0
+          ? summary.periodHours
+          : 24 * 30,
+      remaining,
+      limits: remaining === null ? [] : [{ label: 'included', remaining }],
+    };
+  }
+
   if (provider === 'kimi') {
     const rows = ((quota as { rows?: KimiRowLike[] }).rows ?? []).filter(
       (row) => typeof row.resetAtMs === 'number'

--- a/src/features/quota/resetSchedule.ts
+++ b/src/features/quota/resetSchedule.ts
@@ -65,6 +65,9 @@ export const XAI_WEEKLY_ROW_ID = 'xai:weekly';
 /** Row id for Cursor's included-allowance window, which has no id of its own. */
 export const CURSOR_INCLUDED_ROW_ID = 'cursor:included';
 
+/** Row id for Cursor's agent window, a weekly limit beside the monthly one. */
+export const CURSOR_AGENT_ROW_ID = 'cursor:agent';
+
 const isUsableMs = (value: unknown): value is number =>
   typeof value === 'number' && Number.isFinite(value);
 
@@ -136,9 +139,29 @@ export function collectQuotaRowInstants(
     // Unlike xAI's monthly figure, this billing cycle IS the quota window: the
     // included allowance is what rate-limits the account, and it returns in
     // full when the cycle rolls. There is no separate shorter window to prefer.
-    const summary = (quota as { summary?: { cycleEndMs?: number | null } | null }).summary;
-    if (!summary || !isUsableMs(summary.cycleEndMs)) return [];
-    return [{ rowId: CURSOR_INCLUDED_ROW_ID, atMs: summary.cycleEndMs, kind: 'window' }];
+    const summary = (
+      quota as {
+        summary?: {
+          cycleEndMs?: number | null;
+          agent?: { resetAtMs?: number | null } | null;
+        } | null;
+      }
+    ).summary;
+    if (!summary) return [];
+    const instants: QuotaRowInstant[] = [];
+    if (isUsableMs(summary.cycleEndMs)) {
+      instants.push({ rowId: CURSOR_INCLUDED_ROW_ID, atMs: summary.cycleEndMs, kind: 'window' });
+    }
+    // The weekly agent window usually recovers long before the monthly one, so
+    // omitting it would rank this card by the wrong date under "soonest".
+    if (isUsableMs(summary.agent?.resetAtMs)) {
+      instants.push({
+        rowId: CURSOR_AGENT_ROW_ID,
+        atMs: summary.agent?.resetAtMs as number,
+        kind: 'window',
+      });
+    }
+    return instants;
   }
 
   return [];

--- a/src/features/quota/resetSchedule.ts
+++ b/src/features/quota/resetSchedule.ts
@@ -62,6 +62,9 @@ interface ResetCreditLike {
 /** Row id used by the xAI weekly limit, which has no id of its own. */
 export const XAI_WEEKLY_ROW_ID = 'xai:weekly';
 
+/** Row id for Cursor's included-allowance window, which has no id of its own. */
+export const CURSOR_INCLUDED_ROW_ID = 'cursor:included';
+
 const isUsableMs = (value: unknown): value is number =>
   typeof value === 'number' && Number.isFinite(value);
 
@@ -127,6 +130,15 @@ export function collectQuotaRowInstants(
 
   if (provider === 'kimi') {
     return collectRows((quota as { rows?: WindowLike[] }).rows ?? [], 'row');
+  }
+
+  if (provider === 'cursor') {
+    // Unlike xAI's monthly figure, this billing cycle IS the quota window: the
+    // included allowance is what rate-limits the account, and it returns in
+    // full when the cycle rolls. There is no separate shorter window to prefer.
+    const summary = (quota as { summary?: { cycleEndMs?: number | null } | null }).summary;
+    if (!summary || !isUsableMs(summary.cycleEndMs)) return [];
+    return [{ rowId: CURSOR_INCLUDED_ROW_ID, atMs: summary.cycleEndMs, kind: 'window' }];
   }
 
   return [];

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -490,7 +490,10 @@
     "auto_used": "Auto used",
     "api_used": "API used",
     "by_model": "By model ({{amount}})",
-    "reset_at": "resets {{time}}"
+    "reset_at": "resets {{time}}",
+    "agent_usage": "Agent usage (weekly)",
+    "agent_exhausted": "Weekly agent usage is exhausted",
+    "fast_requests": "Fast requests"
   },
   "kimi_quota": {
     "title": "Kimi Quota",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -473,6 +473,25 @@
     "plan_pro": "Pro 20x",
     "plan_prolite": "Pro 5x"
   },
+  "cursor_quota": {
+    "title": "Cursor Quota",
+    "empty_title": "No Cursor Auth Files",
+    "empty_desc": "Sign in to Cursor from the plugin panel to view remaining quota.",
+    "idle": "Click here to refresh quota",
+    "loading": "Loading quota...",
+    "load_failed": "Failed to load quota: {{message}}",
+    "missing_auth_index": "Auth file missing auth_index",
+    "empty_data": "No quota data available",
+    "refresh_button": "Refresh Quota",
+    "fetch_all": "Fetch All",
+    "plan_label": "Plan",
+    "price_label": "Price",
+    "included_usage": "Included usage",
+    "auto_used": "Auto used",
+    "api_used": "API used",
+    "by_model": "By model ({{amount}})",
+    "reset_at": "resets {{time}}"
+  },
   "kimi_quota": {
     "title": "Kimi Quota",
     "empty_title": "No Kimi Auth Files",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -460,6 +460,25 @@
     "plan_pro": "Pro 20x",
     "plan_prolite": "Pro 5x"
   },
+  "cursor_quota": {
+    "title": "Квота Cursor",
+    "empty_title": "Нет учётных данных Cursor",
+    "empty_desc": "Войдите в Cursor на панели плагина, чтобы увидеть остаток квоты.",
+    "idle": "Нажмите, чтобы обновить квоту",
+    "loading": "Загрузка квоты...",
+    "load_failed": "Не удалось загрузить квоту: {{message}}",
+    "missing_auth_index": "В учётных данных нет auth_index",
+    "empty_data": "Нет данных о квоте",
+    "refresh_button": "Обновить квоту",
+    "fetch_all": "Загрузить все",
+    "plan_label": "План",
+    "price_label": "Цена",
+    "included_usage": "Включённый объём",
+    "auto_used": "Auto использовано",
+    "api_used": "API использовано",
+    "by_model": "По моделям ({{amount}})",
+    "reset_at": "сброс {{time}}"
+  },
   "kimi_quota": {
     "title": "Квота Kimi",
     "empty_title": "Файлы авторизации Kimi отсутствуют",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -477,7 +477,10 @@
     "auto_used": "Auto использовано",
     "api_used": "API использовано",
     "by_model": "По моделям ({{amount}})",
-    "reset_at": "сброс {{time}}"
+    "reset_at": "сброс {{time}}",
+    "agent_usage": "Использование агента (за неделю)",
+    "agent_exhausted": "Недельная квота агента исчерпана",
+    "fast_requests": "Быстрые запросы"
   },
   "kimi_quota": {
     "title": "Квота Kimi",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -490,7 +490,10 @@
     "auto_used": "Auto 已用",
     "api_used": "API 已用",
     "by_model": "按模型（{{amount}}）",
-    "reset_at": "{{time}} 重置"
+    "reset_at": "{{time}} 重置",
+    "agent_usage": "Agent 用量（每周）",
+    "agent_exhausted": "本周 Agent 用量已用尽",
+    "fast_requests": "快速请求"
   },
   "kimi_quota": {
     "title": "Kimi 额度",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -473,6 +473,25 @@
     "plan_pro": "Pro 20x",
     "plan_prolite": "Pro 5x"
   },
+  "cursor_quota": {
+    "title": "Cursor 额度",
+    "empty_title": "没有 Cursor 凭证",
+    "empty_desc": "在插件面板中登录 Cursor 后即可查看剩余额度。",
+    "idle": "点击刷新额度",
+    "loading": "正在加载额度...",
+    "load_failed": "加载额度失败：{{message}}",
+    "missing_auth_index": "凭证缺少 auth_index",
+    "empty_data": "暂无额度数据",
+    "refresh_button": "刷新额度",
+    "fetch_all": "全部获取",
+    "plan_label": "套餐",
+    "price_label": "价格",
+    "included_usage": "包含额度",
+    "auto_used": "Auto 已用",
+    "api_used": "API 已用",
+    "by_model": "按模型（{{amount}}）",
+    "reset_at": "{{time}} 重置"
+  },
   "kimi_quota": {
     "title": "Kimi 额度",
     "empty_title": "暂无 Kimi 认证",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -490,7 +490,10 @@
     "auto_used": "Auto 已用",
     "api_used": "API 已用",
     "by_model": "依模型（{{amount}}）",
-    "reset_at": "{{time}} 重置"
+    "reset_at": "{{time}} 重置",
+    "agent_usage": "Agent 用量（每週）",
+    "agent_exhausted": "本週 Agent 用量已用盡",
+    "fast_requests": "快速請求"
   },
   "kimi_quota": {
     "title": "Kimi 配額",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -473,6 +473,25 @@
     "plan_pro": "Pro 20x",
     "plan_prolite": "Pro 5x"
   },
+  "cursor_quota": {
+    "title": "Cursor 額度",
+    "empty_title": "沒有 Cursor 憑證",
+    "empty_desc": "在外掛面板登入 Cursor 後即可查看剩餘額度。",
+    "idle": "點擊重新整理額度",
+    "loading": "正在載入額度...",
+    "load_failed": "載入額度失敗：{{message}}",
+    "missing_auth_index": "憑證缺少 auth_index",
+    "empty_data": "暫無額度資料",
+    "refresh_button": "重新整理額度",
+    "fetch_all": "全部取得",
+    "plan_label": "方案",
+    "price_label": "價格",
+    "included_usage": "包含額度",
+    "auto_used": "Auto 已用",
+    "api_used": "API 已用",
+    "by_model": "依模型（{{amount}}）",
+    "reset_at": "{{time}} 重置"
+  },
   "kimi_quota": {
     "title": "Kimi 配額",
     "empty_title": "暫無 Kimi 驗證",

--- a/src/stores/useQuotaStore.ts
+++ b/src/stores/useQuotaStore.ts
@@ -7,6 +7,7 @@ import type {
   AntigravityQuotaState,
   ClaudeQuotaState,
   CodexQuotaState,
+  CursorQuotaState,
   KimiQuotaState,
   XaiQuotaState,
 } from '@/types';
@@ -18,11 +19,13 @@ interface QuotaStoreState {
   antigravityQuota: Record<string, AntigravityQuotaState>;
   claudeQuota: Record<string, ClaudeQuotaState>;
   codexQuota: Record<string, CodexQuotaState>;
+  cursorQuota: Record<string, CursorQuotaState>;
   kimiQuota: Record<string, KimiQuotaState>;
   xaiQuota: Record<string, XaiQuotaState>;
   setAntigravityQuota: (updater: QuotaUpdater<Record<string, AntigravityQuotaState>>) => void;
   setClaudeQuota: (updater: QuotaUpdater<Record<string, ClaudeQuotaState>>) => void;
   setCodexQuota: (updater: QuotaUpdater<Record<string, CodexQuotaState>>) => void;
+  setCursorQuota: (updater: QuotaUpdater<Record<string, CursorQuotaState>>) => void;
   setKimiQuota: (updater: QuotaUpdater<Record<string, KimiQuotaState>>) => void;
   setXaiQuota: (updater: QuotaUpdater<Record<string, XaiQuotaState>>) => void;
   clearQuotaCache: () => void;
@@ -40,6 +43,7 @@ export const useQuotaStore = create<QuotaStoreState>((set) => ({
   antigravityQuota: {},
   claudeQuota: {},
   codexQuota: {},
+  cursorQuota: {},
   kimiQuota: {},
   xaiQuota: {},
   setAntigravityQuota: (updater) =>
@@ -53,6 +57,10 @@ export const useQuotaStore = create<QuotaStoreState>((set) => ({
   setCodexQuota: (updater) =>
     set((state) => ({
       codexQuota: resolveUpdater(updater, state.codexQuota),
+    })),
+  setCursorQuota: (updater) =>
+    set((state) => ({
+      cursorQuota: resolveUpdater(updater, state.cursorQuota),
     })),
   setKimiQuota: (updater) =>
     set((state) => ({
@@ -68,6 +76,7 @@ export const useQuotaStore = create<QuotaStoreState>((set) => ({
       antigravityQuota: {},
       claudeQuota: {},
       codexQuota: {},
+      cursorQuota: {},
       kimiQuota: {},
       xaiQuota: {},
     })),

--- a/src/types/quota.ts
+++ b/src/types/quota.ts
@@ -447,6 +447,27 @@ export interface CursorModelSpend {
   cacheWriteTokens: number;
 }
 
+export interface CursorAgentUsage {
+  currentPeriodStart?: string;
+  nextResetTimestampUtc?: string;
+  usagePercent?: number | string;
+  hasAvailableUsage?: boolean;
+  hasNonZeroIncludedLimit?: boolean;
+}
+
+export interface CursorFastRequests {
+  requestQuota?: number | string;
+}
+
+/** Cursor's agent product runs on its own weekly window. */
+export interface CursorAgentWindow {
+  usedPercent: number | null;
+  remainingPercent: number | null;
+  resetAtMs: number | null;
+  periodHours: number | null;
+  exhausted: boolean;
+}
+
 export interface CursorQuotaSummary {
   planName: string | null;
   planPrice: string | null;
@@ -464,6 +485,8 @@ export interface CursorQuotaSummary {
   periodHours: number | null;
   models: CursorModelSpend[];
   totalSpendCents: number | null;
+  agent: CursorAgentWindow | null;
+  fastRequestQuota: number | null;
 }
 
 export interface CursorQuotaState {

--- a/src/types/quota.ts
+++ b/src/types/quota.ts
@@ -397,3 +397,78 @@ export interface XaiQuotaState {
   error?: string;
   errorStatus?: number;
 }
+
+// Cursor payload types (aiserver.v1.DashboardService)
+export interface CursorPlanInfo {
+  planInfo?: {
+    planName?: string;
+    includedAmountCents?: number | string;
+    price?: string;
+    billingCycleEnd?: string;
+    planOwner?: string;
+  };
+}
+
+export interface CursorCurrentPeriodUsage {
+  billingCycleStart?: string;
+  billingCycleEnd?: string;
+  planUsage?: {
+    totalSpend?: number | string;
+    includedSpend?: number | string;
+    remaining?: number | string;
+    limit?: number | string;
+    autoPercentUsed?: number | string;
+    apiPercentUsed?: number | string;
+    totalPercentUsed?: number | string;
+  };
+  spendLimitUsage?: { limitType?: string };
+}
+
+export interface CursorAggregatedUsage {
+  aggregations?: {
+    modelIntent?: string;
+    inputTokens?: string;
+    outputTokens?: string;
+    cacheReadTokens?: string;
+    cacheWriteTokens?: string;
+    totalCents?: number | string;
+    tier?: number;
+  }[];
+  totalCostCents?: number | string;
+}
+
+/** One model's share of the period's spend. */
+export interface CursorModelSpend {
+  model: string;
+  cents: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+}
+
+export interface CursorQuotaSummary {
+  planName: string | null;
+  planPrice: string | null;
+  spendLimitType: string | null;
+  limitCents: number | null;
+  usedCents: number | null;
+  remainingCents: number | null;
+  /** Remaining share of the included allowance, 0..100. */
+  remainingPercent: number | null;
+  autoPercentUsed: number | null;
+  apiPercentUsed: number | null;
+  cycleStartMs: number | null;
+  /** Instant the allowance returns, in epoch ms. */
+  cycleEndMs: number | null;
+  periodHours: number | null;
+  models: CursorModelSpend[];
+  totalSpendCents: number | null;
+}
+
+export interface CursorQuotaState {
+  status: 'idle' | 'loading' | 'success' | 'error';
+  summary: CursorQuotaSummary | null;
+  error?: string;
+  errorStatus?: number;
+}

--- a/src/utils/quota/constants.ts
+++ b/src/utils/quota/constants.ts
@@ -30,6 +30,10 @@ export const TYPE_COLORS: Record<string, TypeColorSet> = {
     light: { bg: '#dce8ff', text: '#0560cf' },
     dark: { bg: '#003880', text: '#70b5ff' },
   },
+  cursor: {
+    light: { bg: '#e8eaed', text: '#1f2328' },
+    dark: { bg: '#2b2f36', text: '#d7dbe2' },
+  },
   antigravity: {
     light: { bg: '#e0f7fa', text: '#006064' },
     dark: { bg: '#004d40', text: '#80deea' },

--- a/src/utils/quota/cursor.ts
+++ b/src/utils/quota/cursor.ts
@@ -8,8 +8,11 @@
  */
 
 import type {
+  CursorAgentUsage,
+  CursorAgentWindow,
   CursorAggregatedUsage,
   CursorCurrentPeriodUsage,
+  CursorFastRequests,
   CursorModelSpend,
   CursorPlanInfo,
   CursorQuotaSummary,
@@ -21,6 +24,10 @@ const CURSOR_DASHBOARD = 'https://api2.cursor.sh/aiserver.v1.DashboardService';
 export const CURSOR_PLAN_INFO_URL = `${CURSOR_DASHBOARD}/GetPlanInfo`;
 export const CURSOR_PERIOD_USAGE_URL = `${CURSOR_DASHBOARD}/GetCurrentPeriodUsage`;
 export const CURSOR_AGGREGATED_USAGE_URL = `${CURSOR_DASHBOARD}/GetAggregatedUsageEvents`;
+/** The agent product's own weekly window, separate from the dollar allowance. */
+export const CURSOR_AGENT_USAGE_URL = `${CURSOR_DASHBOARD}/GetSandUsageStatus`;
+/** Legacy request pool, still reported and still consumed by some surfaces. */
+export const CURSOR_FAST_REQUESTS_URL = `${CURSOR_DASHBOARD}/GetFastRequests`;
 
 export const CURSOR_REQUEST_HEADERS = {
   Authorization: 'Bearer $TOKEN$',
@@ -106,10 +113,19 @@ export function buildCursorModelRows(usage: CursorAggregatedUsage | null): Curso
  * allowance returns, which is what makes this a quota window rather than an
  * invoice.
  */
+/** Milliseconds for an ISO instant, or null when it is absent or unparseable. */
+const isoToMs = (value: unknown): number | null => {
+  if (typeof value !== 'string' || value.trim() === '') return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
 export function buildCursorQuotaSummary(
   plan: CursorPlanInfo | null,
   period: CursorCurrentPeriodUsage | null,
-  usage: CursorAggregatedUsage | null
+  usage: CursorAggregatedUsage | null,
+  agent: CursorAgentUsage | null = null,
+  fast: CursorFastRequests | null = null
 ): CursorQuotaSummary {
   const planUsage = period?.planUsage;
 
@@ -148,5 +164,36 @@ export function buildCursorQuotaSummary(
     periodHours,
     models: buildCursorModelRows(usage),
     totalSpendCents: parseCursorNumber(usage?.totalCostCents),
+    agent: buildCursorAgentWindow(agent),
+    fastRequestQuota: parseCursorNumber(fast?.requestQuota),
+  };
+}
+
+/**
+ * The agent product's weekly window.
+ *
+ * It is a second quota, not a view of the first: it runs on its own weekly
+ * period and its own percentage, and an account can exhaust it with the dollar
+ * allowance barely touched. `hasNonZeroIncludedLimit` false means the plan
+ * includes none of it, which is different from having used none.
+ */
+export function buildCursorAgentWindow(agent: CursorAgentUsage | null): CursorAgentWindow | null {
+  if (!agent) return null;
+  if (agent.hasNonZeroIncludedLimit === false) return null;
+
+  const usedPercent = parseCursorNumber(agent.usagePercent);
+  const resetAtMs = isoToMs(agent.nextResetTimestampUtc);
+  const startedAtMs = isoToMs(agent.currentPeriodStart);
+  if (usedPercent === null && resetAtMs === null) return null;
+
+  return {
+    usedPercent,
+    remainingPercent: usedPercent === null ? null : Math.max(0, Math.min(100, 100 - usedPercent)),
+    resetAtMs,
+    periodHours:
+      startedAtMs !== null && resetAtMs !== null && resetAtMs > startedAtMs
+        ? (resetAtMs - startedAtMs) / HOUR_MS
+        : null,
+    exhausted: agent.hasAvailableUsage === false,
   };
 }

--- a/src/utils/quota/cursor.ts
+++ b/src/utils/quota/cursor.ts
@@ -1,0 +1,152 @@
+/**
+ * Cursor quota data layer helpers.
+ *
+ * Cursor reports a subscription allowance in cents against a monthly billing
+ * cycle, plus a per-model spend breakdown for the same period. Three reads on
+ * `aiserver.v1.DashboardService` cover it; everything here is pure parsing over
+ * their payloads so the shapes stay testable without a network.
+ */
+
+import type {
+  CursorAggregatedUsage,
+  CursorCurrentPeriodUsage,
+  CursorModelSpend,
+  CursorPlanInfo,
+  CursorQuotaSummary,
+} from '@/types';
+
+/** Cursor's account plane. Inference lives elsewhere and is not read here. */
+const CURSOR_DASHBOARD = 'https://api2.cursor.sh/aiserver.v1.DashboardService';
+
+export const CURSOR_PLAN_INFO_URL = `${CURSOR_DASHBOARD}/GetPlanInfo`;
+export const CURSOR_PERIOD_USAGE_URL = `${CURSOR_DASHBOARD}/GetCurrentPeriodUsage`;
+export const CURSOR_AGGREGATED_USAGE_URL = `${CURSOR_DASHBOARD}/GetAggregatedUsageEvents`;
+
+export const CURSOR_REQUEST_HEADERS = {
+  Authorization: 'Bearer $TOKEN$',
+  'Content-Type': 'application/json',
+};
+
+/** How many models the card lists before it stops. */
+export const CURSOR_MODEL_ROW_LIMIT = 6;
+
+const HOUR_MS = 60 * 60 * 1000;
+
+/**
+ * Cursor sends every 64-bit field as a decimal string, so a plain `Number()`
+ * on a missing key would yield NaN and render as a real zero. Absent stays
+ * absent.
+ */
+export const parseCursorNumber = (value: unknown): number | null => {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (trimmed === '') return null;
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+export const parseCursorPayload = <T>(body: unknown): T | null => {
+  if (body && typeof body === 'object') return body as T;
+  if (typeof body !== 'string') return null;
+  try {
+    const parsed: unknown = JSON.parse(body);
+    return parsed && typeof parsed === 'object' ? (parsed as T) : null;
+  } catch {
+    return null;
+  }
+};
+
+/** Cents to a displayable amount. Cursor counts in whole cents. */
+export const formatCursorCents = (cents: number | null): string => {
+  if (cents === null) return '--';
+  return `$${(cents / 100).toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+};
+
+const sortBySpend = (models: CursorModelSpend[]): CursorModelSpend[] =>
+  [...models].sort((left, right) => right.cents - left.cents || left.model.localeCompare(right.model));
+
+/**
+ * The per-model breakdown, costliest first.
+ *
+ * Rows with no cost are dropped rather than listed at zero: a model that was
+ * loaded but never billed says nothing about where the allowance went.
+ */
+export function buildCursorModelRows(usage: CursorAggregatedUsage | null): CursorModelSpend[] {
+  const aggregations = usage?.aggregations ?? [];
+  const rows = aggregations
+    .map((row): CursorModelSpend | null => {
+      const model = typeof row?.modelIntent === 'string' ? row.modelIntent.trim() : '';
+      if (model === '') return null;
+      const cents = parseCursorNumber(row?.totalCents) ?? 0;
+      if (cents <= 0) return null;
+      return {
+        model,
+        cents,
+        inputTokens: parseCursorNumber(row?.inputTokens) ?? 0,
+        outputTokens: parseCursorNumber(row?.outputTokens) ?? 0,
+        cacheReadTokens: parseCursorNumber(row?.cacheReadTokens) ?? 0,
+        cacheWriteTokens: parseCursorNumber(row?.cacheWriteTokens) ?? 0,
+      };
+    })
+    .filter((row): row is CursorModelSpend => row !== null);
+
+  return sortBySpend(rows).slice(0, CURSOR_MODEL_ROW_LIMIT);
+}
+
+/**
+ * One card's worth of state, assembled from the three reads.
+ *
+ * `limit` is the plan's included allowance and `used` what has been drawn from
+ * it, both in cents, so the meter reads the same way as every other provider's:
+ * remaining capacity, not money spent. The billing cycle end is the instant the
+ * allowance returns, which is what makes this a quota window rather than an
+ * invoice.
+ */
+export function buildCursorQuotaSummary(
+  plan: CursorPlanInfo | null,
+  period: CursorCurrentPeriodUsage | null,
+  usage: CursorAggregatedUsage | null
+): CursorQuotaSummary {
+  const planUsage = period?.planUsage;
+
+  const limitCents = parseCursorNumber(planUsage?.limit) ?? parseCursorNumber(plan?.planInfo?.includedAmountCents);
+  const usedCents = parseCursorNumber(planUsage?.totalSpend);
+  const remainingCents = parseCursorNumber(planUsage?.remaining);
+
+  const cycleStartMs =
+    parseCursorNumber(period?.billingCycleStart) ?? null;
+  const cycleEndMs =
+    parseCursorNumber(period?.billingCycleEnd) ?? parseCursorNumber(plan?.planInfo?.billingCycleEnd);
+
+  const periodHours =
+    cycleStartMs !== null && cycleEndMs !== null && cycleEndMs > cycleStartMs
+      ? (cycleEndMs - cycleStartMs) / HOUR_MS
+      : null;
+
+  const remainingPercent =
+    limitCents !== null && limitCents > 0 && usedCents !== null
+      ? Math.max(0, Math.min(100, ((limitCents - usedCents) / limitCents) * 100))
+      : null;
+
+  return {
+    planName: typeof plan?.planInfo?.planName === 'string' ? plan.planInfo.planName : null,
+    planPrice: typeof plan?.planInfo?.price === 'string' ? plan.planInfo.price : null,
+    spendLimitType:
+      typeof period?.spendLimitUsage?.limitType === 'string' ? period.spendLimitUsage.limitType : null,
+    limitCents,
+    usedCents,
+    remainingCents,
+    remainingPercent,
+    autoPercentUsed: parseCursorNumber(planUsage?.autoPercentUsed),
+    apiPercentUsed: parseCursorNumber(planUsage?.apiPercentUsed),
+    cycleStartMs,
+    cycleEndMs,
+    periodHours,
+    models: buildCursorModelRows(usage),
+    totalSpendCents: parseCursorNumber(usage?.totalCostCents),
+  };
+}

--- a/src/utils/quota/index.ts
+++ b/src/utils/quota/index.ts
@@ -14,3 +14,4 @@ export * from './validators';
 export * from './builders';
 export * from './resetCredits';
 export * from './xaiPaid';
+export * from './cursor';

--- a/src/utils/quota/validators.ts
+++ b/src/utils/quota/validators.ts
@@ -23,6 +23,10 @@ export function isCodexFile(file: AuthFileItem): boolean {
   return resolveAuthProvider(file) === 'codex';
 }
 
+export function isCursorFile(file: AuthFileItem): boolean {
+  return resolveAuthProvider(file) === 'cursor';
+}
+
 export function isKimiFile(file: AuthFileItem): boolean {
   return resolveAuthProvider(file) === 'kimi';
 }

--- a/tests/cursorQuota.test.ts
+++ b/tests/cursorQuota.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Cursor quota parsing, over payloads captured verbatim from
+ * aiserver.v1.DashboardService on a live Ultra account.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import {
+  buildCursorModelRows,
+  buildCursorQuotaSummary,
+  formatCursorCents,
+  parseCursorNumber,
+  parseCursorPayload,
+} from '../src/utils/quota/cursor';
+import { collectQuotaRowInstants, CURSOR_INCLUDED_ROW_ID } from '../src/features/quota/resetSchedule';
+import type {
+  CursorAggregatedUsage,
+  CursorCurrentPeriodUsage,
+  CursorPlanInfo,
+} from '../src/types';
+
+const PLAN: CursorPlanInfo = {
+  planInfo: {
+    planName: 'Ultra',
+    includedAmountCents: 40000,
+    price: '$200/mo',
+    billingCycleEnd: '1789830899000',
+    planOwner: 'PLAN_OWNER_STRIPE',
+  },
+};
+
+const PERIOD: CursorCurrentPeriodUsage = {
+  billingCycleStart: '1787152499000',
+  billingCycleEnd: '1789830899000',
+  planUsage: {
+    totalSpend: 132,
+    includedSpend: 132,
+    remaining: 39868,
+    limit: 40000,
+    autoPercentUsed: 0.0045,
+    apiPercentUsed: 0.246,
+    totalPercentUsed: 0.0528,
+  },
+  spendLimitUsage: { limitType: 'user' },
+};
+
+const USAGE: CursorAggregatedUsage = {
+  aggregations: [
+    { modelIntent: 'sand-default', inputTokens: '876179', outputTokens: '51579', cacheReadTokens: '6347584', totalCents: 520.22995, tier: 1 },
+    { modelIntent: 'claude-opus-5-low', inputTokens: '174', outputTokens: '11332', cacheWriteTokens: '134056', cacheReadTokens: '2176150', totalCents: 221.0095, tier: 1 },
+    { modelIntent: 'sand-automation', inputTokens: '1020502', outputTokens: '18197', cacheReadTokens: '13607936', totalCents: 447.7077, tier: 1 },
+    { modelIntent: 'never-billed', inputTokens: '10', outputTokens: '0', totalCents: 0, tier: 1 },
+  ],
+  totalCostCents: 1321.5496549999998,
+};
+
+describe('parseCursorNumber', () => {
+  test('reads the decimal strings Cursor sends for 64-bit fields', () => {
+    expect(parseCursorNumber('1789830899000')).toBe(1789830899000);
+    expect(parseCursorNumber(40000)).toBe(40000);
+  });
+
+  test('an absent or unparseable field stays absent rather than becoming zero', () => {
+    expect(parseCursorNumber(undefined)).toBeNull();
+    expect(parseCursorNumber('')).toBeNull();
+    expect(parseCursorNumber('   ')).toBeNull();
+    expect(parseCursorNumber('not-a-number')).toBeNull();
+    expect(parseCursorNumber(Number.NaN)).toBeNull();
+  });
+});
+
+describe('parseCursorPayload', () => {
+  test('accepts the body as a string or as an already-decoded object', () => {
+    expect(parseCursorPayload<{ a: number }>('{"a":1}')).toEqual({ a: 1 });
+    expect(parseCursorPayload<{ a: number }>({ a: 1 })).toEqual({ a: 1 });
+  });
+
+  test('malformed JSON yields null instead of throwing into the card', () => {
+    expect(parseCursorPayload('{')).toBeNull();
+    expect(parseCursorPayload('"a string"')).toBeNull();
+  });
+});
+
+describe('buildCursorModelRows', () => {
+  test('orders by spend and drops models that were never billed', () => {
+    const rows = buildCursorModelRows(USAGE);
+    expect(rows.map((row) => row.model)).toEqual([
+      'sand-default',
+      'sand-automation',
+      'claude-opus-5-low',
+    ]);
+    expect(rows[0].cacheReadTokens).toBe(6347584);
+  });
+
+  test('no usage read at all is an empty list, not a crash', () => {
+    expect(buildCursorModelRows(null)).toEqual([]);
+    expect(buildCursorModelRows({})).toEqual([]);
+  });
+});
+
+describe('buildCursorQuotaSummary', () => {
+  test('reads the allowance, the draw-down and the cycle from a live payload', () => {
+    const summary = buildCursorQuotaSummary(PLAN, PERIOD, USAGE);
+    expect(summary.planName).toBe('Ultra');
+    expect(summary.planPrice).toBe('$200/mo');
+    expect(summary.limitCents).toBe(40000);
+    expect(summary.usedCents).toBe(132);
+    expect(summary.remainingCents).toBe(39868);
+    expect(summary.cycleEndMs).toBe(1789830899000);
+    // 1787152499000 -> 1789830899000 is 31 days.
+    expect(summary.periodHours).toBe(744);
+    expect(summary.models).toHaveLength(3);
+  });
+
+  test('the meter reads remaining capacity, not money spent', () => {
+    const summary = buildCursorQuotaSummary(PLAN, PERIOD, USAGE);
+    expect(summary.remainingPercent).toBeCloseTo(99.67, 2);
+  });
+
+  test('falls back to the plan read when the period omits the allowance', () => {
+    const summary = buildCursorQuotaSummary(PLAN, { billingCycleStart: '1787152499000' }, null);
+    expect(summary.limitCents).toBe(40000);
+    expect(summary.cycleEndMs).toBe(1789830899000);
+    // The cycle end came from the plan read, so the pair is still complete.
+    expect(summary.periodHours).toBe(744);
+  });
+
+  test('a cycle with no end anywhere states no length rather than inventing one', () => {
+    const summary = buildCursorQuotaSummary(null, { billingCycleStart: '1787152499000' }, null);
+    expect(summary.cycleEndMs).toBeNull();
+    expect(summary.periodHours).toBeNull();
+  });
+
+  test('an account with no plan read still reports what the period knows', () => {
+    const summary = buildCursorQuotaSummary(null, PERIOD, null);
+    expect(summary.planName).toBeNull();
+    expect(summary.limitCents).toBe(40000);
+    expect(summary.models).toEqual([]);
+  });
+
+  test('a zero allowance yields no percentage rather than a division by zero', () => {
+    const summary = buildCursorQuotaSummary(null, { planUsage: { limit: 0, totalSpend: 0 } }, null);
+    expect(summary.remainingPercent).toBeNull();
+  });
+});
+
+describe('formatCursorCents', () => {
+  test('cents render as dollars, and an absent amount says so', () => {
+    expect(formatCursorCents(40000)).toBe('$400.00');
+    expect(formatCursorCents(132)).toBe('$1.32');
+    expect(formatCursorCents(null)).toBe('--');
+  });
+});
+
+describe('collectQuotaRowInstants for cursor', () => {
+  test('the billing cycle end is the instant the allowance returns', () => {
+    const quota = {
+      status: 'success',
+      summary: buildCursorQuotaSummary(PLAN, PERIOD, USAGE),
+    };
+    expect(collectQuotaRowInstants('cursor', quota)).toEqual([
+      { rowId: CURSOR_INCLUDED_ROW_ID, atMs: 1789830899000, kind: 'window' },
+    ]);
+  });
+
+  test('a card that has not loaded contributes no instant', () => {
+    expect(collectQuotaRowInstants('cursor', { status: 'idle', summary: null })).toEqual([]);
+    expect(collectQuotaRowInstants('cursor', { status: 'success', summary: null })).toEqual([]);
+  });
+});

--- a/tests/cursorQuota.test.ts
+++ b/tests/cursorQuota.test.ts
@@ -11,7 +11,11 @@ import {
   parseCursorNumber,
   parseCursorPayload,
 } from '../src/utils/quota/cursor';
-import { collectQuotaRowInstants, CURSOR_INCLUDED_ROW_ID } from '../src/features/quota/resetSchedule';
+import {
+  collectQuotaRowInstants,
+  CURSOR_AGENT_ROW_ID,
+  CURSOR_INCLUDED_ROW_ID,
+} from '../src/features/quota/resetSchedule';
 import type {
   CursorAggregatedUsage,
   CursorCurrentPeriodUsage,
@@ -165,5 +169,66 @@ describe('collectQuotaRowInstants for cursor', () => {
   test('a card that has not loaded contributes no instant', () => {
     expect(collectQuotaRowInstants('cursor', { status: 'idle', summary: null })).toEqual([]);
     expect(collectQuotaRowInstants('cursor', { status: 'success', summary: null })).toEqual([]);
+  });
+});
+
+const AGENT = {
+  currentPeriodStart: '2026-08-19T15:16:39.259Z',
+  nextResetTimestampUtc: '2026-08-26T15:16:39.259Z',
+  usagePercent: 1.188947,
+  hasAvailableUsage: true,
+  hasNonZeroIncludedLimit: true,
+};
+
+describe('the agent window, which is a second quota', () => {
+  test('is read as its own weekly window, not as a view of the allowance', () => {
+    const summary = buildCursorQuotaSummary(PLAN, PERIOD, USAGE, AGENT, { requestQuota: 500 });
+    expect(summary.agent).not.toBeNull();
+    expect(summary.agent?.usedPercent).toBeCloseTo(1.1889, 3);
+    expect(summary.agent?.remainingPercent).toBeCloseTo(98.811, 3);
+    expect(summary.agent?.resetAtMs).toBe(Date.parse('2026-08-26T15:16:39.259Z'));
+    expect(summary.agent?.periodHours).toBe(168);
+    expect(summary.fastRequestQuota).toBe(500);
+  });
+
+  test('a plan that includes none of it contributes no row', () => {
+    const summary = buildCursorQuotaSummary(PLAN, PERIOD, USAGE, {
+      ...AGENT,
+      hasNonZeroIncludedLimit: false,
+    });
+    expect(summary.agent).toBeNull();
+  });
+
+  test('exhaustion is carried, because zero remaining and no data look alike', () => {
+    const summary = buildCursorQuotaSummary(PLAN, PERIOD, USAGE, {
+      ...AGENT,
+      usagePercent: 100,
+      hasAvailableUsage: false,
+    });
+    expect(summary.agent?.exhausted).toBe(true);
+    expect(summary.agent?.remainingPercent).toBe(0);
+  });
+
+  test('both windows are offered to the recovery sort, weekly one included', () => {
+    const quota = {
+      status: 'success',
+      summary: buildCursorQuotaSummary(PLAN, PERIOD, USAGE, AGENT, null),
+    };
+    const instants = collectQuotaRowInstants('cursor', quota);
+    expect(instants.map((instant) => instant.rowId).sort()).toEqual([
+      CURSOR_AGENT_ROW_ID,
+      CURSOR_INCLUDED_ROW_ID,
+    ]);
+    // The weekly window recovers first, which is the whole reason it is here.
+    const agent = instants.find((instant) => instant.rowId === CURSOR_AGENT_ROW_ID);
+    const included = instants.find((instant) => instant.rowId === CURSOR_INCLUDED_ROW_ID);
+    expect(agent!.atMs).toBeLessThan(included!.atMs);
+  });
+
+  test('an account with no agent read still reports the allowance', () => {
+    const summary = buildCursorQuotaSummary(PLAN, PERIOD, USAGE, null, null);
+    expect(summary.agent).toBeNull();
+    expect(summary.fastRequestQuota).toBeNull();
+    expect(summary.limitCents).toBe(40000);
   });
 });

--- a/tests/quotaPageLogic.test.ts
+++ b/tests/quotaPageLogic.test.ts
@@ -21,6 +21,7 @@ const FILES: AuthFileItem[] = [
   file('kimi-a.json', 'kimi'),
   file('codex-b.json', 'codex'),
   file('grok-a.json', 'grok'), // 别名归一到 xai
+  file('cursor-a.json', 'cursor'),
   file('gemini-a.json', 'gemini'), // 不支持额度
   file('claude-off.json', 'claude', { disabled: true }), // 停用
 ];
@@ -29,6 +30,7 @@ describe('resolveQuotaProviderType', () => {
   test('maps provider aliases and rejects unsupported or disabled files', () => {
     expect(resolveQuotaProviderType(file('a', 'grok'))).toBe('xai');
     expect(resolveQuotaProviderType(file('a', 'antigravity'))).toBe('antigravity');
+    expect(resolveQuotaProviderType(file('a', 'cursor'))).toBe('cursor');
     expect(resolveQuotaProviderType(file('a', 'gemini'))).toBeNull();
     expect(resolveQuotaProviderType(file('a', 'claude', { disabled: true }))).toBeNull();
   });
@@ -39,24 +41,32 @@ describe('classifyQuotaFiles', () => {
     const entries = classifyQuotaFiles(FILES);
     expect(entries.map((entry) => entry.file.name)).not.toContain('gemini-a.json');
     expect(entries.map((entry) => entry.file.name)).not.toContain('claude-off.json');
-    expect(entries).toHaveLength(5);
+    expect(entries).toHaveLength(6);
   });
 
   test('orders entries by provider tab order', () => {
     const entries = classifyQuotaFiles(FILES);
-    expect(entries.map((entry) => entry.type)).toEqual(['claude', 'codex', 'codex', 'xai', 'kimi']);
+    expect(entries.map((entry) => entry.type)).toEqual([
+      'claude',
+      'codex',
+      'codex',
+      'xai',
+      'kimi',
+      'cursor',
+    ]);
   });
 });
 
 describe('buildTabCounts', () => {
   test('counts per provider plus an all total, zero-filling empty tabs', () => {
     expect(buildTabCounts(classifyQuotaFiles(FILES))).toEqual({
-      all: 5,
+      all: 6,
       claude: 1,
       antigravity: 0,
       codex: 2,
       xai: 1,
       kimi: 1,
+      cursor: 1,
     });
   });
 });
@@ -65,7 +75,7 @@ describe('filterEntriesByTab', () => {
   const entries = classifyQuotaFiles(FILES);
 
   test("passes everything through on the 'all' tab", () => {
-    expect(filterEntriesByTab(entries, 'all')).toHaveLength(5);
+    expect(filterEntriesByTab(entries, 'all')).toHaveLength(6);
   });
 
   test('filters to a single provider', () => {
@@ -135,11 +145,13 @@ describe('sortQuotaEntries', () => {
         'kimi-a.json': 200,
         'codex-b.json': 400,
         'grok-a.json': 50,
+        'cursor-a.json': 150,
       })
     );
     expect(byName(sorted)).toEqual([
       'grok-a.json',
       'claude-a.json',
+      'cursor-a.json',
       'kimi-a.json',
       'codex-a.json',
       'codex-b.json',
@@ -160,6 +172,7 @@ describe('sortQuotaEntries', () => {
       'claude-a.json',
       'codex-a.json',
       'grok-a.json',
+      'cursor-a.json',
     ]);
   });
 


### PR DESCRIPTION
Adds Cursor to the Quota page and Auth Files quota section, alongside the existing providers.

- Reads quota through the management `api-call` endpoint using the same `aiserver.v1.DashboardService` calls Cursor's own dashboard makes: current period usage and plan info are required reads; aggregated per-model usage, fast-requests, and agent usage enrich the card when available.
- Shows plan and subscription state, included-usage allowance with spend, and a per-model table of input/output/cache tokens with cost, costliest first.
- Distinguishes a failed allowance read (error state) from failed enrichment (still renders the quota meter).
- Includes the Cursor icon, en/ru/zh-CN/zh-TW locale strings, and tests (`tests/cursorQuota.test.ts`, extended `tests/quotaPageLogic.test.ts`).

No changes to other providers.