### PR TITLE
fix(ui): improve sheet drawer entrance and exit slide animation

### DIFF
--- a/src/components/ui/Sheet/Sheet.module.scss
+++ b/src/components/ui/Sheet/Sheet.module.scss
@@ -4,19 +4,20 @@
 .overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.5);
-  opacity: 0;
-  transition: opacity 200ms ease;
+  background: rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
   z-index: 2000;
   display: flex;
   justify-content: flex-end;
+  opacity: 0;
 
   &.entering {
-    opacity: 1;
+    animation: sheet-fade-in 280ms cubic-bezier(0.16, 1, 0.3, 1) forwards;
   }
 
   &.exiting {
-    opacity: 0;
+    animation: sheet-fade-out 280ms cubic-bezier(0.4, 0, 0.2, 1) forwards;
   }
 }
 
@@ -24,20 +25,58 @@
   position: relative;
   background: var(--bg-primary);
   border-left: 1px solid var(--border-color);
-  box-shadow: var(--floating-shadow);
-  transform: translateX(100%);
-  transition: transform 280ms cubic-bezier(0.32, 0.72, 0, 1);
+  box-shadow:
+    -8px 0 32px rgba(0, 0, 0, 0.16),
+    var(--floating-shadow);
+  transform: translate3d(100%, 0, 0);
+  will-change: transform;
   display: flex;
   flex-direction: column;
   height: 100%;
   outline: none;
 
   &.entering {
-    transform: translateX(0);
+    animation: sheet-slide-in 320ms cubic-bezier(0.16, 1, 0.3, 1) forwards;
   }
 
   &.exiting {
-    transform: translateX(100%);
+    animation: sheet-slide-out 280ms cubic-bezier(0.32, 0, 0.67, 0) forwards;
+  }
+}
+
+@keyframes sheet-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes sheet-fade-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes sheet-slide-in {
+  from {
+    transform: translate3d(100%, 0, 0);
+  }
+  to {
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes sheet-slide-out {
+  from {
+    transform: translate3d(0, 0, 0);
+  }
+  to {
+    transform: translate3d(100%, 0, 0);
   }
 }
 
@@ -148,3 +187,29 @@
     padding: 12px 16px;
   }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .overlay.entering,
+  .overlay.exiting,
+  .content.entering,
+  .content.exiting {
+    animation: none;
+  }
+
+  .overlay.entering {
+    opacity: 1;
+  }
+
+  .overlay.exiting {
+    opacity: 0;
+  }
+
+  .content.entering {
+    transform: none;
+  }
+
+  .content.exiting {
+    transform: translate3d(100%, 0, 0);
+  }
+}
+


### PR DESCRIPTION
## Summary

Enhances the visual motion and transition smoothness of the base `Sheet` (Drawer) component when opening and closing.

### Problem

Previously, the `Sheet` component relied on CSS `transition: transform / opacity` combined with an `.entering` class rendered synchronously upon portal mounting. Because the element was mounted with `.entering` directly in the initial paint, the CSS transition never triggered, causing the drawer to pop into view abruptly without a slide-in motion.

### Key Changes

1. **Keyframe-Driven Motion (HeroUI / Radix Drawer Parity)**:
   - Replaced CSS `transition` with explicit CSS `@keyframes` (`sheet-slide-in` / `sheet-slide-out` and `sheet-fade-in` / `sheet-fade-out`), ensuring the entrance animation executes smoothly regardless of initial DOM mounting timing.
   - Employed an ease-out deceleration curve (`cubic-bezier(0.16, 1, 0.3, 1)`) for the 320ms slide-in, delivering a fluid, spring-like feel.
2. **Backdrop & Hardware Acceleration**:
   - Upgraded overlay backdrop to include `backdrop-filter: blur(2px)` for depth.
   - Applied GPU-accelerated `transform: translate3d(100%, 0, 0)` and `will-change: transform` for 60fps rendering.
3. **Accessibility**:
   - Added full `@media (prefers-reduced-motion: reduce)` support to disable keyframes for users requesting reduced motion.

## Verification

- `bun test` -> 430 passed across 63 test files.
- `bun run type-check` (`tsc --noEmit`) -> 0 errors.
- `bun run build` -> production bundle compiled cleanly.