### PR TITLE
feat(quota): show the Codex spend-control credit budget

### DIFF
--- a/src/features/quota/providers/codex/CodexQuotaBody.tsx
+++ b/src/features/quota/providers/codex/CodexQuotaBody.tsx
@@ -161,6 +161,17 @@ export function CodexQuotaBody({ quota, classes }: QuotaBodyProps<CodexQuotaStat
           const remaining =
             clampedUsed === null ? null : Math.max(0, Math.min(100, 100 - clampedUsed));
           const percentLabel = remaining === null ? '--' : `${Math.round(remaining)}%`;
+          // Only the spend-control row carries an absolute budget; a
+          // percentage alone never says how large the pool being spent is.
+          // Upstream sends fractional credits ("3138.653407096863") — rounded
+          // here to match how ChatGPT's own usage page reports them.
+          const amountLabel =
+            typeof window.usedAmount === 'number' && typeof window.totalAmount === 'number'
+              ? t('codex_quota.spend_control_amount', {
+                  used: Math.round(window.usedAmount).toLocaleString(locale),
+                  total: Math.round(window.totalAmount).toLocaleString(locale),
+                })
+              : null;
           const windowLabel = window.labelKey
             ? t(window.labelKey, window.labelParams as Record<string, string | number>)
             : window.label;
@@ -178,6 +189,7 @@ export function CodexQuotaBody({ quota, classes }: QuotaBodyProps<CodexQuotaStat
                 <span className={classes.quotaModel}>{windowLabel}</span>
                 <div className={classes.quotaMeta}>
                   <span className={classes.quotaPercent}>{percentLabel}</span>
+                  {amountLabel && <span className={classes.quotaAmount}>{amountLabel}</span>}
                   {resetDisplay && (
                     <QuotaResetLabel display={resetDisplay} classes={classes} soon={soon} />
                   )}

--- a/src/features/quota/providers/codex/data.ts
+++ b/src/features/quota/providers/codex/data.ts
@@ -8,6 +8,7 @@ import type {
   AuthFileItem,
   CodexRateLimitInfo,
   CodexRateLimitResetCredit,
+  CodexSpendControlLimit,
   CodexQuotaState,
   CodexUsageWindow,
   CodexQuotaWindow,
@@ -31,11 +32,13 @@ import {
   resolveCodexPlanType,
   resolveCodexSubscriptionActiveUntil,
   formatCodexResetLabel,
+  formatInstantShort,
   createStatusError,
   isCodexFile,
   isDisabledAuthFile,
 } from '@/utils/quota';
 import { normalizeAuthIndex } from '@/utils/authIndex';
+import { CODEX_SPEND_CONTROL_ROW_ID } from '../../resetSchedule';
 import type { QuotaProviderData } from '../types';
 
 const CODEX_RESET_CREDITS_REQUEST_TIMEOUT_MS = 8000;
@@ -88,6 +91,50 @@ export const buildCodexQuotaWindows = (
     payload.code_review_rate_limit ?? payload.codeReviewRateLimit ?? undefined;
   const additionalRateLimits = payload.additional_rate_limits ?? payload.additionalRateLimits ?? [];
   const windows: CodexQuotaWindow[] = [];
+
+  const spendControl = payload.spend_control ?? payload.spendControl ?? null;
+  const spendLimit = spendControl?.individual_limit ?? spendControl?.individualLimit ?? null;
+
+  const addSpendControlWindow = (limitInfo: CodexSpendControlLimit) => {
+    const total = normalizeNumberValue(limitInfo.limit);
+    const remainingAmount = normalizeNumberValue(limitInfo.remaining);
+    const usedAmount = normalizeNumberValue(limitInfo.used);
+    const usedPercentRaw = normalizeNumberValue(limitInfo.used_percent ?? limitInfo.usedPercent);
+    const remainingPercent = normalizeNumberValue(
+      limitInfo.remaining_percent ?? limitInfo.remainingPercent
+    );
+
+    // used/remaining/limit are sent as decimal strings and any one of them can
+    // be absent, so each is derived from the other two rather than dropping
+    // the row. The percentages come as numbers and are preferred when present.
+    const used =
+      usedAmount ?? (total !== null && remainingAmount !== null ? total - remainingAmount : null);
+    const usedPercent =
+      usedPercentRaw ??
+      (remainingPercent !== null
+        ? 100 - remainingPercent
+        : total !== null && total > 0 && used !== null
+          ? (used / total) * 100
+          : null);
+    if (usedPercent === null && used === null && total === null) return;
+
+    const resetAtMs =
+      resolveResetMs([limitInfo.reset_at, limitInfo.resetAt]) ??
+      parseOffsetSecondsToMs(
+        limitInfo.reset_after_seconds ?? limitInfo.resetAfterSeconds,
+        Date.now()
+      );
+    windows.push({
+      id: CODEX_SPEND_CONTROL_ROW_ID,
+      label: t('codex_quota.spend_control_window'),
+      labelKey: 'codex_quota.spend_control_window',
+      usedPercent,
+      resetLabel: resetAtMs === null ? '-' : formatInstantShort(resetAtMs),
+      resetAtMs,
+      usedAmount: used,
+      totalAmount: total,
+    });
+  };
 
   const addWindow = (
     id: string,
@@ -278,6 +325,12 @@ export const buildCodexQuotaWindows = (
         additionalAllowed
       );
     });
+  }
+
+  // Last, like the xAI monthly figure: the rolling windows are what governs
+  // the next request, the budget is what governs the month.
+  if (spendLimit) {
+    addSpendControlWindow(spendLimit);
   }
 
   return windows;

--- a/src/features/quota/quotaTimelineModel.ts
+++ b/src/features/quota/quotaTimelineModel.ts
@@ -11,6 +11,7 @@
  */
 
 import { DAY_MS, HOUR_MS } from '@/utils/time/durations';
+import { CODEX_SPEND_CONTROL_ROW_ID } from './resetSchedule';
 import type { QuotaProviderType } from './providers/types';
 
 export { DAY_MS, HOUR_MS };
@@ -351,7 +352,13 @@ export function buildTimelineLane(input: TimelineLaneInput): TimelineLane {
 
   if (provider === 'claude' || provider === 'codex') {
     const windows = ((quota as { windows?: WindowLike[] }).windows ?? []).filter(
-      (window) => typeof window.resetAtMs === 'number'
+      (window) =>
+        typeof window.resetAtMs === 'number' &&
+        // A spend-control budget refilling is a billing cycle, not capacity
+        // coming back, so it must not anchor a lane — same rule the xAI branch
+        // below applies to its monthly figure. The card still shows its
+        // countdown.
+        !(provider === 'codex' && window.id === CODEX_SPEND_CONTROL_ROW_ID)
     );
     const preferredCodexId =
       maxPeriodHours !== undefined && maxPeriodHours <= SESSION_PERIOD_HOURS

--- a/src/features/quota/resetSchedule.ts
+++ b/src/features/quota/resetSchedule.ts
@@ -62,6 +62,15 @@ interface ResetCreditLike {
 /** Row id used by the xAI weekly limit, which has no id of its own. */
 export const XAI_WEEKLY_ROW_ID = 'xai:weekly';
 
+/**
+ * Row id of the Codex spend-control budget.
+ *
+ * Shared so this module and quotaTimelineModel can exclude it by identity: a
+ * credit budget refilling is a spend cap turning over, which both keep out of
+ * recovery ranking for the reason given on collectQuotaRowInstants below.
+ */
+export const CODEX_SPEND_CONTROL_ROW_ID = 'spend-control';
+
 const isUsableMs = (value: unknown): value is number =>
   typeof value === 'number' && Number.isFinite(value);
 
@@ -78,10 +87,10 @@ const collectRows = (rows: readonly WindowLike[], fallbackPrefix: string): Quota
  * Every recovery instant on one credential, tagged with the row it belongs to.
  *
  * Only genuine capacity-return events are collected. The Codex subscription
- * renewal date and xAI's monthly billing rollover are excluded: a spend cap
- * turning over is not a rate limit lifting, and ranking cards by it would
- * answer a different question than the one being asked. Both still render
- * their own countdown.
+ * renewal date, the Codex spend-control budget and xAI's monthly billing
+ * rollover are excluded: a spend cap turning over is not a rate limit lifting, and
+ * ranking cards by it would answer a different question than the one being
+ * asked. All three still render their own countdown.
  */
 export function collectQuotaRowInstants(
   provider: QuotaProviderType,
@@ -91,7 +100,13 @@ export function collectQuotaRowInstants(
   if (!state || state.status !== 'success') return [];
 
   if (provider === 'claude' || provider === 'codex') {
-    const windows = collectRows((quota as { windows?: WindowLike[] }).windows ?? [], 'window');
+    const allWindows = (quota as { windows?: WindowLike[] }).windows ?? [];
+    const windows = collectRows(
+      provider === 'codex'
+        ? allWindows.filter((window) => window.id !== CODEX_SPEND_CONTROL_ROW_ID)
+        : allWindows,
+      'window'
+    );
     if (provider !== 'codex') return windows;
 
     const credits = (

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -448,6 +448,8 @@
     "primary_window": "5-hour limit",
     "secondary_window": "Weekly limit",
     "team_secondary_window": "Monthly limit",
+    "spend_control_window": "Monthly credits",
+    "spend_control_amount": "{{used}} / {{total}} credits",
     "code_review_primary_window": "Code review 5-hour limit",
     "code_review_secondary_window": "Code review weekly limit",
     "code_review_team_secondary_window": "Code review monthly limit",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -441,6 +441,8 @@
     "primary_window": "Лимит на 5 часов",
     "secondary_window": "Недельный лимит",
     "team_secondary_window": "Месячный лимит",
+    "spend_control_window": "Месячные кредиты",
+    "spend_control_amount": "{{used}} / {{total}} кредитов",
     "code_review_primary_window": "Лимит code review на 5 часов",
     "code_review_secondary_window": "Недельный лимит code review",
     "code_review_team_secondary_window": "Месячный лимит code review",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -448,6 +448,8 @@
     "primary_window": "5 小时限额",
     "secondary_window": "周限额",
     "team_secondary_window": "月度限额",
+    "spend_control_window": "月度额度",
+    "spend_control_amount": "{{used}} / {{total}} 额度",
     "code_review_primary_window": "代码审查 5 小时限额",
     "code_review_secondary_window": "代码审查周限额",
     "code_review_team_secondary_window": "代码审查月度限额",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -448,6 +448,8 @@
     "primary_window": "5 小時限額",
     "secondary_window": "週限額",
     "team_secondary_window": "月度限額",
+    "spend_control_window": "月度額度",
+    "spend_control_amount": "{{used}} / {{total}} 額度",
     "code_review_primary_window": "程式碼審查 5 小時限額",
     "code_review_secondary_window": "程式碼審查週限額",
     "code_review_team_secondary_window": "程式碼審查月度限額",

--- a/src/types/quota.ts
+++ b/src/types/quota.ts
@@ -43,6 +43,39 @@ export interface CodexUsageWindow {
   resetAt?: number | string;
 }
 
+/**
+ * One spend-control budget, in credits.
+ *
+ * Business and enterprise plans meter by a credit budget rather than by
+ * rolling percentage windows — such an account reports `rate_limit: null` and
+ * carries its real allowance here. Amounts arrive as decimal strings
+ * ("3138.653407096863"), percentages as numbers.
+ *
+ * Distinct from both sibling concepts on the same payload:
+ * `CodexRateLimitResetCredits` counts manual "reset my rate limit"
+ * consumables, and the root `credits` object is the pay-as-you-go balance.
+ */
+export interface CodexSpendControlLimit {
+  source?: string;
+  limit?: number | string;
+  used?: number | string;
+  remaining?: number | string;
+  used_percent?: number | string;
+  usedPercent?: number | string;
+  remaining_percent?: number | string;
+  remainingPercent?: number | string;
+  reset_after_seconds?: number | string;
+  resetAfterSeconds?: number | string;
+  reset_at?: number | string;
+  resetAt?: number | string;
+}
+
+export interface CodexSpendControl {
+  reached?: boolean;
+  individual_limit?: CodexSpendControlLimit | null;
+  individualLimit?: CodexSpendControlLimit | null;
+}
+
 export interface CodexRateLimitInfo {
   allowed?: boolean;
   limit_reached?: boolean;
@@ -87,6 +120,8 @@ export interface CodexUsagePayload {
   additionalRateLimits?: CodexAdditionalRateLimit[] | null;
   rate_limit_reset_credits?: CodexRateLimitResetCredits | null;
   rateLimitResetCredits?: CodexRateLimitResetCredits | null;
+  spend_control?: CodexSpendControl | null;
+  spendControl?: CodexSpendControl | null;
 }
 
 // Claude API payload types
@@ -230,6 +265,14 @@ export interface CodexQuotaWindow {
   resetAtMs?: number | null;
   /** Window length in hours, from the payload's limit_window_seconds. */
   periodHours?: number | null;
+  /**
+   * Absolute consumption, for credit-metered rows only. A percentage alone
+   * answers "how much is left" but not "how much is left of what", and the
+   * pool size is the number a business admin actually budgets against, so the
+   * credit row carries both and renders them side by side.
+   */
+  usedAmount?: number | null;
+  totalAmount?: number | null;
 }
 
 export interface CodexQuotaState {

--- a/tests/codexQuota.test.ts
+++ b/tests/codexQuota.test.ts
@@ -3,6 +3,8 @@ import type { TFunction } from 'i18next';
 import { CODEX_CONFIG, buildCodexQuotaWindows } from '@/features/quota/providers/codex/data';
 import type { CodexQuotaState, CodexUsagePayload } from '@/types';
 import { normalizeCodexResetCreditsPayload, parseCodexUsagePayload } from '@/utils/quota';
+import { collectQuotaRowInstants } from '@/features/quota/resetSchedule';
+import { buildTimelineLane } from '@/features/quota/quotaTimelineModel';
 
 const t = ((key: string) => key) as TFunction;
 
@@ -85,5 +87,113 @@ describe('Codex current usage payload', () => {
     };
 
     expect(CODEX_CONFIG.canResetQuota?.(quota)).toBeTrue();
+  });
+});
+
+/**
+ * Business/enterprise accounts meter by a credit budget: `rate_limit` is null
+ * and the real allowance arrives under `spend_control.individual_limit`.
+ * Payload captured verbatim from chatgpt.com/backend-api/wham/usage.
+ */
+const BUSINESS_CODEX_USAGE_PAYLOAD: CodexUsagePayload = {
+  plan_type: 'business',
+  rate_limit: null,
+  code_review_rate_limit: null,
+  additional_rate_limits: [
+    {
+      limit_name: 'GPT-5.3-Codex-Spark-Preview',
+      metered_feature: 'codex_bengalfox',
+      rate_limit: {
+        allowed: true,
+        limit_reached: false,
+        primary_window: {
+          used_percent: 0,
+          limit_window_seconds: 18000,
+          reset_after_seconds: 18000,
+          reset_at: 1788587485,
+        },
+        secondary_window: {
+          used_percent: 0,
+          limit_window_seconds: 604800,
+          reset_after_seconds: 604800,
+          reset_at: 1789174285,
+        },
+      },
+    },
+  ],
+  spend_control: {
+    reached: false,
+    individual_limit: {
+      source: 'group_based_spend_controls',
+      limit: '37500',
+      used: '3138.653407096863',
+      remaining: '34361.34659290314',
+      used_percent: 8,
+      remaining_percent: 92,
+      reset_after_seconds: 2243315,
+      reset_at: 1790812800,
+    },
+  },
+  rate_limit_reset_credits: {
+    available_count: 0,
+    applicable_available_count: 0,
+  },
+};
+
+describe('Codex spend-control budget', () => {
+  test('reads the credit budget from the observed business payload', () => {
+    const windows = buildCodexQuotaWindows(BUSINESS_CODEX_USAGE_PAYLOAD, t);
+    const budget = windows.find(({ id }) => id === 'spend-control');
+
+    expect(budget).toBeDefined();
+    expect(budget?.labelKey).toBe('codex_quota.spend_control_window');
+    expect(budget?.usedPercent).toBe(8);
+    expect(budget?.totalAmount).toBe(37500);
+    expect(budget?.usedAmount).toBeCloseTo(3138.653407096863, 6);
+    expect(budget?.resetAtMs).toBe(1790812800 * 1000);
+  });
+
+  test('keeps the budget last so the model windows stay on top', () => {
+    const windows = buildCodexQuotaWindows(BUSINESS_CODEX_USAGE_PAYLOAD, t);
+
+    expect(windows.map(({ id }) => id)).toEqual([
+      'gpt-5-3-codex-spark-preview-five-hour-0',
+      'gpt-5-3-codex-spark-preview-weekly-0',
+      'spend-control',
+    ]);
+  });
+
+  test('derives the used amount and percentage when only limit and remaining arrive', () => {
+    const windows = buildCodexQuotaWindows(
+      { spend_control: { individual_limit: { limit: '200', remaining: '150' } } },
+      t
+    );
+
+    expect(windows[0]?.usedAmount).toBe(50);
+    expect(windows[0]?.usedPercent).toBe(25);
+  });
+
+  test('ignores a spend control carrying no usable numbers', () => {
+    expect(buildCodexQuotaWindows({ spend_control: { reached: false } }, t)).toHaveLength(0);
+    expect(
+      buildCodexQuotaWindows({ spend_control: { individual_limit: {} } }, t)
+    ).toHaveLength(0);
+  });
+
+  // A budget refilling is a billing cycle, not capacity coming back — the same
+  // rule the xAI monthly figure follows.
+  test('excludes the budget from recovery ranking and the timeline lane', () => {
+    const windows = buildCodexQuotaWindows(
+      {
+        spend_control: {
+          individual_limit: { limit: '100', used: '60', reset_at: 1790812800 },
+        },
+      },
+      t
+    );
+    const quota: CodexQuotaState = { status: 'success', windows };
+
+    expect(collectQuotaRowInstants('codex', quota)).toEqual([]);
+    expect(buildTimelineLane({ name: 'a', displayName: 'a', provider: 'codex', quota }).anchorMs).toBeNull();
   });
 });

--- a/tests/quotaBodyRendering.test.ts
+++ b/tests/quotaBodyRendering.test.ts
@@ -68,6 +68,36 @@ describe('CodexQuotaBody', () => {
     expect(markup).toMatch(/3 hours/);
   });
 
+  test('renders the spend-control budget as an absolute pool beside its percentage', () => {
+    // Numbers are the observed business payload: limit 37500, used 3138.65…,
+    // used_percent 8. ChatGPT's own usage page reports these as
+    // "3,139 of 37,500 credits used" with "92% left".
+    const creditMetered: CodexQuotaState = {
+      status: 'success',
+      planType: 'business',
+      windows: [
+        {
+          id: 'spend-control',
+          label: 'Monthly credits',
+          labelKey: 'codex_quota.spend_control_window',
+          usedPercent: 8,
+          resetLabel: '10-01 00:00',
+          resetAtMs: now + 26 * DAY_MS,
+          usedAmount: 3138.653407096863,
+          totalAmount: 37500,
+        },
+      ],
+    };
+    const markup = renderToStaticMarkup(
+      createElement(CodexQuotaBody, { quota: creditMetered, classes })
+    );
+
+    expect(markup).toContain('Monthly credits');
+    expect(markup).toContain('quotaAmount');
+    expect(markup).toContain('3,139 / 37,500 credits');
+    expect(markup).toContain('92%');
+  });
+
   test('renders reset-credit expiry in local time with a countdown', () => {
     const markup = renderToStaticMarkup(createElement(CodexQuotaBody, { quota, classes }));
 


### PR DESCRIPTION
## Summary

- read the Codex monthly credit budget from `spend_control.individual_limit` on the `wham/usage` payload
- render it as a quota row carrying both its percentage and its absolute pool, the way the xAI monthly figure already does
- derive whichever of `limit` / `used` / `remaining` upstream omits from the other two
- keep the budget out of recovery ranking and timeline anchoring, per the rule already stated for the Codex renewal date and the xAI monthly rollover

## Why

Business and enterprise Codex accounts meter by a monthly credit budget instead of rolling percentage windows. `wham/usage` returns `rate_limit: null` for them and carries the real allowance under `spend_control`, which the card did not read — so such a credential showed only its per-model windows, with no sign of the limit that actually governs it. On an account whose only per-model window sits at 0%, the card read as "nothing used" while 8% of the month's budget was already spent.

A percentage alone would not have been enough here. The pool size is the number a business admin budgets against, so the row shows `3,139 / 37,500 credits` beside the `92%`.

Three separate concepts share this payload and are easy to confuse:

| field | meaning |
| --- | --- |
| `spend_control.individual_limit` | the monthly credit budget — **this PR** |
| `rate_limit_reset_credits` | manual "reset my rate limit" consumables (already shown) |
| `credits` | pay-as-you-go balance (`balance: null` on this plan) |

## Observed payload

Captured from a live `chatgpt.com/backend-api/wham/usage` response on a `business` account (identifiers redacted), and used verbatim as the test fixture:

```json
{
  "plan_type": "business",
  "rate_limit": null,
  "additional_rate_limits": [
    {
      "limit_name": "GPT-5.3-Codex-Spark-Preview",
      "metered_feature": "codex_bengalfox",
      "rate_limit": {
        "allowed": true,
        "limit_reached": false,
        "primary_window": {
          "used_percent": 0, "limit_window_seconds": 18000,
          "reset_after_seconds": 18000, "reset_at": 1788587485
        },
        "secondary_window": {
          "used_percent": 0, "limit_window_seconds": 604800,
          "reset_after_seconds": 604800, "reset_at": 1789174285
        }
      }
    }
  ],
  "spend_control": {
    "reached": false,
    "individual_limit": {
      "source": "group_based_spend_controls",
      "limit": "37500",
      "used": "3138.653407096863",
      "remaining": "34361.34659290314",
      "used_percent": 8,
      "remaining_percent": 92,
      "reset_after_seconds": 2243315,
      "reset_at": 1790812800
    }
  }
}
```

Amounts arrive as decimal strings; they are rounded for display to match how ChatGPT's own usage page reports them ("3,139 of 37,500 credits used", "92% left").

## Notes

- **The budget does not anchor a timeline lane and does not enter "soonest recovery" ranking.** `collectQuotaRowInstants` already excludes the Codex renewal date and the xAI monthly rollover on the grounds that a spend cap turning over is not a rate limit lifting; a credit budget refilling is the same kind of event. The row still renders its own countdown. Both exclusions are pinned by a test.
- The row is appended last, so the rolling windows that govern the next request stay on top — same ordering as the xAI monthly figure.
- New i18n keys `codex_quota.spend_control_window` and `codex_quota.spend_control_amount` added to all four locales.

## Validation

- `bun run test` — 439 pass, 0 fail (6 new cases)
- `bun run lint`
- `bun run type-check`
- `bun run build`

Rendering is asserted as markup, not just as builder output: `tests/quotaBodyRendering.test.ts` renders `CodexQuotaBody` with the observed values (`3138.653407096863` of `37500`, `used_percent: 8`) and checks the row reads `Monthly credits | 92% | 3,139 / 37,500 credits`.

Verified end to end against a live `business` credential: this bundle served from a locally built backend, credential added through the panel, quota page refreshed. The screenshot below is that run — the figure differs slightly from the fixture because usage continued between the capture and the screenshot.

## Screenshots

<!-- screenshot of the Codex quota card on a business credential -->
