### PR TITLE
feat: OpenCode Go support, routing-prefix chips and a Claude Max badge

### DIFF
--- a/src/features/authFiles/components/AuthFileQuotaSection.tsx
+++ b/src/features/authFiles/components/AuthFileQuotaSection.tsx
@@ -46,6 +46,8 @@ export function AuthFileQuotaSection(props: AuthFileQuotaSectionProps) {
     if (quotaType === 'claude') return state.claudeQuota[file.name] as QuotaCardState | undefined;
     if (quotaType === 'codex') return state.codexQuota[file.name] as QuotaCardState | undefined;
     if (quotaType === 'kimi') return state.kimiQuota[file.name] as QuotaCardState | undefined;
+    if (quotaType === 'opencode')
+      return state.opencodeQuota[file.name] as QuotaCardState | undefined;
     if (quotaType === 'xai') return state.xaiQuota[file.name] as QuotaCardState | undefined;
     return assertNever(quotaType);
   });

--- a/src/features/authFiles/constants.ts
+++ b/src/features/authFiles/constants.ts
@@ -24,7 +24,7 @@ export type AuthFileModelItem = {
 };
 export type AuthFileIconAsset = string | { light: string; dark: string };
 
-export type QuotaProviderType = 'antigravity' | 'claude' | 'codex' | 'kimi' | 'xai';
+export type QuotaProviderType = 'antigravity' | 'claude' | 'codex' | 'kimi' | 'opencode' | 'xai';
 export type OAuthConfigLoadError = 'loading' | 'unsupported' | 'load' | null;
 
 export const QUOTA_PROVIDER_TYPES = new Set<QuotaProviderType>([
@@ -32,6 +32,7 @@ export const QUOTA_PROVIDER_TYPES = new Set<QuotaProviderType>([
   'claude',
   'codex',
   'kimi',
+  'opencode',
   'xai',
 ]);
 

--- a/src/features/authFiles/opencodeLogin.ts
+++ b/src/features/authFiles/opencodeLogin.ts
@@ -1,0 +1,82 @@
+/**
+ * OpenCode Go credential import.
+ *
+ * OpenCode has no OAuth or device flow: the docs tell you to sign in at
+ * opencode.ai/auth and copy an API key, and every client in the ecosystem
+ * stores that key verbatim. So this is an import, not a login handshake — the
+ * shape it shares with `vertex_import` rather than with the OAuth providers.
+ *
+ * Pure and DOM-free so the naming and payload rules are directly testable; the
+ * page owns the requests.
+ */
+
+/** Where the key comes from; surfaced in the card hint. */
+export const OPENCODE_CONSOLE_URL = 'https://opencode.ai/auth';
+
+/** Auth files are `<provider>-<slug>.json`; the slug identifies the account. */
+export const OPENCODE_AUTH_FILE_PREFIX = 'opencode-';
+
+/**
+ * Account slug for a user-supplied label.
+ *
+ * The result becomes a file name, so it is restricted to `[a-z0-9-]` rather
+ * than merely escaped — that rules out separators and traversal by
+ * construction instead of by sanitizing after the fact.
+ */
+export function slugifyOpencodeLabel(label: string): string {
+  return label
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export function buildOpencodeAuthFileName(label: string): string | null {
+  const slug = slugifyOpencodeLabel(label);
+  return slug ? `${OPENCODE_AUTH_FILE_PREFIX}${slug}.json` : null;
+}
+
+export interface OpencodeCredentialFile {
+  name: string;
+  /** Pretty-printed so the file stays readable when edited by hand. */
+  content: string;
+}
+
+/**
+ * The credential written to the auth dir.
+ *
+ * `access_token` rather than `api_key`: the management `api-call` proxy
+ * resolves `$TOKEN$` from `metadata.access_token` first, and that is how the
+ * quota card reads the key back. `label` is what the auth-file and quota cards
+ * show, since the usage API returns no account identity of its own.
+ */
+export function buildOpencodeCredentialFile(
+  label: string,
+  apiKey: string
+): OpencodeCredentialFile | null {
+  const name = buildOpencodeAuthFileName(label);
+  const key = apiKey.trim();
+  if (!name || !key) return null;
+
+  return {
+    name,
+    content: `${JSON.stringify(
+      {
+        type: 'opencode',
+        access_token: key,
+        label: label.trim(),
+      },
+      null,
+      2
+    )}\n`,
+  };
+}
+
+/** i18n key explaining why the upstream rejected a key, by status. */
+export function opencodeKeyErrorKey(statusCode: number): string {
+  if (statusCode === 401) return 'opencode_login.key_rejected';
+  // The Go windows are entitlement-gated; a valid Zen key without the
+  // subscription reaches this branch rather than 401.
+  if (statusCode === 403) return 'opencode_login.no_subscription';
+  return 'opencode_login.validate_failed';
+}

--- a/src/features/dashboard/utils.ts
+++ b/src/features/dashboard/utils.ts
@@ -15,6 +15,7 @@ const PROVIDER_LABELS: Record<string, string> = {
   kimi: 'Kimi',
   iflow: 'iFlow',
   antigravity: 'Antigravity',
+  opencode: 'OpenCode',
 };
 
 /**

--- a/src/features/quota/QuotaPage.tsx
+++ b/src/features/quota/QuotaPage.tsx
@@ -104,6 +104,7 @@ export function QuotaPage() {
   const claudeQuota = useQuotaStore((state) => state.claudeQuota);
   const codexQuota = useQuotaStore((state) => state.codexQuota);
   const kimiQuota = useQuotaStore((state) => state.kimiQuota);
+  const opencodeQuota = useQuotaStore((state) => state.opencodeQuota);
   const xaiQuota = useQuotaStore((state) => state.xaiQuota);
 
   const quotaByType = useMemo<Record<QuotaProviderType, Record<string, QuotaCardState>>>(
@@ -113,9 +114,10 @@ export function QuotaPage() {
         claude: claudeQuota,
         codex: codexQuota,
         kimi: kimiQuota,
+        opencode: opencodeQuota,
         xai: xaiQuota,
       }) as unknown as Record<QuotaProviderType, Record<string, QuotaCardState>>,
-    [antigravityQuota, claudeQuota, codexQuota, kimiQuota, xaiQuota]
+    [antigravityQuota, claudeQuota, codexQuota, kimiQuota, opencodeQuota, xaiQuota]
   );
 
   const getQuota = useCallback(

--- a/src/features/quota/components/QuotaCard.module.scss
+++ b/src/features/quota/components/QuotaCard.module.scss
@@ -85,6 +85,21 @@
   @include text-ellipsis;
 }
 
+/* Routing prefix, e.g. `personal/`. Trails the file name and never squeezes
+   it: the name is the identity, the prefix is how you address it. */
+.prefixChip {
+  flex-shrink: 0;
+  padding: 1px 6px;
+  border-radius: 6px;
+  font-family: $font-mono;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: var(--text-secondary);
+  background: color-mix(in srgb, var(--bg-tertiary) 70%, transparent);
+  border: 1px solid var(--border-subtle, transparent);
+}
+
 /* ---------- body 容器 ---------- */
 
 .body {

--- a/src/features/quota/components/QuotaCard.tsx
+++ b/src/features/quota/components/QuotaCard.tsx
@@ -100,6 +100,14 @@ export function QuotaCard(props: QuotaCardProps) {
         <span className={styles.fileName} title={file.name}>
           {file.name}
         </span>
+        {file.prefix && (
+          <span
+            className={styles.prefixChip}
+            title={t('quota_management.prefix_hint', { prefix: file.prefix })}
+          >
+            {`${file.prefix}/`}
+          </span>
+        )}
       </header>
 
       <div className={styles.body}>

--- a/src/features/quota/constants.ts
+++ b/src/features/quota/constants.ts
@@ -7,6 +7,7 @@ export const QUOTA_TAB_ORDER: readonly QuotaProviderType[] = [
   'codex',
   'xai',
   'kimi',
+  'opencode',
 ];
 
 export type QuotaTabId = 'all' | QuotaProviderType;

--- a/src/features/quota/logic.ts
+++ b/src/features/quota/logic.ts
@@ -8,6 +8,7 @@ import { ANTIGRAVITY_CONFIG } from './providers/antigravity/data';
 import { CLAUDE_CONFIG } from './providers/claude/data';
 import { CODEX_CONFIG } from './providers/codex/data';
 import { KIMI_CONFIG } from './providers/kimi/data';
+import { OPENCODE_CONFIG } from './providers/opencode/data';
 import { XAI_CONFIG } from './providers/xai/data';
 import type { QuotaProviderType } from './providers/types';
 import { QUOTA_TAB_ORDER, type QuotaSortMode, type QuotaTabId } from './constants';
@@ -17,6 +18,7 @@ const QUOTA_FILTER_MAP: Record<QuotaProviderType, (file: AuthFileItem) => boolea
   claude: CLAUDE_CONFIG.filterFn,
   codex: CODEX_CONFIG.filterFn,
   kimi: KIMI_CONFIG.filterFn,
+  opencode: OPENCODE_CONFIG.filterFn,
   xai: XAI_CONFIG.filterFn,
 };
 

--- a/src/features/quota/providers/claude/ClaudeQuotaBody.tsx
+++ b/src/features/quota/providers/claude/ClaudeQuotaBody.tsx
@@ -5,7 +5,7 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { ClaudeQuotaState } from '@/types';
-import { buildResetDisplay } from '@/utils/quota';
+import { buildResetDisplay, resolveClaudePlanTier } from '@/utils/quota';
 import { useNow } from '@/hooks/useNow';
 import { QuotaMeter } from '../../components/QuotaMeter';
 import { QuotaResetLabel } from '../../components/QuotaResetLabel';
@@ -22,13 +22,21 @@ export function ClaudeQuotaBody({ quota, classes }: QuotaBodyProps<ClaudeQuotaSt
   const windows = quota.windows ?? [];
   const extraUsage = quota.extraUsage ?? null;
   const planType = quota.planType ?? null;
+  // Max earns the same badge treatment Codex gives Pro/Pro Lite.
+  const planTier = resolveClaudePlanTier(planType);
+  const planValueClass =
+    planTier === 'elite'
+      ? classes.elitePlanValue
+      : planTier === 'premium'
+        ? classes.premiumPlanValue
+        : classes.codexPlanValue;
 
   return (
     <>
       {planType && (
         <div className={classes.codexPlan}>
           <span className={classes.codexPlanLabel}>{t('claude_quota.plan_label')}</span>
-          <span className={classes.codexPlanValue}>{t(`claude_quota.${planType}`)}</span>
+          <span className={planValueClass}>{t(`claude_quota.${planType}`)}</span>
         </div>
       )}
       {extraUsage && extraUsage.is_enabled && (

--- a/src/features/quota/providers/index.ts
+++ b/src/features/quota/providers/index.ts
@@ -19,6 +19,8 @@ import { CODEX_CONFIG } from './codex/data';
 import { CodexQuotaBody } from './codex/CodexQuotaBody';
 import { KIMI_CONFIG } from './kimi/data';
 import { KimiQuotaBody } from './kimi/KimiQuotaBody';
+import { OPENCODE_CONFIG } from './opencode/data';
+import { OpencodeQuotaBody } from './opencode/OpencodeQuotaBody';
 import { XAI_CONFIG } from './xai/data';
 import { XaiQuotaBody } from './xai/XaiQuotaBody';
 
@@ -52,6 +54,7 @@ export const QUOTA_ADAPTERS: Record<QuotaProviderType, QuotaAdapter> = {
   claude: { ...CLAUDE_CONFIG, Body: ClaudeQuotaBody } as unknown as QuotaAdapter,
   codex: { ...CODEX_CONFIG, Body: CodexQuotaBody } as unknown as QuotaAdapter,
   kimi: { ...KIMI_CONFIG, Body: KimiQuotaBody } as unknown as QuotaAdapter,
+  opencode: { ...OPENCODE_CONFIG, Body: OpencodeQuotaBody } as unknown as QuotaAdapter,
   xai: { ...XAI_CONFIG, Body: XaiQuotaBody } as unknown as QuotaAdapter,
 };
 

--- a/src/features/quota/providers/opencode/OpencodeQuotaBody.tsx
+++ b/src/features/quota/providers/opencode/OpencodeQuotaBody.tsx
@@ -1,0 +1,64 @@
+/**
+ * OpenCode Go quota body: one meter per rolling / weekly / monthly window.
+ */
+
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { OpencodeQuotaState } from '@/types';
+import { buildResetDisplay } from '@/utils/quota';
+import { useNow } from '@/hooks/useNow';
+import { QuotaMeter } from '../../components/QuotaMeter';
+import { QuotaResetLabel } from '../../components/QuotaResetLabel';
+import { collectQuotaRowInstants, pickUrgentRowId } from '../../resetSchedule';
+import type { QuotaBodyProps } from '../../types';
+
+export function OpencodeQuotaBody({ quota, classes }: QuotaBodyProps<OpencodeQuotaState>) {
+  const { t, i18n } = useTranslation();
+  // Ahead of the early return below — hooks cannot be conditional.
+  const now = useNow();
+  const soonestRowId = useMemo(
+    () => pickUrgentRowId(collectQuotaRowInstants('opencode', quota), now),
+    [quota, now]
+  );
+  const rows = quota.rows ?? [];
+
+  if (rows.length === 0) {
+    return <div className={classes.quotaMessage}>{t('opencode_quota.empty_data')}</div>;
+  }
+
+  return (
+    <>
+      {rows.map((row, index) => {
+        const percentLabel = row.rateLimited
+          ? t('opencode_quota.rate_limited')
+          : `${row.remainingPercent}%`;
+        const resetDisplay = buildResetDisplay(
+          null,
+          row.resetAtMs,
+          now,
+          i18n.resolvedLanguage
+        );
+        const soon = row.id === soonestRowId;
+
+        return (
+          <div
+            key={row.id}
+            className={classes.quotaRow}
+            title={soon ? t('quota_management.soonest_row_hint') : undefined}
+          >
+            <div className={classes.quotaRowHeader}>
+              <span className={classes.quotaModel}>{t(row.labelKey)}</span>
+              <div className={classes.quotaMeta}>
+                <span className={classes.quotaPercent}>{percentLabel}</span>
+                {resetDisplay && (
+                  <QuotaResetLabel display={resetDisplay} classes={classes} soon={soon} />
+                )}
+              </div>
+            </div>
+            <QuotaMeter percent={row.remainingPercent} classes={classes} index={index} />
+          </div>
+        );
+      })}
+    </>
+  );
+}

--- a/src/features/quota/providers/opencode/data.ts
+++ b/src/features/quota/providers/opencode/data.ts
@@ -1,0 +1,66 @@
+/**
+ * OpenCode Go quota data layer. React-free / SCSS-free.
+ */
+
+import type { TFunction } from 'i18next';
+import type { AuthFileItem, OpencodeQuotaRow, OpencodeQuotaState } from '@/types';
+import { apiCallApi, getApiCallErrorMessage } from '@/services/api';
+import {
+  OPENCODE_USAGE_URL,
+  OPENCODE_REQUEST_HEADERS,
+  parseOpencodeUsagePayload,
+  buildOpencodeQuotaRows,
+  createStatusError,
+  isOpencodeFile,
+  isDisabledAuthFile,
+} from '@/utils/quota';
+import { normalizeAuthIndex } from '@/utils/authIndex';
+import type { QuotaProviderData } from '../types';
+
+const fetchOpencodeQuota = async (
+  file: AuthFileItem,
+  t: TFunction
+): Promise<OpencodeQuotaRow[]> => {
+  const rawAuthIndex = file['auth_index'] ?? file.authIndex;
+  const authIndex = normalizeAuthIndex(rawAuthIndex);
+  if (!authIndex) {
+    throw new Error(t('opencode_quota.missing_auth_index'));
+  }
+
+  const result = await apiCallApi.request({
+    authIndex,
+    method: 'GET',
+    url: OPENCODE_USAGE_URL,
+    header: { ...OPENCODE_REQUEST_HEADERS },
+  });
+
+  if (result.statusCode < 200 || result.statusCode >= 300) {
+    throw createStatusError(getApiCallErrorMessage(result), result.statusCode);
+  }
+
+  const payload = parseOpencodeUsagePayload(result.body ?? result.bodyText);
+  if (!payload) {
+    throw new Error(t('opencode_quota.empty_data'));
+  }
+
+  // The timeline model is React-free and cannot translate, so the label is
+  // resolved here alongside the key — same split as claude/data.ts.
+  return buildOpencodeQuotaRows(payload).map((row) => ({ ...row, label: t(row.labelKey) }));
+};
+
+export const OPENCODE_CONFIG: QuotaProviderData<OpencodeQuotaState, OpencodeQuotaRow[]> = {
+  type: 'opencode',
+  i18nPrefix: 'opencode_quota',
+  filterFn: (file) => isOpencodeFile(file) && !isDisabledAuthFile(file),
+  fetchQuota: fetchOpencodeQuota,
+  storeSelector: (state) => state.opencodeQuota,
+  storeSetter: 'setOpencodeQuota',
+  buildLoadingState: () => ({ status: 'loading', rows: [] }),
+  buildSuccessState: (rows) => ({ status: 'success', rows }),
+  buildErrorState: (message, status) => ({
+    status: 'error',
+    rows: [],
+    error: message,
+    errorStatus: status,
+  }),
+};

--- a/src/features/quota/providers/types.ts
+++ b/src/features/quota/providers/types.ts
@@ -12,12 +12,13 @@ import type {
   ClaudeQuotaState,
   CodexQuotaState,
   KimiQuotaState,
+  OpencodeQuotaState,
   XaiQuotaState,
 } from '@/types';
 
 export type QuotaUpdater<T> = T | ((prev: T) => T);
 
-export type QuotaProviderType = 'antigravity' | 'claude' | 'codex' | 'kimi' | 'xai';
+export type QuotaProviderType = 'antigravity' | 'claude' | 'codex' | 'kimi' | 'opencode' | 'xai';
 
 /** useQuotaStore 的结构契约（storeSelector/storeSetter 依赖）。 */
 export interface QuotaStore {
@@ -25,11 +26,13 @@ export interface QuotaStore {
   claudeQuota: Record<string, ClaudeQuotaState>;
   codexQuota: Record<string, CodexQuotaState>;
   kimiQuota: Record<string, KimiQuotaState>;
+  opencodeQuota: Record<string, OpencodeQuotaState>;
   xaiQuota: Record<string, XaiQuotaState>;
   setAntigravityQuota: (updater: QuotaUpdater<Record<string, AntigravityQuotaState>>) => void;
   setClaudeQuota: (updater: QuotaUpdater<Record<string, ClaudeQuotaState>>) => void;
   setCodexQuota: (updater: QuotaUpdater<Record<string, CodexQuotaState>>) => void;
   setKimiQuota: (updater: QuotaUpdater<Record<string, KimiQuotaState>>) => void;
+  setOpencodeQuota: (updater: QuotaUpdater<Record<string, OpencodeQuotaState>>) => void;
   setXaiQuota: (updater: QuotaUpdater<Record<string, XaiQuotaState>>) => void;
   clearQuotaCache: () => void;
 }

--- a/src/features/quota/quotaTimelineModel.ts
+++ b/src/features/quota/quotaTimelineModel.ts
@@ -291,6 +291,13 @@ interface KimiRowLike {
   periodHours?: number | null;
 }
 
+interface OpencodeRowLike {
+  label?: string;
+  remainingPercent: number;
+  resetAtMs?: number | null;
+  periodHours?: number | null;
+}
+
 interface XaiBillingLike {
   periodType?: string;
   usagePercent?: number | null;
@@ -485,6 +492,27 @@ export function buildTimelineLane(input: TimelineLaneInput): TimelineLane {
       limits: rows
         .map((row) => ({ label: row.label ?? '', remaining: remainingOf(row) }))
         .filter((limit): limit is TimelineLimit => limit.remaining !== null),
+    };
+  }
+
+  if (provider === 'opencode') {
+    const rows = ((quota as { rows?: OpencodeRowLike[] }).rows ?? []).filter(
+      (row) => typeof row.resetAtMs === 'number'
+    );
+    const chosen = pickLaneWindow(rows, maxPeriodHours);
+    if (!chosen) return empty;
+
+    // Rows already carry remaining percent; the used->remaining flip happened
+    // in the builder, where the raw payload was still available.
+    return {
+      ...empty,
+      anchorMs: chosen.resetAtMs ?? null,
+      periodHours: chosen.periodHours ?? null,
+      remaining: clampPercent(chosen.remainingPercent),
+      limits: rows.map((row) => ({
+        label: row.label ?? '',
+        remaining: clampPercent(row.remainingPercent),
+      })),
     };
   }
 

--- a/src/features/quota/resetSchedule.ts
+++ b/src/features/quota/resetSchedule.ts
@@ -125,7 +125,7 @@ export function collectQuotaRowInstants(
     return collectRows(buckets, 'bucket');
   }
 
-  if (provider === 'kimi') {
+  if (provider === 'kimi' || provider === 'opencode') {
     return collectRows((quota as { rows?: WindowLike[] }).rows ?? [], 'row');
   }
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1233,7 +1233,8 @@
     "weekday_wed": "Wed",
     "weekday_thu": "Thu",
     "weekday_fri": "Fri",
-    "weekday_sat": "Sat"
+    "weekday_sat": "Sat",
+    "prefix_hint": "Address this credential as {{prefix}}/<model>"
   },
   "plugin_management": {
     "title": "Plugin Management",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -290,6 +290,7 @@
     "filter_qwen": "Qwen",
     "filter_gemini": "Gemini",
     "filter_kimi": "Kimi",
+    "filter_opencode": "OpenCode",
     "filter_aistudio": "AIStudio",
     "filter_claude": "Claude",
     "filter_codex": "Codex",
@@ -488,6 +489,22 @@
     "limit_window": "{{duration}} limit",
     "limit_index": "Limit #{{index}}",
     "reset_hint": "resets in {{hint}}"
+  },
+  "opencode_quota": {
+    "title": "OpenCode Quota",
+    "empty_title": "No OpenCode Auth Files",
+    "empty_desc": "Upload an OpenCode Go credential to view remaining quota.",
+    "idle": "Click here to refresh quota",
+    "loading": "Loading quota...",
+    "load_failed": "Failed to load quota: {{message}}",
+    "missing_auth_index": "Auth file missing auth_index",
+    "empty_data": "No quota data available",
+    "refresh_button": "Refresh Quota",
+    "fetch_all": "Fetch All",
+    "five_hour_limit": "5-hour limit",
+    "weekly_limit": "Weekly limit",
+    "monthly_limit": "Monthly limit",
+    "rate_limited": "Rate limited"
   },
   "xai_quota": {
     "title": "Grok Quota",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -550,6 +550,26 @@
     "result_location": "Region",
     "result_file": "Persisted file"
   },
+  "opencode_login": {
+    "title": "OpenCode Go Login",
+    "description": "OpenCode has no OAuth flow. Sign in, copy an API key, and paste it here — one credential per account, so several accounts can run side by side. Get a key at",
+    "label_label": "Account label",
+    "label_hint": "Names the credential file and the card. Use one label per account, e.g. personal / work.",
+    "label_placeholder": "personal",
+    "key_label": "API key",
+    "key_hint": "The OpenCode Go key. It is validated against the usage API before being saved.",
+    "key_placeholder": "sk-...",
+    "import_button": "Import OpenCode Credential",
+    "fields_required": "Enter an account label and an API key first",
+    "name_taken": "{{file}} already exists. Pick another account label so the existing credential is not overwritten.",
+    "key_rejected": "OpenCode rejected this API key.",
+    "no_subscription": "This key is valid but the account has no Go subscription.",
+    "validate_failed": "Could not validate the API key.",
+    "success": "Credential saved as {{file}}",
+    "result_title": "Credential saved",
+    "result_file": "Auth file",
+    "add_another_hint": "Add another account by entering a new label and key."
+  },
   "oauth_excluded": {
     "title": "OAuth Model Disablement",
     "description": "Per-provider model disablement is shown as cards; click a card to edit or delete. Wildcards * are supported and the scope follows the auth file filter.",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -537,6 +537,26 @@
     "result_location": "Регион",
     "result_file": "Сохранённый файл"
   },
+  "opencode_login": {
+    "title": "Вход OpenCode Go",
+    "description": "У OpenCode нет OAuth. Войдите, скопируйте API-ключ и вставьте его здесь — по одному credential на аккаунт, поэтому несколько аккаунтов работают одновременно. Получить ключ:",
+    "label_label": "Метка аккаунта",
+    "label_hint": "Задаёт имя файла и заголовок карточки. По одной метке на аккаунт, например personal / work.",
+    "label_placeholder": "personal",
+    "key_label": "API-ключ",
+    "key_hint": "Ключ OpenCode Go. Перед сохранением проверяется через API использования.",
+    "key_placeholder": "sk-...",
+    "import_button": "Импортировать credential OpenCode",
+    "fields_required": "Сначала укажите метку аккаунта и API-ключ",
+    "name_taken": "{{file}} уже существует. Выберите другую метку, чтобы не перезаписать существующий credential.",
+    "key_rejected": "OpenCode отклонил этот API-ключ.",
+    "no_subscription": "Ключ действителен, но у аккаунта нет подписки Go.",
+    "validate_failed": "Не удалось проверить API-ключ.",
+    "success": "Credential сохранён как {{file}}",
+    "result_title": "Credential сохранён",
+    "result_file": "Файл авторизации",
+    "add_another_hint": "Чтобы добавить ещё аккаунт, введите новую метку и ключ."
+  },
   "oauth_excluded": {
     "title": "Отключение OAuth-моделей",
     "description": "Отключения моделей по провайдерам отображаются карточками; нажмите карточку, чтобы изменить или удалить. Поддерживаются шаблоны *. Область зависит от фильтра файлов авторизации.",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -289,6 +289,7 @@
     "filter_qwen": "Qwen",
     "filter_gemini": "Gemini",
     "filter_kimi": "Kimi",
+    "filter_opencode": "OpenCode",
     "filter_aistudio": "AIStudio",
     "filter_claude": "Claude",
     "filter_codex": "Codex",
@@ -475,6 +476,22 @@
     "limit_window": "Лимит {{duration}}",
     "limit_index": "Лимит #{{index}}",
     "reset_hint": "сброс через {{hint}}"
+  },
+  "opencode_quota": {
+    "title": "Квота OpenCode",
+    "empty_title": "Нет учётных данных OpenCode",
+    "empty_desc": "Загрузите учётные данные OpenCode Go, чтобы увидеть оставшуюся квоту.",
+    "idle": "Не загружено. Нажмите \"Обновить квоту\".",
+    "loading": "Загрузка квоты...",
+    "load_failed": "Не удалось загрузить квоту: {{message}}",
+    "missing_auth_index": "В файле авторизации отсутствует auth_index",
+    "empty_data": "Данные по квоте отсутствуют",
+    "refresh_button": "Обновить квоту",
+    "fetch_all": "Получить все",
+    "five_hour_limit": "5-часовой лимит",
+    "weekly_limit": "Недельный лимит",
+    "monthly_limit": "Месячный лимит",
+    "rate_limited": "Лимит исчерпан"
   },
   "xai_quota": {
     "title": "Квота Grok",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1220,7 +1220,8 @@
     "weekday_wed": "Ср",
     "weekday_thu": "Чт",
     "weekday_fri": "Пт",
-    "weekday_sat": "Сб"
+    "weekday_sat": "Сб",
+    "prefix_hint": "Обращайтесь к этому credential как {{prefix}}/<model>"
   },
   "plugin_management": {
     "title": "Управление плагинами",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1233,7 +1233,8 @@
     "weekday_wed": "三",
     "weekday_thu": "四",
     "weekday_fri": "五",
-    "weekday_sat": "六"
+    "weekday_sat": "六",
+    "prefix_hint": "以 {{prefix}}/<model> 调用该凭证"
   },
   "plugin_management": {
     "title": "插件管理",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -550,6 +550,26 @@
     "result_location": "区域",
     "result_file": "存储文件"
   },
+  "opencode_login": {
+    "title": "OpenCode Go 登录",
+    "description": "OpenCode 没有 OAuth 流程。登录后复制 API 密钥并粘贴到这里——每个账号一份凭证，多个账号可并存。获取密钥：",
+    "label_label": "账号标签",
+    "label_hint": "决定凭证文件名与卡片标题。每个账号用一个标签，例如 personal / work。",
+    "label_placeholder": "personal",
+    "key_label": "API 密钥",
+    "key_hint": "OpenCode Go 的密钥。保存前会先通过用量接口校验。",
+    "key_placeholder": "sk-...",
+    "import_button": "导入 OpenCode 凭证",
+    "fields_required": "请先填写账号标签和 API 密钥",
+    "name_taken": "{{file}} 已存在。请换一个账号标签，以免覆盖现有凭证。",
+    "key_rejected": "OpenCode 拒绝了该 API 密钥。",
+    "no_subscription": "密钥有效，但该账号没有 Go 订阅。",
+    "validate_failed": "无法校验该 API 密钥。",
+    "success": "凭证已保存为 {{file}}",
+    "result_title": "凭证已保存",
+    "result_file": "认证文件",
+    "add_another_hint": "填入新的标签和密钥即可添加另一个账号。"
+  },
   "oauth_excluded": {
     "title": "OAuth 模型禁用",
     "description": "按提供商分列展示，点击卡片编辑或删除；支持 * 通配符，范围跟随上方的配置文件过滤标签。",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -290,6 +290,7 @@
     "filter_qwen": "Qwen",
     "filter_gemini": "Gemini",
     "filter_kimi": "Kimi",
+    "filter_opencode": "OpenCode",
     "filter_aistudio": "AIStudio",
     "filter_claude": "Claude",
     "filter_codex": "Codex",
@@ -488,6 +489,22 @@
     "limit_window": "{{duration}} 限额",
     "limit_index": "限额 #{{index}}",
     "reset_hint": "{{hint}} 后重置"
+  },
+  "opencode_quota": {
+    "title": "OpenCode 额度",
+    "empty_title": "暂无 OpenCode 认证",
+    "empty_desc": "上传 OpenCode Go 认证文件后即可查看额度。",
+    "idle": "点击此处刷新额度",
+    "loading": "正在加载额度...",
+    "load_failed": "额度获取失败：{{message}}",
+    "missing_auth_index": "认证文件缺少 auth_index",
+    "empty_data": "暂无额度数据",
+    "refresh_button": "刷新额度",
+    "fetch_all": "获取全部",
+    "five_hour_limit": "5 小时限额",
+    "weekly_limit": "周限额",
+    "monthly_limit": "月限额",
+    "rate_limited": "已限流"
   },
   "xai_quota": {
     "title": "Grok 额度",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -290,6 +290,7 @@
     "filter_qwen": "Qwen",
     "filter_gemini": "Gemini",
     "filter_kimi": "Kimi",
+    "filter_opencode": "OpenCode",
     "filter_aistudio": "AIStudio",
     "filter_claude": "Claude",
     "filter_codex": "Codex",
@@ -488,6 +489,22 @@
     "limit_window": "{{duration}} 限額",
     "limit_index": "限額 #{{index}}",
     "reset_hint": "{{hint}} 後重置"
+  },
+  "opencode_quota": {
+    "title": "OpenCode 配額",
+    "empty_title": "暫無 OpenCode 驗證",
+    "empty_desc": "上傳 OpenCode Go 驗證檔案後即可查看配額。",
+    "idle": "點擊此處重新整理配額",
+    "loading": "正在載入配額...",
+    "load_failed": "配額取得失敗：{{message}}",
+    "missing_auth_index": "驗證檔案缺少 auth_index",
+    "empty_data": "暫無配額資料",
+    "refresh_button": "重新整理配額",
+    "fetch_all": "取得全部",
+    "five_hour_limit": "5 小時限額",
+    "weekly_limit": "週限額",
+    "monthly_limit": "月限額",
+    "rate_limited": "已限流"
   },
   "xai_quota": {
     "title": "Grok 配額",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -550,6 +550,26 @@
     "result_location": "區域",
     "result_file": "儲存檔案"
   },
+  "opencode_login": {
+    "title": "OpenCode Go 登入",
+    "description": "OpenCode 沒有 OAuth 流程。登入後複製 API 金鑰並貼到這裡——每個帳號一份憑證，多個帳號可並存。取得金鑰：",
+    "label_label": "帳號標籤",
+    "label_hint": "決定憑證檔名與卡片標題。每個帳號用一個標籤，例如 personal / work。",
+    "label_placeholder": "personal",
+    "key_label": "API 金鑰",
+    "key_hint": "OpenCode Go 的金鑰。儲存前會先透過用量介面驗證。",
+    "key_placeholder": "sk-...",
+    "import_button": "匯入 OpenCode 憑證",
+    "fields_required": "請先填寫帳號標籤與 API 金鑰",
+    "name_taken": "{{file}} 已存在。請換一個帳號標籤，以免覆蓋現有憑證。",
+    "key_rejected": "OpenCode 拒絕了該 API 金鑰。",
+    "no_subscription": "金鑰有效，但該帳號沒有 Go 訂閱。",
+    "validate_failed": "無法驗證該 API 金鑰。",
+    "success": "憑證已儲存為 {{file}}",
+    "result_title": "憑證已儲存",
+    "result_file": "驗證檔案",
+    "add_another_hint": "填入新的標籤與金鑰即可新增另一個帳號。"
+  },
   "oauth_excluded": {
     "title": "OAuth 模型停用",
     "description": "按供應商分列展示，點擊卡片編輯或刪除；支援 * 萬用字元，範圍跟隨上方的設定檔篩選標籤。",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1259,7 +1259,8 @@
     "weekday_wed": "三",
     "weekday_thu": "四",
     "weekday_fri": "五",
-    "weekday_sat": "六"
+    "weekday_sat": "六",
+    "prefix_hint": "以 {{prefix}}/<model> 呼叫該憑證"
   },
   "plugin_management": {
     "title": "插件管理",

--- a/src/pages/OAuthPage.tsx
+++ b/src/pages/OAuthPage.tsx
@@ -6,11 +6,24 @@ import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { IconPlug } from '@/components/ui/icons';
 import { useAuthStore, useNotificationStore, useThemeStore } from '@/stores';
-import { oauthApi, pluginsApi, type BuiltInOAuthProvider } from '@/services/api';
+import {
+  apiCallApi,
+  authFilesApi,
+  getApiCallErrorMessage,
+  oauthApi,
+  pluginsApi,
+  type BuiltInOAuthProvider,
+} from '@/services/api';
 import { vertexApi, type VertexImportResponse } from '@/services/api/vertex';
 import { copyToClipboard } from '@/utils/clipboard';
 import { getErrorMessage, isRecord } from '@/utils/helpers';
 import { notifyAuthFilesChanged } from '@/features/authFiles/authFilesEvents';
+import {
+  buildOpencodeCredentialFile,
+  opencodeKeyErrorKey,
+  OPENCODE_CONSOLE_URL,
+} from '@/features/authFiles/opencodeLogin';
+import { OPENCODE_USAGE_URL } from '@/utils/quota';
 import { getPluginTitle, resolvePluginAssetURL } from '@/features/plugins/pluginResources';
 import type { PluginListEntry } from '@/types';
 import styles from './OAuthPage.module.scss';
@@ -49,6 +62,14 @@ interface VertexImportState {
   loading: boolean;
   error?: string;
   result?: VertexImportResult;
+}
+
+interface OpencodeImportState {
+  label: string;
+  apiKey: string;
+  loading: boolean;
+  error?: string;
+  savedFile?: string;
 }
 
 interface BuiltInOAuthProviderCard {
@@ -250,6 +271,11 @@ export function OAuthPage() {
   const [vertexState, setVertexState] = useState<VertexImportState>({
     fileName: '',
     location: '',
+    loading: false,
+  });
+  const [opencodeState, setOpencodeState] = useState<OpencodeImportState>({
+    label: '',
+    apiKey: '',
     loading: false,
   });
   const pollingTimers = useRef<Partial<Record<string, number>>>({});
@@ -509,6 +535,72 @@ export function OAuthPage() {
     }
   };
 
+  /**
+   * Validate an OpenCode Go key, then store it as its own auth file.
+   *
+   * The key is checked before it is written: an unusable credential that sits
+   * in the auth dir looks identical to a working one until something routes to
+   * it. The check goes through the management `api-call` proxy without an
+   * auth_index — the key is not stored yet, and the browser cannot reach
+   * opencode.ai directly.
+   */
+  const handleOpencodeImport = async () => {
+    const credential = buildOpencodeCredentialFile(opencodeState.label, opencodeState.apiKey);
+    if (!credential) {
+      const message = t('opencode_login.fields_required');
+      setOpencodeState((prev) => ({ ...prev, error: message, savedFile: undefined }));
+      showNotification(message, 'warning');
+      return;
+    }
+
+    setOpencodeState((prev) => ({ ...prev, loading: true, error: undefined, savedFile: undefined }));
+
+    const fail = (message: string) => {
+      setOpencodeState((prev) => ({ ...prev, loading: false, error: message }));
+      showNotification(message, 'error');
+    };
+
+    try {
+      // Adding a second account is exactly when a label collides, and the
+      // upload would overwrite a working credential without saying so.
+      const existing = await authFilesApi.list();
+      if (existing.files?.some((file) => file.name === credential.name)) {
+        fail(t('opencode_login.name_taken', { file: credential.name }));
+        return;
+      }
+
+      const probe = await apiCallApi.request({
+        method: 'GET',
+        url: OPENCODE_USAGE_URL,
+        header: { Authorization: `Bearer ${opencodeState.apiKey.trim()}` },
+      });
+      if (probe.statusCode < 200 || probe.statusCode >= 300) {
+        fail(
+          `${t(opencodeKeyErrorKey(probe.statusCode))} (${getApiCallErrorMessage(probe)})`.trim()
+        );
+        return;
+      }
+
+      const file = new File([credential.content], credential.name, { type: 'application/json' });
+      const upload = await authFilesApi.uploadFiles([file]);
+      if (upload.failed.length > 0) {
+        fail(t('notification.upload_failed'));
+        return;
+      }
+
+      setOpencodeState({
+        label: '',
+        apiKey: '',
+        loading: false,
+        savedFile: credential.name,
+      });
+      notifyAuthFilesChanged();
+      showNotification(t('opencode_login.success', { file: credential.name }), 'success');
+    } catch (err: unknown) {
+      fail(getErrorMessage(err) || t('notification.upload_failed'));
+    }
+  };
+
   const handleVertexFilePick = () => {
     vertexFileInputRef.current?.click();
   };
@@ -728,7 +820,7 @@ export function OAuthPage() {
           </div>
         </section>
 
-        {/* Vertex JSON 登录 */}
+        {/* Vertex JSON 登录 + OpenCode key import */}
         <section className={styles.providerSection}>
           <h2 className={styles.sectionTitle}>{t('auth_login.other_login_methods')}</h2>
           <Card
@@ -816,6 +908,72 @@ export function OAuthPage() {
                         <span className={styles.keyValueValue}>{vertexState.result.authFile}</span>
                       </div>
                     )}
+                  </div>
+                </div>
+              )}
+            </div>
+          </Card>
+
+          <Card
+            title={<span className={styles.cardTitle}>{t('opencode_login.title')}</span>}
+            extra={
+              <Button onClick={handleOpencodeImport} loading={opencodeState.loading}>
+                {t('opencode_login.import_button')}
+              </Button>
+            }
+          >
+            <div className={styles.cardContent}>
+              <div className={styles.cardHint}>
+                {t('opencode_login.description')}{' '}
+                <a href={OPENCODE_CONSOLE_URL} target="_blank" rel="noreferrer">
+                  {OPENCODE_CONSOLE_URL}
+                </a>
+              </div>
+              <Input
+                label={t('opencode_login.label_label')}
+                hint={t('opencode_login.label_hint')}
+                name="opencode-account-label"
+                autoComplete="off"
+                value={opencodeState.label}
+                onChange={(e) =>
+                  setOpencodeState((prev) => ({
+                    ...prev,
+                    label: e.target.value,
+                    error: undefined,
+                  }))
+                }
+                placeholder={t('opencode_login.label_placeholder')}
+              />
+              <Input
+                type="password"
+                label={t('opencode_login.key_label')}
+                hint={t('opencode_login.key_hint')}
+                name="opencode-api-key"
+                autoComplete="new-password"
+                value={opencodeState.apiKey}
+                onChange={(e) =>
+                  setOpencodeState((prev) => ({
+                    ...prev,
+                    apiKey: e.target.value,
+                    error: undefined,
+                  }))
+                }
+                placeholder={t('opencode_login.key_placeholder')}
+              />
+              {opencodeState.error && (
+                <div className="status-badge error">{opencodeState.error}</div>
+              )}
+              {opencodeState.savedFile && (
+                <div className={styles.connectionBox}>
+                  <div className={styles.connectionLabel}>{t('opencode_login.result_title')}</div>
+                  <div className={styles.keyValueList}>
+                    <div className={styles.keyValueItem}>
+                      <span className={styles.keyValueKey}>{t('opencode_login.result_file')}</span>
+                      <span className={styles.keyValueValue}>{opencodeState.savedFile}</span>
+                    </div>
+                  </div>
+                  <div className={styles.cardHintSecondary}>
+                    {t('opencode_login.add_another_hint')}
                   </div>
                 </div>
               )}

--- a/src/services/api/authFiles.ts
+++ b/src/services/api/authFiles.ts
@@ -249,6 +249,7 @@ const normalizeAuthFileEntry = (entry: AuthFileEntry): AuthFileEntry => {
   // account / account_type 故意不归一化：api-key 类凭证的 account 就是 API key 本身
   // （sdk/cliproxy/auth/types.go AccountInfo），不能进入展示与搜索路径。
   const projectId = readTextField(entry, 'project_id');
+  const prefix = readTextField(entry, 'prefix');
   const modified = readDateField(entry);
   const priority = readIntegerField(entry['priority']);
   const weight = readIntegerField(entry['weight']);
@@ -267,6 +268,7 @@ const normalizeAuthFileEntry = (entry: AuthFileEntry): AuthFileEntry => {
     ...(note ? { note } : {}),
     ...(email ? { email } : {}),
     ...(projectId ? { projectId } : {}),
+    ...(prefix ? { prefix } : {}),
   };
 };
 

--- a/src/stores/useQuotaStore.ts
+++ b/src/stores/useQuotaStore.ts
@@ -8,6 +8,7 @@ import type {
   ClaudeQuotaState,
   CodexQuotaState,
   KimiQuotaState,
+  OpencodeQuotaState,
   XaiQuotaState,
 } from '@/types';
 
@@ -19,11 +20,13 @@ interface QuotaStoreState {
   claudeQuota: Record<string, ClaudeQuotaState>;
   codexQuota: Record<string, CodexQuotaState>;
   kimiQuota: Record<string, KimiQuotaState>;
+  opencodeQuota: Record<string, OpencodeQuotaState>;
   xaiQuota: Record<string, XaiQuotaState>;
   setAntigravityQuota: (updater: QuotaUpdater<Record<string, AntigravityQuotaState>>) => void;
   setClaudeQuota: (updater: QuotaUpdater<Record<string, ClaudeQuotaState>>) => void;
   setCodexQuota: (updater: QuotaUpdater<Record<string, CodexQuotaState>>) => void;
   setKimiQuota: (updater: QuotaUpdater<Record<string, KimiQuotaState>>) => void;
+  setOpencodeQuota: (updater: QuotaUpdater<Record<string, OpencodeQuotaState>>) => void;
   setXaiQuota: (updater: QuotaUpdater<Record<string, XaiQuotaState>>) => void;
   clearQuotaCache: () => void;
 }
@@ -41,6 +44,7 @@ export const useQuotaStore = create<QuotaStoreState>((set) => ({
   claudeQuota: {},
   codexQuota: {},
   kimiQuota: {},
+  opencodeQuota: {},
   xaiQuota: {},
   setAntigravityQuota: (updater) =>
     set((state) => ({
@@ -58,6 +62,10 @@ export const useQuotaStore = create<QuotaStoreState>((set) => ({
     set((state) => ({
       kimiQuota: resolveUpdater(updater, state.kimiQuota),
     })),
+  setOpencodeQuota: (updater) =>
+    set((state) => ({
+      opencodeQuota: resolveUpdater(updater, state.opencodeQuota),
+    })),
   setXaiQuota: (updater) =>
     set((state) => ({
       xaiQuota: resolveUpdater(updater, state.xaiQuota),
@@ -69,6 +77,7 @@ export const useQuotaStore = create<QuotaStoreState>((set) => ({
       claudeQuota: {},
       codexQuota: {},
       kimiQuota: {},
+      opencodeQuota: {},
       xaiQuota: {},
     })),
 }));

--- a/src/types/authFile.ts
+++ b/src/types/authFile.ts
@@ -8,6 +8,7 @@ import type { RecentRequestBucket } from '@/utils/recentRequests';
 export type AuthFileType =
   | 'qwen'
   | 'kimi'
+  | 'opencode'
   | 'gemini'
   | 'aistudio'
   | 'claude'

--- a/src/types/authFile.ts
+++ b/src/types/authFile.ts
@@ -33,6 +33,13 @@ export interface AuthFileItem {
   email?: string;
   /** GCP / Vertex 项目 ID，账号邮箱缺失时作为身份回落。 */
   projectId?: string;
+  /**
+   * Routing prefix for this credential (`prefix/<model>`).
+   *
+   * Only present on servers new enough to send it; older ones omit the field
+   * and every prefix-aware surface simply renders nothing.
+   */
+  prefix?: string;
   size?: number;
   authIndex?: string | number | null;
   runtimeOnly?: boolean | string;

--- a/src/types/quota.ts
+++ b/src/types/quota.ts
@@ -310,6 +310,45 @@ export interface KimiQuotaState {
   errorStatus?: number;
 }
 
+// OpenCode Go API payload types
+export interface OpencodeUsageWindowPayload {
+  /** `"ok"` while the window still has room, `"rate-limited"` once it is spent. */
+  status?: string;
+  /** Percent USED in this window; the server floors and clamps it to 0-100. */
+  percent?: number | string;
+  resetsAt?: string;
+}
+
+export interface OpencodeUsagePayload {
+  usage?: {
+    rolling?: OpencodeUsageWindowPayload | null;
+    weekly?: OpencodeUsageWindowPayload | null;
+    monthly?: OpencodeUsageWindowPayload | null;
+  } | null;
+}
+
+export interface OpencodeQuotaRow {
+  id: string;
+  labelKey: string;
+  /** Translated `labelKey`, filled by the data layer for the React-free timeline. */
+  label?: string;
+  /** Percent still available, derived as `100 - percent`. */
+  remainingPercent: number;
+  /** The window reported itself as spent; the meter reads 0 either way. */
+  rateLimited: boolean;
+  /** Reset instant in epoch ms; null when the payload carried no usable date. */
+  resetAtMs: number | null;
+  /** Window length in hours; null for the monthly window, which has no fixed span. */
+  periodHours: number | null;
+}
+
+export interface OpencodeQuotaState {
+  status: 'idle' | 'loading' | 'success' | 'error';
+  rows: OpencodeQuotaRow[];
+  error?: string;
+  errorStatus?: number;
+}
+
 // xAI/Grok API payload types
 export interface XaiBillingCent {
   val?: number | string;

--- a/src/utils/quota/builders.ts
+++ b/src/utils/quota/builders.ts
@@ -11,6 +11,8 @@ import type {
   KimiLimitItem,
   KimiLimitWindow,
   KimiQuotaRow,
+  OpencodeUsagePayload,
+  OpencodeQuotaRow,
   XaiBillingConfig,
   XaiBillingPeriod,
   XaiBillingPeriodType,
@@ -369,6 +371,52 @@ export function buildKimiQuotaRows(payload: KimiUsagePayload): KimiQuotaRow[] {
   }
 
   return rows;
+}
+
+/**
+ * The three windows the Go plan meters, in the order the card lists them.
+ *
+ * `periodHours` is deliberately null for the monthly window: it anchors on the
+ * subscription anniversary rather than a fixed span, so drawing it as a
+ * fixed-length period on the timeline would misplace its start.
+ */
+const OPENCODE_WINDOWS = [
+  { key: 'rolling', labelKey: 'opencode_quota.five_hour_limit', periodHours: 5 },
+  { key: 'weekly', labelKey: 'opencode_quota.weekly_limit', periodHours: 24 * 7 },
+  { key: 'monthly', labelKey: 'opencode_quota.monthly_limit', periodHours: null },
+] as const;
+
+/**
+ * Rows for one OpenCode Go credential.
+ *
+ * The upstream route reports percent USED per window, so the meter value is
+ * derived rather than read. Windows that fail to decode are skipped instead of
+ * failing the whole card: the route is first-party but undocumented, and one
+ * malformed window should not hide the two that parsed.
+ */
+export function buildOpencodeQuotaRows(payload: OpencodeUsagePayload): OpencodeQuotaRow[] {
+  const usage = payload.usage;
+  if (!usage || typeof usage !== 'object') return [];
+
+  return OPENCODE_WINDOWS.map((descriptor): OpencodeQuotaRow | null => {
+    const window = usage[descriptor.key];
+    if (!window || typeof window !== 'object') return null;
+
+    const used = normalizeNumberValue(window.percent);
+    if (used === null || used < 0 || used > 100) return null;
+
+    const status = normalizeStringValue(window.status)?.toLowerCase() ?? null;
+    const rateLimited = status === 'rate-limited';
+
+    return {
+      id: descriptor.key,
+      labelKey: descriptor.labelKey,
+      remainingPercent: rateLimited ? 0 : Math.max(0, Math.min(100, Math.round(100 - used))),
+      rateLimited,
+      resetAtMs: resolveResetMs([window.resetsAt]),
+      periodHours: descriptor.periodHours,
+    };
+  }).filter((row): row is OpencodeQuotaRow => row !== null);
 }
 
 function normalizeXaiCentValue(value: XaiBillingConfig['monthlyLimit']): number | null {

--- a/src/utils/quota/constants.ts
+++ b/src/utils/quota/constants.ts
@@ -30,6 +30,10 @@ export const TYPE_COLORS: Record<string, TypeColorSet> = {
     light: { bg: '#dce8ff', text: '#0560cf' },
     dark: { bg: '#003880', text: '#70b5ff' },
   },
+  opencode: {
+    light: { bg: '#e8e6e4', text: '#3b3838' },
+    dark: { bg: '#2c2929', text: '#cfcecd' },
+  },
   antigravity: {
     light: { bg: '#e0f7fa', text: '#006064' },
     dark: { bg: '#004d40', text: '#80deea' },
@@ -138,6 +142,13 @@ export const CODEX_REQUEST_HEADERS = {
 export const KIMI_USAGE_URL = 'https://api.kimi.com/coding/v1/usages';
 
 export const KIMI_REQUEST_HEADERS = {
+  Authorization: 'Bearer $TOKEN$',
+};
+
+// OpenCode Go API configuration
+export const OPENCODE_USAGE_URL = 'https://opencode.ai/zen/go/v1/usage';
+
+export const OPENCODE_REQUEST_HEADERS = {
   Authorization: 'Bearer $TOKEN$',
 };
 

--- a/src/utils/quota/parsers.ts
+++ b/src/utils/quota/parsers.ts
@@ -6,6 +6,7 @@ import type {
   ClaudeUsagePayload,
   CodexUsagePayload,
   KimiUsagePayload,
+  OpencodeUsagePayload,
   XaiBillingPayload,
 } from '@/types';
 import { normalizeAuthIndex } from '@/utils/authIndex';
@@ -182,6 +183,23 @@ export function parseKimiUsagePayload(payload: unknown): KimiUsagePayload | null
   }
   if (typeof payload === 'object') {
     return payload as KimiUsagePayload;
+  }
+  return null;
+}
+
+export function parseOpencodeUsagePayload(payload: unknown): OpencodeUsagePayload | null {
+  if (payload === undefined || payload === null) return null;
+  if (typeof payload === 'string') {
+    const trimmed = payload.trim();
+    if (!trimmed) return null;
+    try {
+      return JSON.parse(trimmed) as OpencodeUsagePayload;
+    } catch {
+      return null;
+    }
+  }
+  if (typeof payload === 'object') {
+    return payload as OpencodeUsagePayload;
   }
   return null;
 }

--- a/src/utils/quota/planTier.ts
+++ b/src/utils/quota/planTier.ts
@@ -19,6 +19,27 @@ export const ELITE_CODEX_PLAN_TYPE = 'pro';
  * 顺序敏感：'pro' 同时命中 PREMIUM_CODEX_PLAN_TYPES，elite 判断必须在最前，
  * 否则 Pro 20x 会静默退回金卡。契约由 tests/quotaPlanTier.test.ts 守护。
  */
+/**
+ * Claude plan keys that earn a badge.
+ *
+ * The profile endpoint only exposes a `has_claude_max` boolean, so `plan_max`
+ * is what a Max subscription actually resolves to today; `plan_max5` and
+ * `plan_max20` are carried because the i18n table already distinguishes them.
+ * Max sits at gold rather than platinum: platinum marks the single top tier,
+ * and a bare `plan_max` cannot be told apart from Max 5x.
+ */
+export const PREMIUM_CLAUDE_PLAN_TYPES = new Set(['plan_max', 'plan_max5']);
+
+export const ELITE_CLAUDE_PLAN_TYPE = 'plan_max20';
+
+export function resolveClaudePlanTier(planType: string | null | undefined): CodexPlanTier {
+  const normalized = normalizePlanType(planType);
+  if (!normalized) return 'plain';
+  if (normalized === ELITE_CLAUDE_PLAN_TYPE) return 'elite';
+  if (PREMIUM_CLAUDE_PLAN_TYPES.has(normalized)) return 'premium';
+  return 'plain';
+}
+
 export function resolvePlanTier(planType: string | null | undefined): CodexPlanTier {
   const normalized = normalizePlanType(planType);
   if (!normalized) return 'plain';

--- a/src/utils/quota/validators.ts
+++ b/src/utils/quota/validators.ts
@@ -27,6 +27,10 @@ export function isKimiFile(file: AuthFileItem): boolean {
   return resolveAuthProvider(file) === 'kimi';
 }
 
+export function isOpencodeFile(file: AuthFileItem): boolean {
+  return resolveAuthProvider(file) === 'opencode';
+}
+
 export function isXaiFile(file: AuthFileItem): boolean {
   return resolveAuthProvider(file) === 'xai';
 }

--- a/tests/opencodeLogin.test.ts
+++ b/tests/opencodeLogin.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  buildOpencodeAuthFileName,
+  buildOpencodeCredentialFile,
+  opencodeKeyErrorKey,
+  slugifyOpencodeLabel,
+} from '@/features/authFiles/opencodeLogin';
+
+describe('OpenCode account slug', () => {
+  test('lowercases and joins words with a single dash', () => {
+    expect(slugifyOpencodeLabel('  Go Principal ')).toBe('go-principal');
+    expect(slugifyOpencodeLabel('cuenta   2')).toBe('cuenta-2');
+  });
+
+  test('reduces anything that could escape the auth dir to a plain slug', () => {
+    expect(slugifyOpencodeLabel('../../etc/passwd')).toBe('etc-passwd');
+    expect(slugifyOpencodeLabel('a/b\\c')).toBe('a-b-c');
+  });
+
+  test('has no name for a label that carries no usable characters', () => {
+    expect(slugifyOpencodeLabel('///')).toBe('');
+    expect(buildOpencodeAuthFileName('///')).toBeNull();
+    expect(buildOpencodeAuthFileName('   ')).toBeNull();
+  });
+});
+
+describe('OpenCode credential file', () => {
+  test('writes the key where the api-call proxy looks for it', () => {
+    const file = buildOpencodeCredentialFile('Go Principal', '  sk-abc123  ');
+    expect(file?.name).toBe('opencode-go-principal.json');
+    expect(JSON.parse(file!.content)).toEqual({
+      type: 'opencode',
+      access_token: 'sk-abc123',
+      label: 'Go Principal',
+    });
+  });
+
+  test('gives each account its own file, so several can coexist', () => {
+    expect(buildOpencodeCredentialFile('personal', 'sk-1')?.name).toBe('opencode-personal.json');
+    expect(buildOpencodeCredentialFile('trabajo', 'sk-2')?.name).toBe('opencode-trabajo.json');
+  });
+
+  test('refuses an empty key or an unusable label', () => {
+    expect(buildOpencodeCredentialFile('personal', '   ')).toBeNull();
+    expect(buildOpencodeCredentialFile('', 'sk-1')).toBeNull();
+  });
+});
+
+describe('OpenCode key rejection', () => {
+  test('separates a bad key from a key without the Go subscription', () => {
+    expect(opencodeKeyErrorKey(401)).toBe('opencode_login.key_rejected');
+    expect(opencodeKeyErrorKey(403)).toBe('opencode_login.no_subscription');
+    expect(opencodeKeyErrorKey(500)).toBe('opencode_login.validate_failed');
+  });
+});

--- a/tests/opencodeQuota.test.ts
+++ b/tests/opencodeQuota.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from 'bun:test';
+import { buildTimelineLane } from '@/features/quota/quotaTimelineModel';
+import { collectQuotaRowInstants, pickSoonestRowId } from '@/features/quota/resetSchedule';
+import { classifyQuotaFiles, resolveQuotaProviderType } from '@/features/quota/logic';
+import type { AuthFileItem } from '@/types';
+import { buildOpencodeQuotaRows, parseOpencodeUsagePayload, isOpencodeFile } from '@/utils/quota';
+
+/** A live `GET /zen/go/v1/usage` body, trimmed to the fields the card reads. */
+const SAMPLE = {
+  usage: {
+    rolling: { status: 'ok', percent: 16, resetsAt: '2099-08-30T19:55:45.422Z' },
+    weekly: { status: 'ok', percent: 77, resetsAt: '2099-08-31T00:00:00.422Z' },
+    monthly: { status: 'ok', percent: 38, resetsAt: '2099-09-25T04:37:48.422Z' },
+  },
+};
+
+describe('OpenCode quota rows', () => {
+  test('reports remaining percent from the used percent the API sends', () => {
+    const rows = buildOpencodeQuotaRows(SAMPLE);
+
+    expect(rows.map(({ id }) => id)).toEqual(['rolling', 'weekly', 'monthly']);
+    expect(rows.map(({ remainingPercent }) => remainingPercent)).toEqual([84, 23, 62]);
+    expect(rows.map(({ rateLimited }) => rateLimited)).toEqual([false, false, false]);
+  });
+
+  test('labels each window and periods all but the monthly one', () => {
+    const rows = buildOpencodeQuotaRows(SAMPLE);
+
+    expect(rows.map(({ labelKey }) => labelKey)).toEqual([
+      'opencode_quota.five_hour_limit',
+      'opencode_quota.weekly_limit',
+      'opencode_quota.monthly_limit',
+    ]);
+    // The monthly window anchors on the subscription anniversary, so it has no
+    // fixed span for the timeline to project.
+    expect(rows.map(({ periodHours }) => periodHours)).toEqual([5, 168, null]);
+  });
+
+  test('reads a rate-limited window as fully spent', () => {
+    const rows = buildOpencodeQuotaRows({
+      usage: { rolling: { status: 'rate-limited', percent: 100, resetsAt: '2099-01-01T00:00:00Z' } },
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.rateLimited).toBe(true);
+    expect(rows[0]?.remainingPercent).toBe(0);
+  });
+
+  test('skips malformed windows instead of dropping the whole card', () => {
+    const rows = buildOpencodeQuotaRows({
+      usage: {
+        rolling: { status: 'ok', percent: 140, resetsAt: '2099-01-01T00:00:00Z' },
+        weekly: { status: 'ok', resetsAt: '2099-01-01T00:00:00Z' },
+        monthly: { status: 'ok', percent: 38, resetsAt: '2099-09-25T04:37:48.422Z' },
+      },
+    });
+
+    expect(rows.map(({ id }) => id)).toEqual(['monthly']);
+  });
+
+  test('returns no rows when the payload carries no usage object', () => {
+    expect(buildOpencodeQuotaRows({})).toEqual([]);
+    expect(buildOpencodeQuotaRows({ usage: null })).toEqual([]);
+  });
+
+  test('parses the response body whether it arrives as text or as an object', () => {
+    expect(parseOpencodeUsagePayload(JSON.stringify(SAMPLE))).toEqual(SAMPLE);
+    expect(parseOpencodeUsagePayload(SAMPLE)).toEqual(SAMPLE);
+    expect(parseOpencodeUsagePayload('not json')).toBeNull();
+    expect(parseOpencodeUsagePayload(null)).toBeNull();
+  });
+});
+
+describe('OpenCode credential detection', () => {
+  test('matches on either provider or type, and nothing else', () => {
+    expect(isOpencodeFile({ name: 'a.json', provider: 'opencode' })).toBe(true);
+    expect(isOpencodeFile({ name: 'b.json', type: 'opencode' })).toBe(true);
+    expect(isOpencodeFile({ name: 'c.json', provider: 'codex' })).toBe(false);
+  });
+});
+
+describe('OpenCode on the quota page', () => {
+  const file = (name: string, provider: string, extra: Partial<AuthFileItem> = {}): AuthFileItem =>
+    ({ name, provider, ...extra }) as AuthFileItem;
+
+  test('classifies an OpenCode credential and skips a disabled one', () => {
+    expect(resolveQuotaProviderType(file('opencode-go.json', 'opencode'))).toBe('opencode');
+    expect(
+      resolveQuotaProviderType(file('opencode-off.json', 'opencode', { disabled: true }))
+    ).toBeNull();
+  });
+
+  test('places OpenCode last in the provider tab order', () => {
+    const entries = classifyQuotaFiles([
+      file('opencode-go.json', 'opencode'),
+      file('claude-a.json', 'claude'),
+    ]);
+    expect(entries.map((entry) => entry.type)).toEqual(['claude', 'opencode']);
+  });
+});
+
+describe('OpenCode quota scheduling', () => {
+  test('feeds every window reset to the soonest-recovery ranking', () => {
+    const rows = buildOpencodeQuotaRows(SAMPLE);
+    const instants = collectQuotaRowInstants('opencode', { status: 'success', rows });
+
+    expect(instants.map(({ rowId }) => rowId)).toEqual(['rolling', 'weekly', 'monthly']);
+    expect(pickSoonestRowId(instants, Date.parse('2099-08-30T00:00:00Z'))).toBe('rolling');
+  });
+
+  test('anchors the timeline lane on the longest window that fits the span', () => {
+    const rows = buildOpencodeQuotaRows(SAMPLE).map((row) => ({ ...row, label: row.labelKey }));
+    const lane = buildTimelineLane({
+      name: 'opencode-go.json',
+      displayName: 'OpenCode Go',
+      provider: 'opencode',
+      quota: { status: 'success', rows },
+      maxPeriodHours: 5,
+    });
+
+    expect(lane.anchorMs).toBe(rows[0]?.resetAtMs);
+    expect(lane.periodHours).toBe(5);
+    expect(lane.remaining).toBe(84);
+    expect(lane.limits).toHaveLength(3);
+  });
+});

--- a/tests/quotaPageLogic.test.ts
+++ b/tests/quotaPageLogic.test.ts
@@ -57,6 +57,7 @@ describe('buildTabCounts', () => {
       codex: 2,
       xai: 1,
       kimi: 1,
+      opencode: 0,
     });
   });
 });

--- a/tests/quotaPlanTier.test.ts
+++ b/tests/quotaPlanTier.test.ts
@@ -3,6 +3,7 @@ import {
   ELITE_CODEX_PLAN_TYPE,
   PREMIUM_CODEX_PLAN_TYPES,
   resolvePlanTier,
+  resolveClaudePlanTier,
 } from '@/utils/quota';
 
 describe('resolvePlanTier', () => {
@@ -37,5 +38,32 @@ describe('resolvePlanTier', () => {
     expect(resolvePlanTier(undefined)).toBe('plain');
     expect(resolvePlanTier('')).toBe('plain');
     expect(resolvePlanTier('   ')).toBe('plain');
+  });
+});
+
+describe('resolveClaudePlanTier', () => {
+  test('gives Max the gold badge, not the platinum one', () => {
+    // Platinum marks a single top tier; the profile endpoint exposes only a
+    // has_claude_max boolean, so plan_max cannot be told apart from Max 5x.
+    expect(resolveClaudePlanTier('plan_max')).toBe('premium');
+    expect(resolveClaudePlanTier('plan_max5')).toBe('premium');
+  });
+
+  test('reserves platinum for Max 20x', () => {
+    expect(resolveClaudePlanTier('plan_max20')).toBe('elite');
+  });
+
+  test('leaves the lower tiers unbadged', () => {
+    expect(resolveClaudePlanTier('plan_pro')).toBe('plain');
+    expect(resolveClaudePlanTier('plan_team')).toBe('plain');
+    expect(resolveClaudePlanTier('plan_free')).toBe('plain');
+    expect(resolveClaudePlanTier('plan_unknown')).toBe('plain');
+  });
+
+  test('tolerates casing, padding and absence', () => {
+    expect(resolveClaudePlanTier('  PLAN_MAX  ')).toBe('premium');
+    expect(resolveClaudePlanTier(null)).toBe('plain');
+    expect(resolveClaudePlanTier(undefined)).toBe('plain');
+    expect(resolveClaudePlanTier('')).toBe('plain');
   });
 });


### PR DESCRIPTION
Three commits: an OpenCode Go quota provider, the login-page import that creates
the credentials it reads, and two smaller quota-page additions.

## 1. feat(quota): add OpenCode Go quota provider

## What

Adds OpenCode as a sixth quota provider. A credential with `"type": "opencode"`
in the auth dir now gets a card showing the remaining capacity of its Go plan,
and a lane on the quota timeline.

![card](screenshot)

## Why no backend change

The file token store is already generic: `readAuthFiles` turns any auth-dir JSON
into an `Auth` with `Provider = metadata.type`, so an `opencode-*.json` shows up
in `GET /v0/management/auth-files` with an `auth_index`, and
`POST /v0/management/api-call` resolves `$TOKEN$` from `metadata.access_token`.
The card fetches through that proxy exactly like the Kimi one, so this PR is
console-only.

Verified against a live credential:

```
POST /v0/management/api-call
{"auth_index":"…","method":"GET","url":"https://opencode.ai/zen/go/v1/usage",
 "header":{"Authorization":"Bearer $TOKEN$"}}
-> 200 {"usage":{"rolling":{"status":"ok","percent":16,"resetsAt":"…"}, …}}
```

## Payload notes

`GET https://opencode.ai/zen/go/v1/usage` returns three windows, each with
`status` (`ok` | `rate-limited`), `percent` and `resetsAt`.

- **`percent` is the percentage USED**, so the meter is `100 - percent`. This is
  the inverse of Antigravity's `remainingFraction`, which makes it easy to get
  backwards — hence the explicit test.
- `rolling` is a 5-hour window, `weekly` resets Monday UTC, and **`monthly`
  anchors on the subscription anniversary rather than a fixed span**, so it
  carries no `periodHours` and the timeline does not project it as a
  fixed-length period.
- `status: "rate-limited"` reads as fully spent.
- Malformed windows are skipped rather than failing the card: the route is
  first-party but undocumented, and one bad window should not hide the two that
  parsed.

## One thing worth flagging

`QuotaPage` builds its provider→cache map behind
`as unknown as Record<QuotaProviderType, Record<string, QuotaCardState>>`. That
cast defeats the exhaustiveness check every other switch in the quota feature
relies on, so a missing provider entry is not a type error — it is a runtime
`Cannot read properties of undefined` that takes down the whole `/quota` route.
`tsc --noEmit` passed with the entry missing; only opening the page surfaced it.
I added the entry and left the cast alone to keep this PR scoped, but it may be
worth removing separately.

## Not included

No `opencode.svg` in `src/assets/icons/`, so the card and tab fall back to the
initial-letter avatar. Happy to add the mark if you would rather ship one.

## 2. feat(oauth): add OpenCode Go credential import

Adds an OpenCode entry under **Other login methods**, next to the Vertex
import, so accounts can be added from the console instead of by hand-writing
JSON into the auth dir. Each import writes its own `opencode-<slug>.json`, so
several accounts run side by side and each gets its own quota card.

It is an import rather than an OAuth card because OpenCode has no OAuth or
device flow — the docs say to sign in at opencode.ai/auth and copy an API key.
A "Start OpenCode Login" button would promise a handshake that does not exist.

- The key is validated against the usage API before it is written; an unusable
  credential in the auth dir is indistinguishable from a working one until
  something routes to it. The probe uses `api-call` with no auth_index.
- 401 (rejected key) and 403 (valid key, no Go subscription) are reported apart.
- An import whose file name already exists is refused instead of overwriting —
  adding a second account is exactly when labels collide.
- The label is slugified to `[a-z0-9-]` before becoming a file name.
- Both inputs carry explicit `autocomplete` attributes: the key field is
  `type="password"`, which makes Chrome treat the label field above it as a
  username and overwrite both with saved credentials.

### Known wrinkle, not addressed here

`metadata.label` is honoured by `FileTokenStore.labelFor` (the disk-scan path)
but ignored by `buildAuthFromFileData` and `synthesizeFileAuths`, which both
derive the label from `type`/`email` only. So a freshly uploaded credential
reports `label: "opencode"` until it is re-read from disk. The cards title
themselves from the file name, so the impact is cosmetic — but the two paths
disagreeing looks like a pre-existing bug worth a separate fix.

## 3. feat(quota): show the routing prefix and badge Claude Max

**Routing prefix.** With `force-model-prefix` enabled, `personal/claude-opus-5`
and `ag/gemini-3.5-flash` are answered by different credentials, and nothing on
the card said which one owns which prefix — you had to open the details sheet,
which downloads the whole credential. Cards now trail the file name with a
`prefix/` chip.

That needs the server to report the field, which is
router-for-me/CLIProxyAPI#5351. **This PR does not depend on it**: servers that
do not send `prefix` render no chip, so it can merge in either order.

**Claude Max badge.** Codex has shown its plan as a badge for a while — platinum
for Pro 20x, gold for Pro/Pro Lite — while Claude rendered its plan as plain
text, so a Max subscription looked the same as Free. Max now gets the gold badge
and Max 20x the platinum one.

Max is gold rather than platinum deliberately: platinum marks a single top tier,
and `/api/oauth/profile` only exposes a `has_claude_max` boolean, so `plan_max`
cannot be told apart from Max 5x. `plan_max20` is wired up for the day upstream
distinguishes them.

## Testing

- `bun run verify` (test + lint + build) green: 446 tests pass, up from 424.
- New `tests/opencodeQuota.test.ts` covers the used→remaining flip, per-window
  labels and periods, rate-limited and malformed windows, payload parsing,
  credential detection, tab ordering and the timeline lane.
- `tests/quotaPageLogic.test.ts` gains `opencode: 0` in the pinned tab-count map
  — that assertion documents zero-filling of empty tabs.
- Manually verified against a real OpenCode Go subscription on CLIProxyAPI
  7.2.142: card, countdowns, soonest-recovery hint and timeline lane all render.
- The import was exercised end to end in a browser: a rejected key reports 401
  and writes nothing, a colliding label is refused, and a valid key produces a
  second credential that gets its own card.
- Prefix chips and the Max badge verified against a live instance with five
  distinct prefixes in play.
