### PR TITLE
fix(system): unify quick link icon background styles to dark tone

### DIFF
--- a/src/pages/SystemPage.module.scss
+++ b/src/pages/SystemPage.module.scss
@@ -306,16 +306,13 @@
   width: 44px;
   height: 44px;
   border-radius: $radius-md;
-  background-color: var(--primary-color);
+  background-color: #24292f;
   color: white;
   flex-shrink: 0;
 
-  &.github {
-    background-color: #24292f;
-  }
-
+  &.github,
   &.docs {
-    background-color: #10b981;
+    background-color: #24292f;
   }
 }
 


### PR DESCRIPTION
## Summary

Unifies the icon background colors in the **Quick Links** section of the System / About page (`SystemPage`), aligning the documentation link icon (`.docs`) with the dark tone (`#24292f`) used by the repository links.

### Key Changes

- Updated `src/pages/SystemPage.module.scss` to style both `.github` and `.docs` quick link icon containers with the consistent dark background (`#24292f`), eliminating the visual mismatch from the previous green background.

## Verification

- `bun test` -> 430 passed across 63 test files.
- `bun run type-check` (`tsc --noEmit`) -> 0 errors.
- `bun run build` -> production bundle compiled cleanly.