### PR TITLE
feat(auth-files): add model testing controls

### DIFF
--- a/src/features/authFiles/AuthFilesPage.tsx
+++ b/src/features/authFiles/AuthFilesPage.tsx
@@ -101,6 +101,8 @@ export function AuthFilesPage() {
     modelsLoading,
     modelsList,
     modelsFileName,
+    modelsAuthIndex,
+    modelsAuthDisabled,
     modelsFileType,
     modelsError,
     showModels,
@@ -768,6 +770,8 @@ export function AuthFilesPage() {
       <AuthFileModelsModal
         open={modelsModalOpen}
         fileName={modelsFileName}
+        authIndex={modelsAuthIndex}
+        disabled={disableControls || modelsAuthDisabled}
         fileType={modelsFileType}
         loading={modelsLoading}
         error={modelsError}

--- a/src/features/authFiles/components/AuthFileModelsModal.module.scss
+++ b/src/features/authFiles/components/AuthFileModelsModal.module.scss
@@ -1,6 +1,6 @@
 @use '../../../styles/mixins' as *;
 
-/* 「支持的模型」弹窗：可点击复制的 mono 模型清单 */
+/* Credential model list with independent copy and test actions. */
 
 .list {
   display: flex;
@@ -13,28 +13,36 @@
 
 .item {
   display: flex;
-  align-items: baseline;
-  gap: 8px;
-  flex-wrap: wrap;
-  padding: 8px 10px;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px;
   border-radius: 8px;
-  border: 1px solid transparent;
-  cursor: pointer;
-  transition:
-    background-color $transition-fast,
-    border-color $transition-fast,
-    transform var(--dur-press, 160ms) var(--ease-out-strong, ease-out);
-
-  &:active {
-    transform: scale(0.99);
-  }
+  border: 1px solid var(--border-color);
 }
 
-@media (hover: hover) and (pointer: fine) {
-  .item:hover {
-    background: var(--bg-tertiary);
-    border-color: color-mix(in srgb, var(--border-color) 70%, transparent);
-  }
+.modelRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.copyButton {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  flex: 1;
+  min-width: 0;
+  gap: 6px;
+  border: 0;
+  background: transparent;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
+}
+
+.copyButton:focus-visible {
+  outline: 2px solid var(--primary-color);
+  outline-offset: 3px;
 }
 
 .itemExcluded {
@@ -79,12 +87,24 @@
   white-space: nowrap;
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .item {
-    transition: none;
-  }
+.testSuccess,
+.testFailure {
+  font-size: 12px;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
 
-  .item:active {
-    transform: none;
-  }
+.testSuccess {
+  color: var(--success-badge-text);
+}
+.testFailure {
+  color: var(--failure-badge-text);
+}
+.testSuccess:empty,
+.testFailure:empty {
+  display: none;
+}
+.imageHint {
+  color: var(--text-tertiary);
+  font-size: 11px;
 }

--- a/src/features/authFiles/components/AuthFileModelsModal.tsx
+++ b/src/features/authFiles/components/AuthFileModelsModal.tsx
@@ -1,4 +1,6 @@
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { authFilesApi, type AuthFileModelTestResult } from '@/services/api';
 import { Modal } from '@/components/ui/Modal';
 import { Button } from '@/components/ui/Button';
 import { EmptyState } from '@/components/ui/EmptyState';
@@ -9,6 +11,8 @@ import styles from './AuthFileModelsModal.module.scss';
 export type AuthFileModelsModalProps = {
   open: boolean;
   fileName: string;
+  authIndex: string;
+  disabled?: boolean;
   fileType: string;
   loading: boolean;
   error: 'unsupported' | null;
@@ -20,19 +24,107 @@ export type AuthFileModelsModalProps = {
 
 export function AuthFileModelsModal(props: AuthFileModelsModalProps) {
   const { t } = useTranslation();
-  const { open, fileName, fileType, loading, error, models, excluded, onClose, onCopyText } = props;
-
   return (
     <Modal
-      open={open}
-      onClose={onClose}
-      title={t('auth_files.models_title', { defaultValue: '支持的模型' }) + ` - ${fileName}`}
+      open={props.open}
+      onClose={props.onClose}
+      title={`${t('auth_files.models_title')} - ${props.fileName}`}
       footer={
-        <Button variant="secondary" onClick={onClose}>
+        <Button variant="secondary" onClick={props.onClose}>
           {t('common.close')}
         </Button>
       }
     >
+      {props.open && <ModelsModalContent key={`${props.fileName}:${props.authIndex}`} {...props} />}
+    </Modal>
+  );
+}
+
+function ModelsModalContent(props: AuthFileModelsModalProps) {
+  const { t } = useTranslation();
+  const {
+    authIndex,
+    fileType,
+    loading,
+    error,
+    models,
+    excluded,
+    onCopyText,
+    disabled = false,
+  } = props;
+  const [testingModels, setTestingModels] = useState<Set<string>>(new Set());
+  const [testResults, setTestResults] = useState<Record<string, AuthFileModelTestResult>>({});
+  const requestsRef = useRef(new Map<string, AbortController>());
+  useEffect(
+    () => () => {
+      requestsRef.current.forEach((controller) => controller.abort());
+      requestsRef.current.clear();
+    },
+    []
+  );
+
+  const testModel = async (model: AuthFileModelItem) => {
+    if (
+      !authIndex ||
+      disabled ||
+      !model.testKind ||
+      model.testKind === 'unsupported' ||
+      requestsRef.current.has(model.id)
+    )
+      return;
+    const controller = new AbortController();
+    requestsRef.current.set(model.id, controller);
+    setTestingModels((current) => new Set(current).add(model.id));
+    setTestResults((current) => {
+      const next = { ...current };
+      delete next[model.id];
+      return next;
+    });
+    try {
+      const result = await authFilesApi.testModelForAuthFile(
+        authIndex,
+        model.id,
+        controller.signal
+      );
+      if (!controller.signal.aborted)
+        setTestResults((current) => ({ ...current, [model.id]: result }));
+    } catch (error) {
+      if (!controller.signal.aborted) {
+        const status = (error as { status?: number })?.status;
+        setTestResults((current) => ({
+          ...current,
+          [model.id]: {
+            success: false,
+            model: model.id,
+            kind: model.testKind === 'image' ? 'image' : 'text',
+            latencyMs: 0,
+            error: {
+              code: 'request_failed',
+              message:
+                status === 404 || status === 405
+                  ? t('auth_files.model_test_upgrade')
+                  : error instanceof Error
+                    ? error.message
+                    : t('auth_files.model_test_failed'),
+            },
+          },
+        }));
+      }
+    } finally {
+      if (requestsRef.current.get(model.id) === controller) {
+        requestsRef.current.delete(model.id);
+        if (!controller.signal.aborted) {
+          setTestingModels((current) => {
+            const next = new Set(current);
+            next.delete(model.id);
+            return next;
+          });
+        }
+      }
+    }
+  };
+  return (
+    <>
       {loading ? (
         <div className="hint">
           {t('auth_files.models_loading', { defaultValue: '正在加载模型列表...' })}
@@ -52,39 +144,90 @@ export function AuthFileModelsModal(props: AuthFileModelsModalProps) {
           })}
         />
       ) : (
-        <div className={styles.list}>
-          {models.map((model) => {
-            const excludedModel = isModelExcluded(model.id, fileType, excluded);
-            return (
-              <div
-                key={model.id}
-                className={`${styles.item} ${excludedModel ? styles.itemExcluded : ''}`}
-                onClick={() => {
-                  onCopyText(model.id);
-                }}
-                title={
-                  excludedModel
-                    ? t('auth_files.models_excluded_hint', {
-                        defaultValue: '此 OAuth 模型已被禁用',
-                      })
-                    : t('common.copy', { defaultValue: '点击复制' })
-                }
-              >
-                <span className={styles.modelId}>{model.id}</span>
-                {model.display_name && model.display_name !== model.id && (
-                  <span className={styles.modelDisplayName}>{model.display_name}</span>
-                )}
-                {model.type && <span className={styles.modelType}>{model.type}</span>}
-                {excludedModel && (
-                  <span className={styles.excludedBadge}>
-                    {t('auth_files.models_excluded_badge', { defaultValue: '已禁用' })}
-                  </span>
-                )}
-              </div>
-            );
-          })}
-        </div>
+        <>
+          <p className="hint">{t('auth_files.model_test_hint')}</p>
+          <div className={styles.list}>
+            {models.map((model) => {
+              const excludedModel = isModelExcluded(model.id, fileType, excluded);
+              const result = testResults[model.id];
+              const testing = testingModels.has(model.id);
+              const unavailable = !model.testKind
+                ? t('auth_files.model_test_upgrade')
+                : model.testKind === 'unsupported'
+                  ? t('auth_files.model_test_unsupported')
+                  : !authIndex || disabled
+                    ? t('auth_files.model_test_disabled')
+                    : excludedModel
+                      ? t('auth_files.models_excluded_hint')
+                      : '';
+              return (
+                <div
+                  key={model.id}
+                  className={`${styles.item} ${excludedModel ? styles.itemExcluded : ''}`}
+                >
+                  <div className={styles.modelRow}>
+                    <button
+                      type="button"
+                      className={styles.copyButton}
+                      onClick={() => onCopyText(model.id)}
+                      title={t('common.copy')}
+                    >
+                      <span className={styles.modelId}>{model.id}</span>
+                      {model.display_name && model.display_name !== model.id && (
+                        <span className={styles.modelDisplayName}>{model.display_name}</span>
+                      )}
+                      {model.type && <span className={styles.modelType}>{model.type}</span>}
+                    </button>
+                    {excludedModel && (
+                      <span className={styles.excludedBadge}>
+                        {t('auth_files.models_excluded_badge')}
+                      </span>
+                    )}
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      disabled={Boolean(unavailable) || testing}
+                      loading={testing}
+                      onClick={() => void testModel(model)}
+                      aria-label={t('auth_files.model_test_button', { model: model.id })}
+                    >
+                      {testing ? t('auth_files.model_testing') : t('auth_files.model_test')}
+                    </Button>
+                  </div>
+                  {unavailable && <span className={styles.imageHint}>{unavailable}</span>}
+                  <div
+                    role="status"
+                    aria-live="polite"
+                    className={result?.success ? styles.testSuccess : styles.testFailure}
+                  >
+                    {testing
+                      ? t('auth_files.model_testing')
+                      : result && (
+                          <>
+                            <span>
+                              {result.success
+                                ? t('auth_files.model_test_success')
+                                : t('auth_files.model_test_failed')}{' '}
+                              · {t('auth_files.model_test_latency', { ms: result.latencyMs })}
+                            </span>
+                            <div>
+                              {result.success
+                                ? result.kind === 'image'
+                                  ? t('auth_files.model_test_images', {
+                                      count: result.imageCount ?? 0,
+                                    })
+                                  : result.message
+                                : `${result.error?.statusCode ? `HTTP ${result.error.statusCode}: ` : ''}${result.error?.message || t('auth_files.model_test_failed')}`}
+                            </div>
+                          </>
+                        )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </>
       )}
-    </Modal>
+    </>
   );
 }

--- a/src/features/authFiles/constants.ts
+++ b/src/features/authFiles/constants.ts
@@ -17,6 +17,7 @@ import { TYPE_COLORS } from '@/utils/quota';
 
 export type { ResolvedTheme, ThemeColors, TypeColorSet } from '@/types';
 export type AuthFileModelItem = {
+  testKind?: 'text' | 'image' | 'unsupported';
   id: string;
   display_name?: string;
   type?: string;

--- a/src/features/authFiles/hooks/useAuthFilesModels.ts
+++ b/src/features/authFiles/hooks/useAuthFilesModels.ts
@@ -1,7 +1,7 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { authFilesApi } from '@/services/api';
-import { useNotificationStore } from '@/stores';
+import { useAuthStore, useNotificationStore } from '@/stores';
 import type { AuthFileItem } from '@/types';
 import type { AuthFileModelItem } from '@/features/authFiles/constants';
 
@@ -12,11 +12,13 @@ export type UseAuthFilesModelsResult = {
   modelsLoading: boolean;
   modelsList: AuthFileModelItem[];
   modelsFileName: string;
+  modelsAuthIndex: string;
+  modelsAuthDisabled: boolean;
   modelsFileType: string;
   modelsError: ModelsError;
   showModels: (item: AuthFileItem) => Promise<void>;
   closeModelsModal: () => void;
-  /** 文件集变更后失效缓存；不传 names 则全部清空。 */
+  /** Invalidate selected files, or clear the entire cache when names are omitted. */
   invalidateModels: (names?: string[]) => void;
 };
 
@@ -27,6 +29,8 @@ export function useAuthFilesModels(): UseAuthFilesModelsResult {
   const [modelsModalOpen, setModelsModalOpen] = useState(false);
   const [modelsLoading, setModelsLoading] = useState(false);
   const [modelsList, setModelsList] = useState<AuthFileModelItem[]>([]);
+  const [modelsAuthIndex, setModelsAuthIndex] = useState('');
+  const [modelsAuthDisabled, setModelsAuthDisabled] = useState(false);
   const [modelsFileName, setModelsFileName] = useState('');
   const [modelsFileType, setModelsFileType] = useState('');
   const [modelsError, setModelsError] = useState<ModelsError>(null);
@@ -54,11 +58,28 @@ export function useAuthFilesModels(): UseAuthFilesModelsResult {
     });
   }, []);
 
+  useEffect(
+    () =>
+      useAuthStore.subscribe((state, previous) => {
+        if (
+          state.apiBase !== previous.apiBase ||
+          state.managementKey !== previous.managementKey ||
+          state.isAuthenticated !== previous.isAuthenticated
+        ) {
+          closeModelsModal();
+          invalidateModels();
+        }
+      }),
+    [closeModelsModal, invalidateModels]
+  );
+
   const showModels = useCallback(
     async (item: AuthFileItem) => {
       const cacheKey = item.name.trim();
       const requestId = ++activeModelsRequestIdRef.current;
 
+      setModelsAuthIndex(String(item.authIndex ?? '').trim());
+      setModelsAuthDisabled(Boolean(item.disabled));
       setModelsFileName(item.name);
       setModelsFileType(item.type || '');
       setModelsList([]);
@@ -110,6 +131,8 @@ export function useAuthFilesModels(): UseAuthFilesModelsResult {
     modelsLoading,
     modelsList,
     modelsFileName,
+    modelsAuthIndex,
+    modelsAuthDisabled,
     modelsFileType,
     modelsError,
     showModels,

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -216,6 +216,18 @@
     "routing_strategy_fill_first": "fill-first (prioritize)"
   },
   "auth_files": {
+    "model_test": "Test",
+    "model_test_button": "Test model {{model}}",
+    "model_testing": "Testing…",
+    "model_test_success": "Succeeded",
+    "model_test_failed": "Test failed",
+    "model_test_latency": "{{ms}} ms",
+    "model_test_images": "{{count}} image generated",
+    "model_test_hint": "Each test sends a real generation request using this credential and consumes quota.",
+    "model_test_upgrade": "Update CLI Proxy API to use model tests.",
+    "model_test_unsupported": "Testing this model type is not supported.",
+    "model_test_disabled": "Enable an available credential to test its models.",
+
     "title": "Auth Files Management",
     "meta_total": "{{count}} credentials",
     "meta_active": "{{count}} active",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -215,6 +215,18 @@
     "routing_strategy_fill_first": "fill-first (приоритет)"
   },
   "auth_files": {
+    "model_test": "Тест",
+    "model_test_button": "Проверить модель {{model}}",
+    "model_testing": "Проверка…",
+    "model_test_success": "Успешно",
+    "model_test_failed": "Ошибка проверки",
+    "model_test_latency": "{{ms}} мс",
+    "model_test_images": "Создано изображений: {{count}}",
+    "model_test_hint": "Каждая проверка отправляет реальный запрос генерации с выбранными учётными данными и расходует квоту.",
+    "model_test_upgrade": "Обновите CLI Proxy API для проверки моделей.",
+    "model_test_unsupported": "Проверка этого типа моделей не поддерживается.",
+    "model_test_disabled": "Включите доступные учётные данные для проверки моделей.",
+
     "title": "Управление файлами авторизации",
     "meta_total": "{{count}} учётных данных",
     "meta_active": "{{count}} активно",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -216,6 +216,18 @@
     "routing_strategy_fill_first": "fill-first (优先填充)"
   },
   "auth_files": {
+    "model_test": "测试",
+    "model_test_button": "测试模型 {{model}}",
+    "model_testing": "测试中…",
+    "model_test_success": "成功",
+    "model_test_failed": "测试失败",
+    "model_test_latency": "{{ms}} 毫秒",
+    "model_test_images": "已生成 {{count}} 张图片",
+    "model_test_hint": "每次测试使用当前凭证发送真实生成请求，会消耗额度。",
+    "model_test_upgrade": "请更新 CLI Proxy API 以使用模型测试。",
+    "model_test_unsupported": "暂不支持测试此模型类型。",
+    "model_test_disabled": "请启用可用凭证后测试模型。",
+
     "title": "认证文件管理",
     "meta_total": "{{count}} 个凭证",
     "meta_active": "{{count}} 个启用",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -216,6 +216,18 @@
     "routing_strategy_fill_first": "fill-first（優先填充）"
   },
   "auth_files": {
+    "model_test": "測試",
+    "model_test_button": "測試模型 {{model}}",
+    "model_testing": "測試中…",
+    "model_test_success": "成功",
+    "model_test_failed": "測試失敗",
+    "model_test_latency": "{{ms}} 毫秒",
+    "model_test_images": "已生成 {{count}} 張圖片",
+    "model_test_hint": "每次測試使用目前憑證發送真實生成請求，會消耗額度。",
+    "model_test_upgrade": "請更新 CLI Proxy API 以使用模型測試。",
+    "model_test_unsupported": "暫不支援測試此模型類型。",
+    "model_test_disabled": "請啟用可用憑證後測試模型。",
+
     "title": "驗證檔案管理",
     "meta_total": "{{count}} 個憑證",
     "meta_active": "{{count}} 個啟用",

--- a/src/services/api/authFiles.ts
+++ b/src/services/api/authFiles.ts
@@ -13,6 +13,16 @@ import {
 } from '@/utils/recentRequests';
 import { parseTimestampMs } from '@/utils/timestamp';
 
+export type AuthFileModelTestResult = {
+  success: boolean;
+  model: string;
+  kind: 'text' | 'image';
+  latencyMs: number;
+  imageCount?: number;
+  message?: string;
+  error?: { code: string; statusCode?: number; message: string };
+};
+
 type StatusError = { status?: number };
 type AuthFileStatusResponse = { status: string; disabled: boolean };
 type AuthFileEntry = AuthFilesResponse['files'][number];
@@ -523,16 +533,61 @@ export const authFilesApi = {
     }
   },
 
-  // 获取认证凭证支持的模型
-  async getModelsForAuthFile(
-    name: string
-  ): Promise<{ id: string; display_name?: string; type?: string; owned_by?: string }[]> {
+  async testModelForAuthFile(
+    authIndex: string,
+    model: string,
+    signal?: AbortSignal
+  ): Promise<AuthFileModelTestResult> {
+    const data = await apiClient.post<{
+      success: boolean;
+      model: string;
+      kind: 'text' | 'image';
+      latency_ms: number;
+      image_count?: number;
+      message?: string;
+      error?: { code: string; status_code?: number; message: string };
+    }>('/auth-files/test-model', { auth_index: authIndex, model }, { signal, timeout: 0 });
+    return {
+      success: data.success,
+      model: data.model,
+      kind: data.kind,
+      latencyMs: data.latency_ms,
+      imageCount: data.image_count,
+      message: data.message,
+      error: data.error
+        ? {
+            code: data.error.code,
+            statusCode: data.error.status_code,
+            message: data.error.message,
+          }
+        : undefined,
+    };
+  },
+
+  // Fetch the credential's registered models and optional test capabilities.
+  async getModelsForAuthFile(name: string): Promise<
+    {
+      id: string;
+      display_name?: string;
+      type?: string;
+      owned_by?: string;
+      testKind?: 'text' | 'image' | 'unsupported';
+    }[]
+  > {
     const data = await apiClient.get<Record<string, unknown>>(
       `/auth-files/models?name=${encodeURIComponent(name)}`
     );
     const models = data.models ?? data['models'];
     return Array.isArray(models)
-      ? (models as { id: string; display_name?: string; type?: string; owned_by?: string }[])
+      ? (
+          models as {
+            id: string;
+            display_name?: string;
+            type?: string;
+            owned_by?: string;
+            test_kind?: 'text' | 'image' | 'unsupported';
+          }[]
+        ).map(({ test_kind, ...model }) => ({ ...model, testKind: test_kind }))
       : [];
   },
 

--- a/tests/authFileModelProbe.test.ts
+++ b/tests/authFileModelProbe.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, expect, test } from 'bun:test';
+import { authFilesApi } from '../src/services/api/authFiles';
+import { apiClient } from '../src/services/api/client';
+
+const originalPost = apiClient.post;
+afterEach(() => {
+  apiClient.post = originalPost;
+});
+
+test('model probe binds credential and disables the default short request timeout', async () => {
+  let captured: unknown[] = [];
+  apiClient.post = (async (...args: unknown[]) => {
+    captured = args;
+    return { success: true, model: 'gpt-image-2', kind: 'image', latency_ms: 3200, image_count: 1 };
+  }) as typeof apiClient.post;
+  const controller = new AbortController();
+  const result = await authFilesApi.testModelForAuthFile(
+    'account-index',
+    'gpt-image-2',
+    controller.signal
+  );
+  expect(captured).toEqual([
+    '/auth-files/test-model',
+    { auth_index: 'account-index', model: 'gpt-image-2' },
+    { signal: controller.signal, timeout: 0 },
+  ]);
+  expect(result).toEqual({
+    success: true,
+    model: 'gpt-image-2',
+    kind: 'image',
+    latencyMs: 3200,
+    imageCount: 1,
+    message: undefined,
+    error: undefined,
+  });
+});
+
+test('upstream auth failures remain model test results', async () => {
+  apiClient.post = (async () => ({
+    success: false,
+    model: 'gpt-5.5',
+    kind: 'text',
+    latency_ms: 10,
+    error: { code: 'upstream_error', status_code: 401, message: 'Unauthorized' },
+  })) as typeof apiClient.post;
+  const result = await authFilesApi.testModelForAuthFile('account-index', 'gpt-5.5');
+  expect(result.success).toBe(false);
+  expect(result.error).toEqual({
+    code: 'upstream_error',
+    statusCode: 401,
+    message: 'Unauthorized',
+  });
+});


### PR DESCRIPTION
Fixes router-for-me/CLIProxyAPI#420.

Backend contract: router-for-me/Cli-Proxy-API-Management-Center#426.

## Summary

Add per-model test controls to the auth file models modal so operators can verify model availability with the credential that owns it.

## Changes

- Add capability-aware Test actions for text and image models.
- Call the management probe endpoint with the selected auth index and normalize the response in the API layer.
- Show progress, latency, compact text output, image count, and sanitized failures.
- Allow independent model tests and cancel all in-flight requests when the modal is closed or the connection changes.
- Keep copy actions, excluded-model state, disabled credentials, unsupported models, and older-backend messaging accessible across all four locales.
- Add API contract regression tests.

## Validation

- `bun run verify` (443 tests, ESLint, TypeScript, production build)

UI verification note: the auth-files route builds successfully with the single-file Vite artifact; browser interaction was not run against a live management backend in this checkout because model probes issue real upstream generation requests.
