### PR TITLE
feat(plugins): bridge scoped management requests

### DIFF
--- a/src/features/plugins/PluginResourcePage.tsx
+++ b/src/features/plugins/PluginResourcePage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { EmptyState } from '@/components/ui/EmptyState';
@@ -12,6 +12,12 @@ import {
   PLUGIN_RESOURCES_REFRESH_EVENT,
   resolvePluginAssetURL,
 } from './pluginResources';
+import {
+  executePluginManagementBridgeRequest,
+  normalizePluginManagementBridgeRequest,
+  pluginManagementBridgeFailure,
+  resolvePluginManagementBridgeContext,
+} from './pluginManagementBridge';
 import styles from './PluginResourcePage.module.scss';
 
 const hasStatus = (error: unknown, status: number) => isRecord(error) && error.status === status;
@@ -38,6 +44,7 @@ export function PluginResourcePage() {
   const [data, setData] = useState<PluginListResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const frameRef = useRef<HTMLIFrameElement | null>(null);
 
   const connected = connectionStatus === 'connected';
   const pluginID = useMemo(() => safeDecodeURIComponent(params.pluginId), [params.pluginId]);
@@ -86,6 +93,47 @@ export function PluginResourcePage() {
   }, [data?.plugins, menuIndex, pluginID]);
 
   const iframeSrc = resource ? resolvePluginAssetURL(resource.menu.path, apiBase) : '';
