### PR TITLE
feat(quota): show the routing prefix on cards and badge Claude Max

### DIFF
--- a/src/features/quota/components/QuotaCard.module.scss
+++ b/src/features/quota/components/QuotaCard.module.scss
@@ -85,6 +85,21 @@
   @include text-ellipsis;
 }
 
+/* Routing prefix, e.g. `personal/`. Trails the file name and never squeezes
+   it: the name is the identity, the prefix is how you address it. */
+.prefixChip {
+  flex-shrink: 0;
+  padding: 1px 6px;
+  border-radius: 6px;
+  font-family: $font-mono;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: var(--text-secondary);
+  background: color-mix(in srgb, var(--bg-tertiary) 70%, transparent);
+  border: 1px solid var(--border-subtle, transparent);
+}
+
 /* ---------- body 容器 ---------- */
 
 .body {

--- a/src/features/quota/components/QuotaCard.tsx
+++ b/src/features/quota/components/QuotaCard.tsx
@@ -100,6 +100,14 @@ export function QuotaCard(props: QuotaCardProps) {
         <span className={styles.fileName} title={file.name}>
           {file.name}
         </span>
+        {file.prefix && (
+          <span
+            className={styles.prefixChip}
+            title={t('quota_management.prefix_hint', { prefix: file.prefix })}
+          >
+            {`${file.prefix}/`}
+          </span>
+        )}
       </header>
 
       <div className={styles.body}>

--- a/src/features/quota/providers/claude/ClaudeQuotaBody.tsx
+++ b/src/features/quota/providers/claude/ClaudeQuotaBody.tsx
@@ -5,7 +5,7 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { ClaudeQuotaState } from '@/types';
-import { buildResetDisplay } from '@/utils/quota';
+import { buildResetDisplay, resolveClaudePlanTier } from '@/utils/quota';
 import { useNow } from '@/hooks/useNow';
 import { QuotaMeter } from '../../components/QuotaMeter';
 import { QuotaResetLabel } from '../../components/QuotaResetLabel';
@@ -22,13 +22,21 @@ export function ClaudeQuotaBody({ quota, classes }: QuotaBodyProps<ClaudeQuotaSt
   const windows = quota.windows ?? [];
   const extraUsage = quota.extraUsage ?? null;
   const planType = quota.planType ?? null;
+  // Max earns the same badge treatment Codex gives Pro/Pro Lite.
+  const planTier = resolveClaudePlanTier(planType);
+  const planValueClass =
+    planTier === 'elite'
+      ? classes.elitePlanValue
+      : planTier === 'premium'
+        ? classes.premiumPlanValue
+        : classes.codexPlanValue;
 
   return (
     <>
       {planType && (
         <div className={classes.codexPlan}>
           <span className={classes.codexPlanLabel}>{t('claude_quota.plan_label')}</span>
-          <span className={classes.codexPlanValue}>{t(`claude_quota.${planType}`)}</span>
+          <span className={planValueClass}>{t(`claude_quota.${planType}`)}</span>
         </div>
       )}
       {extraUsage && extraUsage.is_enabled && (

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1196,7 +1196,8 @@
     "weekday_wed": "Wed",
     "weekday_thu": "Thu",
     "weekday_fri": "Fri",
-    "weekday_sat": "Sat"
+    "weekday_sat": "Sat",
+    "prefix_hint": "Address this credential as {{prefix}}/<model>"
   },
   "plugin_management": {
     "title": "Plugin Management",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1183,7 +1183,8 @@
     "weekday_wed": "Ср",
     "weekday_thu": "Чт",
     "weekday_fri": "Пт",
-    "weekday_sat": "Сб"
+    "weekday_sat": "Сб",
+    "prefix_hint": "Обращайтесь к этому credential как {{prefix}}/<model>"
   },
   "plugin_management": {
     "title": "Управление плагинами",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1196,7 +1196,8 @@
     "weekday_wed": "三",
     "weekday_thu": "四",
     "weekday_fri": "五",
-    "weekday_sat": "六"
+    "weekday_sat": "六",
+    "prefix_hint": "以 {{prefix}}/<model> 调用该凭证"
   },
   "plugin_management": {
     "title": "插件管理",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1222,7 +1222,8 @@
     "weekday_wed": "三",
     "weekday_thu": "四",
     "weekday_fri": "五",
-    "weekday_sat": "六"
+    "weekday_sat": "六",
+    "prefix_hint": "以 {{prefix}}/<model> 呼叫該憑證"
   },
   "plugin_management": {
     "title": "插件管理",

--- a/src/services/api/authFiles.ts
+++ b/src/services/api/authFiles.ts
@@ -249,6 +249,7 @@ const normalizeAuthFileEntry = (entry: AuthFileEntry): AuthFileEntry => {
   // account / account_type 故意不归一化：api-key 类凭证的 account 就是 API key 本身
   // （sdk/cliproxy/auth/types.go AccountInfo），不能进入展示与搜索路径。
   const projectId = readTextField(entry, 'project_id');
+  const prefix = readTextField(entry, 'prefix');
   const modified = readDateField(entry);
   const priority = readIntegerField(entry['priority']);
   const weight = readIntegerField(entry['weight']);
@@ -267,6 +268,7 @@ const normalizeAuthFileEntry = (entry: AuthFileEntry): AuthFileEntry => {
     ...(note ? { note } : {}),
     ...(email ? { email } : {}),
     ...(projectId ? { projectId } : {}),
+    ...(prefix ? { prefix } : {}),
   };
 };
 

--- a/src/types/authFile.ts
+++ b/src/types/authFile.ts
@@ -32,6 +32,13 @@ export interface AuthFileItem {
   email?: string;
   /** GCP / Vertex 项目 ID，账号邮箱缺失时作为身份回落。 */
   projectId?: string;
+  /**
+   * Routing prefix for this credential (`prefix/<model>`).
+   *
+   * Only present on servers new enough to send it; older ones omit the field
+   * and every prefix-aware surface simply renders nothing.
+   */
+  prefix?: string;
   size?: number;
   authIndex?: string | number | null;
   runtimeOnly?: boolean | string;

--- a/src/utils/quota/planTier.ts
+++ b/src/utils/quota/planTier.ts
@@ -19,6 +19,27 @@ export const ELITE_CODEX_PLAN_TYPE = 'pro';
  * 顺序敏感：'pro' 同时命中 PREMIUM_CODEX_PLAN_TYPES，elite 判断必须在最前，
  * 否则 Pro 20x 会静默退回金卡。契约由 tests/quotaPlanTier.test.ts 守护。
  */
+/**
+ * Claude plan keys that earn a badge.
+ *
+ * The profile endpoint only exposes a `has_claude_max` boolean, so `plan_max`
+ * is what a Max subscription actually resolves to today; `plan_max5` and
+ * `plan_max20` are carried because the i18n table already distinguishes them.
+ * Max sits at gold rather than platinum: platinum marks the single top tier,
+ * and a bare `plan_max` cannot be told apart from Max 5x.
+ */
+export const PREMIUM_CLAUDE_PLAN_TYPES = new Set(['plan_max', 'plan_max5']);
+
+export const ELITE_CLAUDE_PLAN_TYPE = 'plan_max20';
+
+export function resolveClaudePlanTier(planType: string | null | undefined): CodexPlanTier {
+  const normalized = normalizePlanType(planType);
+  if (!normalized) return 'plain';
+  if (normalized === ELITE_CLAUDE_PLAN_TYPE) return 'elite';
+  if (PREMIUM_CLAUDE_PLAN_TYPES.has(normalized)) return 'premium';
+  return 'plain';
+}
+
 export function resolvePlanTier(planType: string | null | undefined): CodexPlanTier {
   const normalized = normalizePlanType(planType);
   if (!normalized) return 'plain';

--- a/tests/quotaPlanTier.test.ts
+++ b/tests/quotaPlanTier.test.ts
@@ -3,6 +3,7 @@ import {
   ELITE_CODEX_PLAN_TYPE,
   PREMIUM_CODEX_PLAN_TYPES,
   resolvePlanTier,
+  resolveClaudePlanTier,
 } from '@/utils/quota';
 
 describe('resolvePlanTier', () => {
@@ -37,5 +38,32 @@ describe('resolvePlanTier', () => {
     expect(resolvePlanTier(undefined)).toBe('plain');
     expect(resolvePlanTier('')).toBe('plain');
     expect(resolvePlanTier('   ')).toBe('plain');
+  });
+});
+
+describe('resolveClaudePlanTier', () => {
+  test('gives Max the gold badge, not the platinum one', () => {
+    // Platinum marks a single top tier; the profile endpoint exposes only a
+    // has_claude_max boolean, so plan_max cannot be told apart from Max 5x.
+    expect(resolveClaudePlanTier('plan_max')).toBe('premium');
+    expect(resolveClaudePlanTier('plan_max5')).toBe('premium');
+  });
+
+  test('reserves platinum for Max 20x', () => {
+    expect(resolveClaudePlanTier('plan_max20')).toBe('elite');
+  });
+
+  test('leaves the lower tiers unbadged', () => {
+    expect(resolveClaudePlanTier('plan_pro')).toBe('plain');
+    expect(resolveClaudePlanTier('plan_team')).toBe('plain');
+    expect(resolveClaudePlanTier('plan_free')).toBe('plain');
+    expect(resolveClaudePlanTier('plan_unknown')).toBe('plain');
+  });
+
+  test('tolerates casing, padding and absence', () => {
+    expect(resolveClaudePlanTier('  PLAN_MAX  ')).toBe('premium');
+    expect(resolveClaudePlanTier(null)).toBe('plain');
+    expect(resolveClaudePlanTier(undefined)).toBe('plain');
+    expect(resolveClaudePlanTier('')).toBe('plain');
   });
 });


### PR DESCRIPTION
Two things the quota page could not tell you at a glance. Both are
provider-agnostic — they improve credentials you already support.

## Routing prefix on the card

With `force-model-prefix` enabled, `personal/claude-opus-5` and
`ag/gemini-3.5-flash` are answered by *different* credentials. Nothing on the
card said which one owns which prefix, so on an instance with several accounts
per provider there was no way to tell the cards apart beyond the file name.

Reading it today means `GET /auth-files/:name` and parsing the raw credential,
which pulls access and refresh tokens into the browser — fine for a details
sheet the user opened deliberately, not fine for a listing that renders every
credential on load. So cards now read the field from the listing and trail the
file name with a `prefix/` chip.

That field is added by router-for-me/CLIProxyAPI#5351. **This PR does not depend
on it**: servers that do not send `prefix` render no chip, so the two can merge
in either order.

## Claude Max badge

Codex has shown its plan as a badge for a while — platinum for Pro 20x, gold for
Pro / Pro Lite — while Claude rendered its plan as plain text, so a Max
subscription looked exactly like Free. Max now gets the gold badge and Max 20x
the platinum one, reusing the existing `elitePlanValue` / `premiumPlanValue`
classes rather than adding new ones.

Max is gold rather than platinum deliberately: platinum marks a single top tier,
and `/api/oauth/profile` only exposes a `has_claude_max` boolean, so `plan_max`
cannot be told apart from Max 5x. `plan_max20` is wired up for the day upstream
distinguishes them.

`resolveClaudePlanTier` is kept separate from `resolvePlanTier` rather than
generalised: the two ladders disagree about what the entry paid tier means, and
folding them together would need a mode flag plus two sets of pinned tests.

## Testing

- `bun run verify` (test + lint + build) green: 428 tests pass, up from 424.
- New cases in `tests/quotaPlanTier.test.ts` cover the gold/platinum split,
  the unbadged lower tiers, and casing/padding/absence.
- Verified against a live instance with five distinct prefixes in play
  (`personal`, `wibond`, `ag`, `plus`, `prolite`): chips render for the
  credentials that set one and are absent for the rest, and a Max credential
  shows the gold badge while a Team one stays plain.
