### PR TITLE
fix(quota): clear gateway cooldown after Codex reset credit

### DIFF
--- a/src/features/quota/providers/codex/data.ts
+++ b/src/features/quota/providers/codex/data.ts
@@ -13,7 +13,7 @@ import type {
   CodexQuotaWindow,
   CodexUsagePayload,
 } from '@/types';
-import { apiCallApi, getApiCallErrorMessage } from '@/services/api';
+import { apiCallApi, authFilesApi, getApiCallErrorMessage } from '@/services/api';
 import {
   CODEX_RATE_LIMIT_RESET_CREDITS_URL,
   CODEX_RATE_LIMIT_RESET_CREDITS_CONSUME_URL,
@@ -418,14 +418,8 @@ const createCodexRedeemRequestId = (): string => {
 
 const consumeCodexRateLimitResetCredit = async (
   file: AuthFileItem,
-  t: TFunction
+  authIndex: string
 ): Promise<void> => {
-  const rawAuthIndex = file['auth_index'] ?? file.authIndex;
-  const authIndex = normalizeAuthIndex(rawAuthIndex);
-  if (!authIndex) {
-    throw new Error(t('codex_quota.missing_auth_index'));
-  }
-
   const requestHeader = buildCodexRequestHeader(file);
 
   const result = await apiCallApi.request({
@@ -443,8 +437,24 @@ const consumeCodexRateLimitResetCredit = async (
   }
 };
 
+/**
+ * Auth indexes whose credit was redeemed but whose gateway cooldown clear failed.
+ * A retry resumes the clear instead of spending a second credit. In-memory only:
+ * after a reload the next reset redeems again.
+ */
+const pendingGatewayResets = new Set<string>();
+
 const resetCodexQuota = async (file: AuthFileItem, t: TFunction): Promise<CodexQuotaData> => {
-  await consumeCodexRateLimitResetCredit(file, t);
+  const authIndex = normalizeAuthIndex(file['auth_index'] ?? file.authIndex);
+  if (!authIndex) {
+    throw new Error(t('codex_quota.missing_auth_index'));
+  }
+  if (!pendingGatewayResets.has(authIndex)) {
+    await consumeCodexRateLimitResetCredit(file, authIndex);
+    pendingGatewayResets.add(authIndex);
+  }
+  await authFilesApi.resetQuota(authIndex);
+  pendingGatewayResets.delete(authIndex);
   return fetchCodexQuota(file, t);
 };
 

--- a/src/services/api/authFiles.ts
+++ b/src/services/api/authFiles.ts
@@ -425,6 +425,8 @@ export const authFilesApi = {
       expired: buildManualRefreshExpiredAt(),
     }),
 
+  resetQuota: (authIndex: string) => apiClient.post('/reset-quota', { auth_index: authIndex }),
+
   uploadFiles: async (files: File[]): Promise<AuthFileBatchUploadResult> => {
     const requestedNames = files.map((file) => file.name);
     if (requestedNames.length === 0) {

--- a/tests/codexQuota.test.ts
+++ b/tests/codexQuota.test.ts
@@ -1,8 +1,15 @@
 import { describe, expect, test } from 'bun:test';
 import type { TFunction } from 'i18next';
 import { CODEX_CONFIG, buildCodexQuotaWindows } from '@/features/quota/providers/codex/data';
+import { apiCallApi, authFilesApi } from '@/services/api';
 import type { CodexQuotaState, CodexUsagePayload } from '@/types';
-import { normalizeCodexResetCreditsPayload, parseCodexUsagePayload } from '@/utils/quota';
+import {
+  CODEX_RATE_LIMIT_RESET_CREDITS_CONSUME_URL,
+  CODEX_RATE_LIMIT_RESET_CREDITS_URL,
+  CODEX_USAGE_URL,
+  normalizeCodexResetCreditsPayload,
+  parseCodexUsagePayload,
+} from '@/utils/quota';
 
 const t = ((key: string) => key) as TFunction;
 
@@ -85,5 +92,72 @@ describe('Codex current usage payload', () => {
     };
 
     expect(CODEX_CONFIG.canResetQuota?.(quota)).toBeTrue();
+  });
+});
+
+/** Stubs the two APIs a reset touches and records every call in order. */
+const stubCodexResetApis = (resetQuota: (authIndex: string) => Promise<unknown>) => {
+  const originalRequest = apiCallApi.request;
+  const originalResetQuota = authFilesApi.resetQuota;
+  const calls: string[] = [];
+  apiCallApi.request = async ({ url }) => {
+    calls.push(url);
+    const body = url === CODEX_USAGE_URL ? CURRENT_CODEX_USAGE_PAYLOAD : null;
+    return { statusCode: 200, header: {}, bodyText: '', body };
+  };
+  authFilesApi.resetQuota = async (authIndex) => {
+    calls.push(`reset-quota:${authIndex}`);
+    return resetQuota(authIndex);
+  };
+  return {
+    calls,
+    restore: () => {
+      apiCallApi.request = originalRequest;
+      authFilesApi.resetQuota = originalResetQuota;
+    },
+  };
+};
+
+describe('Codex quota reset', () => {
+  test('clears the gateway cooldown after the credit is redeemed and before usage is re-read', async () => {
+    const { calls, restore } = stubCodexResetApis(async () => ({}));
+
+    try {
+      await CODEX_CONFIG.resetQuota?.({ name: 'codex.json', authIndex: 7 }, t);
+    } finally {
+      restore();
+    }
+
+    expect(calls).toEqual([
+      CODEX_RATE_LIMIT_RESET_CREDITS_CONSUME_URL,
+      'reset-quota:7',
+      CODEX_USAGE_URL,
+      CODEX_RATE_LIMIT_RESET_CREDITS_URL,
+    ]);
+  });
+
+  test('a retry after a failed gateway clear resumes the clear without redeeming again', async () => {
+    let gatewayDown = true;
+    const { calls, restore } = stubCodexResetApis(async () => {
+      if (gatewayDown) throw new Error('502 gateway unavailable');
+      return {};
+    });
+    const file = { name: 'codex-retry.json', authIndex: 8 };
+
+    try {
+      await expect(CODEX_CONFIG.resetQuota?.(file, t)).rejects.toThrow('502');
+      gatewayDown = false;
+      await CODEX_CONFIG.resetQuota?.(file, t);
+    } finally {
+      restore();
+    }
+
+    expect(calls).toEqual([
+      CODEX_RATE_LIMIT_RESET_CREDITS_CONSUME_URL,
+      'reset-quota:8',
+      'reset-quota:8',
+      CODEX_USAGE_URL,
+      CODEX_RATE_LIMIT_RESET_CREDITS_URL,
+    ]);
   });
 });


### PR DESCRIPTION
The Codex quota "Reset" button redeems a rate-limit reset credit
upstream and re-reads usage, but never tells CLIProxyAPI. The gateway
keeps the per-model and credential cooldowns it recorded from the
earlier 429 (resets_at can be days away), so the credential stays
unusable while the card shows the restored quota.

CLIProxyAPI exposes POST /v0/management/reset-quota with
{"auth_index"} for exactly this. After a successful redeem, call it for
the same auth_index, then re-read usage as before. A failed redeem
still throws before the gateway call, so no cooldown is cleared for a
credential that was not actually reset upstream. If the gateway call
fails after the credit was spent, the auth index is remembered in
memory and the next Reset resumes the gateway clear instead of
redeeming a second credit.

Check: tests/codexQuota.test.ts asserts the call order redeem, then
reset-quota, then usage and reset-credits reads, and that a retry after
a failed reset-quota issues no second consume request; both fail
without the data.ts change. bun test (437 pass), bun run lint, bun run
build.