+  const bridgeContext = useMemo(
+    () =>
+      resource && iframeSrc
+        ? resolvePluginManagementBridgeContext(resource.pluginID, iframeSrc, apiBase)
+        : null,
+    [apiBase, iframeSrc, resource]
+  );
+
+  useLayoutEffect(() => {
+    if (!bridgeContext) return;
+
+    let active = true;
+    const handleMessage = (event: MessageEvent) => {
+      const target = frameRef.current?.contentWindow;
+      if (!target || event.source !== target || event.origin !== bridgeContext.origin) return;
+
+      const request = normalizePluginManagementBridgeRequest(event.data, bridgeContext.pluginID);
+      if (!request) return;
+
+      void executePluginManagementBridgeRequest(request)
+        .then((response) => {
+          if (active && frameRef.current?.contentWindow === target) {
+            target.postMessage(response, bridgeContext.origin);
+          }
+        })
+        .catch(() => {
+          if (active && frameRef.current?.contentWindow === target) {
+            target.postMessage(
+              pluginManagementBridgeFailure(request.requestID),
+              bridgeContext.origin
+            );
+          }
+        });
+    };
+
+    window.addEventListener('message', handleMessage);
+    return () => {
+      active = false;
+      window.removeEventListener('message', handleMessage);
+    };
+  }, [bridgeContext]);
 
   return (
     <div className={styles.page}>
@@ -113,6 +161,7 @@ export function PluginResourcePage() {
         </div>
       ) : (
         <iframe
+          ref={frameRef}
           className={styles.frame}
           src={iframeSrc}
           title={resource.label}

--- a/src/features/plugins/pluginManagementBridge.ts
+++ b/src/features/plugins/pluginManagementBridge.ts
@@ -1,0 +1,189 @@
+import type { AxiosRequestConfig } from 'axios';
+import { apiClient } from '@/services/api/client';
+import { isRecord } from '@/utils/helpers';
+
+export const PLUGIN_MANAGEMENT_BRIDGE_VERSION = 1;
+export const PLUGIN_MANAGEMENT_REQUEST_TYPE = 'cliproxy:plugin-management-request';
+export const PLUGIN_MANAGEMENT_RESPONSE_TYPE = 'cliproxy:plugin-management-response';
+
+const PLUGIN_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const REQUEST_ID_PATTERN = /^[A-Za-z0-9._:-]{1,128}$/;
+const ALLOWED_METHODS = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']);
+const ALLOWED_HEADERS = new Set(['accept', 'content-type', 'if-match', 'if-none-match']);
+const MAX_PATH_LENGTH = 4096;
+const MAX_HEADER_VALUE_LENGTH = 8192;
+const MAX_BODY_BYTES = 1024 * 1024;
+
+export interface PluginManagementBridgeContext {
+  origin: string;
+  pluginID: string;
+}
+
+export interface PluginManagementBridgeRequest {
+  requestID: string;
+  method: string;
+  apiPath: string;
+  headers: Record<string, string>;
+  body?: string;
+}
+
+export interface PluginManagementBridgeResponse {
+  type: typeof PLUGIN_MANAGEMENT_RESPONSE_TYPE;
+  version: typeof PLUGIN_MANAGEMENT_BRIDGE_VERSION;
+  requestId: string;
+  status: number;
+  headers: Record<string, string>;
+  body: string;
+}
+
+const asString = (value: unknown): string => (typeof value === 'string' ? value : '');
+
+const isPluginScopedPath = (pathname: string, pluginID: string) => {
+  const prefix = `/v0/management/plugins/${pluginID}`;
+  return pathname === prefix || pathname.startsWith(`${prefix}/`);
+};
+
+export const resolvePluginManagementBridgeContext = (
+  pluginID: string,
+  resourceURL: string,
+  apiBase: string
+): PluginManagementBridgeContext | null => {
+  if (!PLUGIN_ID_PATTERN.test(pluginID) || !resourceURL.trim() || !apiBase.trim()) return null;
+
+  try {
+    const documentURL = typeof window === 'undefined' ? 'http://localhost/' : window.location.href;
+    const apiURL = new URL(apiBase, documentURL);
+    const resource = new URL(resourceURL, apiURL.origin);
+    const resourcePrefix = `/v0/resource/plugins/${pluginID}`;
+    if (
+      resource.origin !== apiURL.origin ||
+      (resource.pathname !== resourcePrefix && !resource.pathname.startsWith(`${resourcePrefix}/`))
+    ) {
+      return null;
+    }
+    return { origin: resource.origin, pluginID };
+  } catch {
+    return null;
+  }
+};
+
+export const normalizePluginManagementBridgeRequest = (
+  value: unknown,
+  pluginID: string
+): PluginManagementBridgeRequest | null => {
+  if (!isRecord(value) || !PLUGIN_ID_PATTERN.test(pluginID)) return null;
+  if (
+    value.type !== PLUGIN_MANAGEMENT_REQUEST_TYPE ||
+    value.version !== PLUGIN_MANAGEMENT_BRIDGE_VERSION
+  ) {
+    return null;
+  }
+
+  const requestID = asString(value.requestId).trim();
+  const method = asString(value.method).trim().toUpperCase();
+  const path = asString(value.path).trim();
+  if (
+    !REQUEST_ID_PATTERN.test(requestID) ||
+    !ALLOWED_METHODS.has(method) ||
+    !path.startsWith('/') ||
+    path.startsWith('//') ||
+    path.length > MAX_PATH_LENGTH ||
+    /[\r\n]/.test(path) ||
+    /%(?:2e|2f|5c)/i.test(path)
+  ) {
+    return null;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(path, 'https://plugin-management.invalid');
+  } catch {
+    return null;
+  }
+  if (parsed.origin !== 'https://plugin-management.invalid' || parsed.hash) return null;
+  if (!isPluginScopedPath(parsed.pathname, pluginID)) return null;
+
+  const headers: Record<string, string> = {};
+  if (value.headers !== undefined) {
+    if (!isRecord(value.headers)) return null;
+    for (const [rawName, rawValue] of Object.entries(value.headers)) {
+      const name = rawName.trim().toLowerCase();
+      if (
+        !ALLOWED_HEADERS.has(name) ||
+        typeof rawValue !== 'string' ||
+        rawValue.length > MAX_HEADER_VALUE_LENGTH ||
+        /[\r\n]/.test(rawValue)
+      ) {
+        return null;
+      }
+      headers[name] = rawValue;
+    }
+  }
+
+  const body = value.body;
+  if (body !== undefined && body !== null) {
+    if (
+      typeof body !== 'string' ||
+      new TextEncoder().encode(body).byteLength > MAX_BODY_BYTES ||
+      method === 'GET'
+    ) {
+      return null;
+    }
+  }
+
+  return {
+    requestID,
+    method,
+    apiPath: `${parsed.pathname.replace(/^\/v0\/management/, '')}${parsed.search}`,
+    headers,
+    ...(typeof body === 'string' ? { body } : {}),
+  };
+};
+
+const readResponseHeader = (headers: unknown, name: string): string => {
+  if (!headers || typeof headers !== 'object') return '';
+  const getter = (headers as { get?: (headerName: string) => unknown }).get;
+  const value =
+    typeof getter === 'function'
+      ? getter.call(headers, name)
+      : ((headers as Record<string, unknown>)[name] ??
+        (headers as Record<string, unknown>)[name.toLowerCase()]);
+  return value === undefined || value === null ? '' : String(value);
+};
+
+export const executePluginManagementBridgeRequest = async (
+  request: PluginManagementBridgeRequest
+): Promise<PluginManagementBridgeResponse> => {
+  const config: AxiosRequestConfig = {
+    url: request.apiPath,
+    method: request.method,
+    headers: request.headers,
+    data: request.body,
+    responseType: 'text',
+    transformResponse: [(value) => value],
+    validateStatus: () => true,
+  };
+  const response = await apiClient.requestRaw<string>(config);
+  const body = typeof response.data === 'string' ? response.data : JSON.stringify(response.data);
+  const contentType = readResponseHeader(response.headers, 'content-type');
+
+  return {
+    type: PLUGIN_MANAGEMENT_RESPONSE_TYPE,
+    version: PLUGIN_MANAGEMENT_BRIDGE_VERSION,
+    requestId: request.requestID,
+    status: response.status,
+    headers: contentType ? { 'content-type': contentType } : {},
+    body,
+  };
+};
+
+export const pluginManagementBridgeFailure = (
+  requestID: string
+): PluginManagementBridgeResponse => ({
+  type: PLUGIN_MANAGEMENT_RESPONSE_TYPE,
+  version: PLUGIN_MANAGEMENT_BRIDGE_VERSION,
+  requestId: requestID,
+  status: 502,
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({ error: 'plugin_management_request_failed' }),
+});

--- a/src/services/api/client.ts
+++ b/src/services/api/client.ts
@@ -231,6 +231,13 @@ class ApiClient {
   }
 
   /**
+   * Send a request while preserving status and response headers.
+   */
+  async requestRaw<T = unknown>(config: AxiosRequestConfig): Promise<AxiosResponse<T>> {
+    return this.instance.request<T>(config);
+  }
+
+  /**
    * 发送 FormData
    */
   async postForm<T = unknown>(

--- a/tests/pluginManagementBridge.test.ts
+++ b/tests/pluginManagementBridge.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  normalizePluginManagementBridgeRequest,
+  PLUGIN_MANAGEMENT_BRIDGE_VERSION,
+  PLUGIN_MANAGEMENT_REQUEST_TYPE,
+  resolvePluginManagementBridgeContext,
+} from '../src/features/plugins/pluginManagementBridge';
+
+const request = (overrides: Record<string, unknown> = {}) => ({
+  type: PLUGIN_MANAGEMENT_REQUEST_TYPE,
+  version: PLUGIN_MANAGEMENT_BRIDGE_VERSION,
+  requestId: 'request-1',
+  method: 'GET',
+  path: '/v0/management/plugins/gpt56-policy/status',
+  ...overrides,
+});
+
+describe('plugin management bridge', () => {
+  test('enables the bridge only for the active plugin resource origin', () => {
+    expect(
+      resolvePluginManagementBridgeContext(
+        'gpt56-policy',
+        'https://proxy.example/v0/resource/plugins/gpt56-policy/policy',
+        'https://proxy.example/v0/management'
+      )
+    ).toEqual({ origin: 'https://proxy.example', pluginID: 'gpt56-policy' });
+    expect(
+      resolvePluginManagementBridgeContext(
+        'gpt56-policy',
+        'https://plugins.example/v0/resource/plugins/gpt56-policy/policy',
+        'https://proxy.example/v0/management'
+      )
+    ).toBeNull();
+    expect(
+      resolvePluginManagementBridgeContext(
+        'gpt56-policy',
+        'https://proxy.example/v0/resource/plugins/other-plugin/policy',
+        'https://proxy.example/v0/management'
+      )
+    ).toBeNull();
+  });
+
+  test('accepts a request scoped to the active plugin', () => {
+    expect(normalizePluginManagementBridgeRequest(request(), 'gpt56-policy')).toEqual({
+      requestID: 'request-1',
+      method: 'GET',
+      apiPath: '/plugins/gpt56-policy/status',
+      headers: {},
+    });
+  });
+
+  test('accepts JSON mutations and preserves the query string', () => {
+    expect(
+      normalizePluginManagementBridgeRequest(
+        request({
+          method: 'POST',
+          path: '/v0/management/plugins/gpt56-policy/speed?source=panel',
+          headers: { 'Content-Type': 'application/json' },
+          body: '{"mode":"fast"}',
+        }),
+        'gpt56-policy'
+      )
+    ).toEqual({
+      requestID: 'request-1',
+      method: 'POST',
+      apiPath: '/plugins/gpt56-policy/speed?source=panel',
+      headers: { 'content-type': 'application/json' },
+      body: '{"mode":"fast"}',
+    });
+  });
+
+  test('rejects requests outside the active plugin namespace', () => {
+    expect(
+      normalizePluginManagementBridgeRequest(
+        request({ path: '/v0/management/config.yaml' }),
+        'gpt56-policy'
+      )
+    ).toBeNull();
+    expect(
+      normalizePluginManagementBridgeRequest(
+        request({ path: '/v0/management/plugins/other-plugin/status' }),
+        'gpt56-policy'
+      )
+    ).toBeNull();
+  });
+
+  test('rejects traversal, encoded separators, fragments, and absolute URLs', () => {
+    for (const path of [
+      '/v0/management/plugins/gpt56-policy/../other',
+      '/v0/management/plugins/gpt56-policy/%2e%2e/other',
+      '/v0/management/plugins/gpt56-policy/%2fconfig',
+      '/v0/management/plugins/gpt56-policy/status#secret',
+      'https://example.com/v0/management/plugins/gpt56-policy/status',
+    ]) {
+      expect(normalizePluginManagementBridgeRequest(request({ path }), 'gpt56-policy')).toBeNull();
+    }
+  });
+
+  test('rejects unsafe methods, headers, and GET bodies', () => {
+    expect(
+      normalizePluginManagementBridgeRequest(request({ method: 'TRACE' }), 'gpt56-policy')
+    ).toBeNull();
+    expect(
+      normalizePluginManagementBridgeRequest(
+        request({ headers: { Authorization: 'Bearer secret' } }),
+        'gpt56-policy'
+      )
+    ).toBeNull();
+    expect(
+      normalizePluginManagementBridgeRequest(request({ body: '{}' }), 'gpt56-policy')
+    ).toBeNull();
+  });
+
+  test('enforces request identifiers, header values, and mutation body limits', () => {
+    expect(
+      normalizePluginManagementBridgeRequest(
+        request({ requestId: 'contains a space' }),
+        'gpt56-policy'
+      )
+    ).toBeNull();
+    expect(
+      normalizePluginManagementBridgeRequest(
+        request({ headers: { Accept: `text/plain${'x'.repeat(8192)}` } }),
+        'gpt56-policy'
+      )
+    ).toBeNull();
+
+    const largestBody = 'x'.repeat(1024 * 1024);
+    expect(
+      normalizePluginManagementBridgeRequest(
+        request({ method: 'PUT', body: largestBody }),
+        'gpt56-policy'
+      )?.body
+    ).toHaveLength(1024 * 1024);
+    expect(
+      normalizePluginManagementBridgeRequest(
+        request({ method: 'PUT', body: `${largestBody}x` }),
+        'gpt56-policy'
+      )
+    ).toBeNull();
+    expect(
+      normalizePluginManagementBridgeRequest(
+        request({ method: 'PATCH', body: '界'.repeat(350_000) }),
+        'gpt56-policy'
+      )
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- add an opt-in `postMessage` bridge from plugin resource iframes to their own authenticated Management API namespace;
- keep the Management Key in the parent Management Center by executing accepted requests through the existing `apiClient`;
- preserve response status, `content-type`, and text bodies so plugin resources can use a small fetch-like client;
- install the bridge listener during the layout phase so an iframe's initial status request cannot race normal effect setup.

## Why

Plugin UI resources are intentionally served from `/v0/resource/plugins/...`, while plugin management routes live under the authenticated `/v0/management/plugins/...` namespace. An iframe can render a plugin's static page today, but it cannot call its management routes without receiving the Management Key.

This change supplies a generic capability boundary instead of adding first-party UI code for individual plugins. A plugin resource can ask the parent page to perform a request, but only inside that same plugin's management namespace.

## Security boundary

- messages are accepted only from the currently rendered iframe window and its resolved API origin;
- the plugin id must match the active resource and a conservative identifier grammar;
- paths are limited to `/v0/management/plugins/<active-plugin-id>` and reject absolute URLs, fragments, traversal, encoded separators, CR/LF, and oversized values;
- only `GET`, `POST`, `PUT`, `PATCH`, and `DELETE` are accepted;
- only `accept`, `content-type`, `if-match`, and `if-none-match` may be forwarded;
- request bodies are strings capped at 1 MiB by UTF-8 byte length, and `GET` bodies are rejected;
- `authorization` cannot be supplied by the iframe, and the Management Key is never posted back to plugin content.

## Validation

- `bun run verify`: 440 tests passed, ESLint passed, TypeScript passed, and the single-file Vite build passed;
- focused bridge tests cover origin/plugin scoping, mutations, query strings, traversal, encoded separators, absolute URLs, unsafe methods/headers, request ids, and byte-size limits;
- browser integration passed against CLIProxyAPI `v7.2.147`: an opt-in plugin resource appeared in the existing sidebar, loaded its initial authenticated status through the bridge, and completed both read and mutation requests;
- UI note: this adds no first-party plugin-specific visuals; plugin-owned content remains inside the existing resource iframe.
