### PR TITLE
feat: expose provider-level proxy for OpenAI-compatible providers

### DIFF
--- a/src/features/providers/adapters.ts
+++ b/src/features/providers/adapters.ts
@@ -172,7 +172,7 @@ export function openaiToResource(config: OpenAIProviderConfig, index: number): P
     apiKey: null,
     authIndex: config.authIndex ?? null,
     baseUrl: config.baseUrl ?? null,
-    proxyUrl: null,
+    proxyUrl: config.proxyUrl ?? firstEntry?.proxyUrl ?? null,
     prefix: config.prefix ?? null,
     modelCount: config.models?.length ?? 0,
     models: collectModelNames(config.models),

--- a/src/features/providers/descriptors.ts
+++ b/src/features/providers/descriptors.ts
@@ -162,7 +162,7 @@ export const PROVIDER_DESCRIPTORS: Record<ProviderBrand, ProviderDescriptor> = {
     supportsDisabled: true,
     supportsBaseUrl: true,
     baseUrlRequired: true,
-    supportsProxyUrl: false,
+    supportsProxyUrl: true,
     supportsPrefix: true,
     supportsModels: true,
     supportsHeaders: true,

--- a/src/features/providers/sheets/forms/BaseProviderForm.tsx
+++ b/src/features/providers/sheets/forms/BaseProviderForm.tsx
@@ -117,7 +117,7 @@ function buildInitialForm(
       apiKey: '',
       name: cfg.name ?? '',
       baseUrl: cfg.baseUrl ?? '',
-      proxyUrl: '',
+      proxyUrl: cfg.proxyUrl ?? '',
       prefix: cfg.prefix ?? '',
       disabled: cfg.disabled === true,
       disableCooling: cfg.disableCooling === true,

--- a/src/features/providers/useProviderWorkbench.ts
+++ b/src/features/providers/useProviderWorkbench.ts
@@ -251,6 +251,7 @@ const buildOpenAIConfig = (
     ...(existing ?? {}),
     name: input.name.trim(),
     baseUrl: input.baseUrl.trim(),
+    proxyUrl: input.proxyUrl.trim() || undefined,
     prefix: input.prefix.trim() || undefined,
     apiKeyEntries,
     disabled: input.disabled,

--- a/src/services/api/providers.ts
+++ b/src/services/api/providers.ts
@@ -58,6 +58,7 @@ const OPENAI_PROVIDER_FIELDS = [
   'disabled',
   'prefix',
   'base-url',
+  'proxy-url',
   'api-key-entries',
   'headers',
   'models',
@@ -417,6 +418,7 @@ const serializeOpenAIProvider = (provider: OpenAIProviderConfig) => {
       ? provider.apiKeyEntries.map((entry) => serializeApiKeyEntry(entry))
       : [],
   };
+  if (provider.proxyUrl?.trim()) payload['proxy-url'] = provider.proxyUrl.trim();
   if (provider.prefix?.trim()) payload.prefix = provider.prefix.trim();
   if (provider.disabled !== undefined) payload.disabled = provider.disabled;
   const headers = serializeHeaders(provider.headers);

--- a/src/services/api/transformers.ts
+++ b/src/services/api/transformers.ts
@@ -254,6 +254,9 @@ const normalizeOpenAIProvider = (
     apiKeyEntries,
   };
 
+  const proxyUrl = normalizePrefix(provider['proxy-url']);
+  if (proxyUrl) result.proxyUrl = proxyUrl;
+
   const disabled = normalizeBoolean(provider.disabled);
   if (disabled !== undefined) result.disabled = disabled;
   const disableCooling = normalizeBoolean(provider['disable-cooling']);

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -61,6 +61,7 @@ export interface OpenAIProviderConfig {
   name: string;
   prefix?: string;
   baseUrl: string;
+  proxyUrl?: string;
   apiKeyEntries: ApiKeyEntry[];
   disabled?: boolean;
   headers?: Record<string, string>;


### PR DESCRIPTION
## Summary
- expose `proxy-url` on the OpenAI-compatible provider form
- load and persist provider-level proxy values
- show the provider proxy in the provider resource summary
- keep existing per-key proxy fields unchanged

## Dependency
The matching core change is proposed in router-for-me/CLIProxyAPI#5201.

## Validation
- `git diff --check` passed
- UI tests/build could not run in this environment because Bun and dependencies are not installed.