### PR TITLE
feat(layout): add Cmd+B / Ctrl+B shortcut and tooltip for sidebar toggle

### DIFF
--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -5,6 +5,7 @@ import {
   useCallback,
   useEffect,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
   type MouseEvent as ReactMouseEvent,
@@ -49,6 +50,7 @@ import { APIKEY_FUN_DISPLAY_NAME, hasApiKeyFunConfig } from '@/features/provider
 import { triggerHeaderRefresh } from '@/hooks/useHeaderRefresh';
 import { LANGUAGE_LABEL_KEYS, LANGUAGE_ORDER } from '@/utils/constants';
 import { isSupportedLanguage } from '@/utils/language';
+import { getSidebarShortcutLabel, isSidebarToggleShortcut } from '@/utils/sidebarShortcut';
 import type { Theme } from '@/types';
 
 const sidebarIcons: Record<string, ReactNode> = {
@@ -811,6 +813,31 @@ export function MainLayout() {
     [hideRailTooltip, showRailTooltip]
   );
 
+  const isMac = useMemo(() => {
+    if (typeof navigator === 'undefined') return false;
+    const platform =
+      (navigator as unknown as { userAgentData?: { platform?: string } }).userAgentData?.platform ||
+      navigator.platform ||
+      navigator.userAgent ||
+      '';
+    return /(Mac|iPhone|iPod|iPad)/i.test(platform);
+  }, []);
+
+  const shortcutText = getSidebarShortcutLabel(isMac);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (isSidebarToggleShortcut(event)) {
+        event.preventDefault();
+        hideRailTooltip();
+        setSidebarCollapsed((prev) => !prev);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [hideRailTooltip]);
+
   const renderNavBadge = (badge?: number, badgeLabel?: string) =>
     typeof badge === 'number' ? (
       <>
@@ -941,6 +968,8 @@ export function MainLayout() {
     ? t('sidebar.toggle_collapse', { defaultValue: 'Close navigation' })
     : t('sidebar.toggle_expand', { defaultValue: 'Open navigation' });
 
+  const sidebarToggleLabel = sidebarCollapsed ? t('sidebar.expand') : t('sidebar.collapse');
+
   return (
     <div
       className={`app-shell ${sidebarCollapsed ? 'sidebar-is-collapsed' : ''} ${
@@ -957,8 +986,18 @@ export function MainLayout() {
             hideRailTooltip();
             setSidebarCollapsed((prev) => !prev);
           }}
-          title={sidebarCollapsed ? t('sidebar.expand') : t('sidebar.collapse')}
-          aria-label={sidebarCollapsed ? t('sidebar.expand') : t('sidebar.collapse')}
+          onMouseEnter={(event) =>
+            handleRailTooltipMouseEnter(event, 'sidebar-toggle', sidebarToggleLabel, shortcutText)
+          }
+          onMouseLeave={handleRailTooltipMouseLeave}
+          onFocus={(event) =>
+            handleRailTooltipFocus(event, 'sidebar-toggle', sidebarToggleLabel, shortcutText)
+          }
+          onBlur={(event) =>
+            handleRailTooltipBlur(event, 'sidebar-toggle', sidebarToggleLabel, shortcutText)
+          }
+          aria-label={`${sidebarToggleLabel} (${shortcutText})`}
+          aria-describedby={railTooltip?.targetID === 'sidebar-toggle' ? NAV_TOOLTIP_ID : undefined}
         >
           {sidebarCollapsed ? headerIcons.chevronRight : headerIcons.chevronLeft}
         </button>
@@ -1137,7 +1176,7 @@ export function MainLayout() {
           </div>
         </aside>
 
-        {!showSidebarLabels && railTooltip && (
+        {railTooltip && (
           <div
             ref={railTooltipRef}
             id={NAV_TOOLTIP_ID}

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -730,7 +730,7 @@
 
 .nav-tooltip {
   position: fixed;
-  left: calc(var(--sidebar-collapsed-width) + 12px);
+  left: calc(var(--sidebar-active-width) + 20px);
   z-index: $z-dropdown + 2;
   transform: translateY(-50%);
   display: flex;
@@ -738,7 +738,7 @@
   gap: 3px;
   box-sizing: border-box;
   width: max-content;
-  max-width: min(320px, calc(100vw - var(--sidebar-collapsed-width) - 24px));
+  max-width: min(320px, calc(100vw - var(--sidebar-active-width) - 32px));
   max-height: calc(100vh - 16px);
   padding: 9px 12px;
   overflow: hidden;
@@ -748,6 +748,7 @@
   box-shadow: 0 14px 36px rgb(0 0 0 / 0.32);
   pointer-events: none;
   animation: nav-tooltip-in $transition-fast ease-out;
+  transition: left $transition-normal;
 
   .nav-tooltip-label {
     max-width: 100%;

--- a/src/utils/sidebarShortcut.ts
+++ b/src/utils/sidebarShortcut.ts
@@ -1,0 +1,22 @@
+export function isSidebarToggleShortcut(event: {
+  key: string;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  target?: EventTarget | null;
+}): boolean {
+  if (!(event.metaKey || event.ctrlKey) || (event.key !== 'b' && event.key !== 'B')) {
+    return false;
+  }
+  const target = event.target as HTMLElement | null;
+  if (
+    target &&
+    (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)
+  ) {
+    return false;
+  }
+  return true;
+}
+
+export function getSidebarShortcutLabel(isMac: boolean): string {
+  return isMac ? '⌘B' : 'Ctrl+B';
+}

--- a/tests/sidebarShortcut.test.ts
+++ b/tests/sidebarShortcut.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  getSidebarShortcutLabel,
+  isSidebarToggleShortcut,
+} from '@/utils/sidebarShortcut';
+
+describe('Sidebar Shortcut Logic', () => {
+  describe('isSidebarToggleShortcut', () => {
+    test('matches metaKey + b (Mac Cmd+B)', () => {
+      expect(
+        isSidebarToggleShortcut({
+          key: 'b',
+          metaKey: true,
+          ctrlKey: false,
+        })
+      ).toBe(true);
+
+      expect(
+        isSidebarToggleShortcut({
+          key: 'B',
+          metaKey: true,
+          ctrlKey: false,
+        })
+      ).toBe(true);
+    });
+
+    test('matches ctrlKey + b (Windows/Linux Ctrl+B)', () => {
+      expect(
+        isSidebarToggleShortcut({
+          key: 'b',
+          metaKey: false,
+          ctrlKey: true,
+        })
+      ).toBe(true);
+
+      expect(
+        isSidebarToggleShortcut({
+          key: 'B',
+          metaKey: false,
+          ctrlKey: true,
+        })
+      ).toBe(true);
+    });
+
+    test('rejects without metaKey or ctrlKey', () => {
+      expect(
+        isSidebarToggleShortcut({
+          key: 'b',
+          metaKey: false,
+          ctrlKey: false,
+        })
+      ).toBe(false);
+    });
+
+    test('rejects keys other than b/B', () => {
+      expect(
+        isSidebarToggleShortcut({
+          key: 'c',
+          metaKey: true,
+          ctrlKey: false,
+        })
+      ).toBe(false);
+
+      expect(
+        isSidebarToggleShortcut({
+          key: 'k',
+          metaKey: false,
+          ctrlKey: true,
+        })
+      ).toBe(false);
+    });
+
+    test('ignores when target is an input, textarea, or contentEditable element', () => {
+      const inputEl = {
+        tagName: 'INPUT',
+        isContentEditable: false,
+      } as unknown as HTMLElement;
+
+      const textareaEl = {
+        tagName: 'TEXTAREA',
+        isContentEditable: false,
+      } as unknown as HTMLElement;
+
+      const contentEditableEl = {
+        tagName: 'DIV',
+        isContentEditable: true,
+      } as unknown as HTMLElement;
+
+      const buttonEl = {
+        tagName: 'BUTTON',
+        isContentEditable: false,
+      } as unknown as HTMLElement;
+
+      expect(
+        isSidebarToggleShortcut({
+          key: 'b',
+          metaKey: true,
+          ctrlKey: false,
+          target: inputEl,
+        })
+      ).toBe(false);
+
+      expect(
+        isSidebarToggleShortcut({
+          key: 'b',
+          metaKey: true,
+          ctrlKey: false,
+          target: textareaEl,
+        })
+      ).toBe(false);
+
+      expect(
+        isSidebarToggleShortcut({
+          key: 'b',
+          metaKey: true,
+          ctrlKey: false,
+          target: contentEditableEl,
+        })
+      ).toBe(false);
+
+      expect(
+        isSidebarToggleShortcut({
+          key: 'b',
+          metaKey: true,
+          ctrlKey: false,
+          target: buttonEl,
+        })
+      ).toBe(true);
+    });
+  });
+
+  describe('getSidebarShortcutLabel', () => {
+    test('returns ⌘B for Mac and Ctrl+B for non-Mac', () => {
+      expect(getSidebarShortcutLabel(true)).toBe('⌘B');
+      expect(getSidebarShortcutLabel(false)).toBe('Ctrl+B');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds an industry-standard keyboard shortcut (`Cmd+B` on macOS, `Ctrl+B` on Windows/Linux) to expand and collapse the sidebar, along with an integrated hover/focus tooltip on the floating toggle button.

### Key Additions & Improvements

1. **Global Keyboard Shortcut (`Cmd+B` / `Ctrl+B`)**:
   - Added global `keydown` listener to toggle sidebar expansion and collapse state.
   - Guarded against triggering while typing in text inputs, textareas, or contentEditable elements.
   - Cleanly cleans up any open rail tooltips on toggle.
   - Platform-aware label resolver displaying `⌘B` for macOS and `Ctrl+B` for Windows/Linux.

2. **Sidebar Toggle Button Tooltip**:
   - Wired the floating toggle button (`.sidebar-toggle-floating`) into the existing `nav-tooltip` system.
   - Shows dynamic action text (`Expand` / `Collapse`) and platform shortcut meta badge (`⌘B` / `Ctrl+B`) on hover and focus.
   - Refined `.nav-tooltip` horizontal positioning (`calc(var(--sidebar-active-width) + 20px)`) to provide comfortable spacing (6–8px) from the floating button, preventing tooltip overlap with the button border and shadow.
   - Full accessibility support with appropriate `aria-label` and `aria-describedby` attributes.

3. **Automated Testing**:
   - Added unit test suite `tests/sidebarShortcut.test.ts` covering shortcut key combinations, modifier keys, input focus guards, and platform label resolutions.
   - All 430 unit tests pass; TypeScript compilation and production build succeed cleanly.

## Verification

- `bun test` -> 430 passed across 63 test files.
- `bun run type-check` (`tsc --noEmit`) -> 0 errors.
- `bun run build` -> production bundle compiled cleanly.