### PR TITLE
feat(auth-files): show plugin OAuth provider branding

### DIFF
--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -37,10 +37,12 @@ import {
   useConfigStore,
   useLanguageStore,
   useNotificationStore,
+  usePluginProviderBrandingStore,
   useThemeStore,
 } from '@/stores';
 import { AUTH_FILES_CHANGED_EVENT } from '@/features/authFiles/authFilesEvents';
 import {
+  collectPluginProviderBranding,
   collectPluginResourceEntries,
   PLUGIN_RESOURCES_REFRESH_EVENT,
   resolvePluginAssetURL,
@@ -315,6 +317,7 @@ export function MainLayout() {
   const connectionStatus = useAuthStore((state) => state.connectionStatus);
   const apiBase = useAuthStore((state) => state.apiBase);
   const supportsPlugin = useAuthStore((state) => state.supportsPlugin);
+  const setPluginProviderBranding = usePluginProviderBrandingStore((state) => state.setBranding);
 
   const fetchConfig = useConfigStore((state) => state.fetchConfig);
   const clearCache = useConfigStore((state) => state.clearCache);
@@ -487,16 +490,19 @@ export function MainLayout() {
   const loadPluginResources = useCallback(async () => {
     if (connectionStatus !== 'connected' || !supportsPlugin) {
       setPluginResources([]);
+      setPluginProviderBranding({});
       return;
     }
 
     try {
       const plugins = await pluginsApi.list();
       setPluginResources(collectPluginResourceEntries(plugins.plugins));
+      setPluginProviderBranding(collectPluginProviderBranding(plugins.plugins, apiBase));
     } catch {
       setPluginResources([]);
+      setPluginProviderBranding({});
     }
-  }, [connectionStatus, supportsPlugin]);
+  }, [apiBase, connectionStatus, setPluginProviderBranding, supportsPlugin]);
 
   const loadAuthFilesCount = useCallback(async () => {
     const requestID = ++authFilesCountRequestRef.current;

--- a/src/components/ui/FallbackImage.tsx
+++ b/src/components/ui/FallbackImage.tsx
@@ -1,0 +1,17 @@
+import { useState, type ImgHTMLAttributes, type ReactNode } from 'react';
+
+interface FallbackImageProps extends Omit<ImgHTMLAttributes<HTMLImageElement>, 'src' | 'onError'> {
+  src: string | null | undefined;
+  fallback: ReactNode;
+}
+
+/**
+ * Renders an image, or `fallback` when there is no source or it fails to load
+ * (e.g. a remote plugin logo that is unreachable).
+ */
+export function FallbackImage({ src, fallback, alt = '', ...imgProps }: FallbackImageProps) {
+  const [failedSrc, setFailedSrc] = useState<string | null>(null);
+
+  if (!src || failedSrc === src) return <>{fallback}</>;
+  return <img {...imgProps} src={src} alt={alt} onError={() => setFailedSrc(src)} />;
+}

--- a/src/features/authFiles/AuthFilesPage.tsx
+++ b/src/features/authFiles/AuthFilesPage.tsx
@@ -50,7 +50,12 @@ import {
   type AuthFilesStatusFilterMode,
   type AuthFilesSortMode,
 } from '@/features/authFiles/uiState';
-import { useAuthStore, useNotificationStore, useThemeStore } from '@/stores';
+import {
+  useAuthStore,
+  useNotificationStore,
+  usePluginProviderBrandingStore,
+  useThemeStore,
+} from '@/stores';
 import styles from './AuthFilesPage.module.scss';
 
 const DEFAULT_REGULAR_PAGE_SIZE = 9;
@@ -78,6 +83,7 @@ export function AuthFilesPage() {
   const showNotification = useNotificationStore((state) => state.showNotification);
   const connectionStatus = useAuthStore((state) => state.connectionStatus);
   const resolvedTheme: ResolvedTheme = useThemeStore((state) => state.resolvedTheme);
+  const pluginBranding = usePluginProviderBrandingStore((state) => state.branding);
   const pageTransitionLayer = usePageTransitionLayer();
   const isCurrentLayer = pageTransitionLayer ? pageTransitionLayer.status === 'current' : true;
   const navigate = useNavigate();
@@ -546,12 +552,12 @@ export function AuthFilesPage() {
       return normalizedFilter === 'all'
         ? t('auth_files.delete_problem_button')
         : t('auth_files.delete_problem_button_with_type', {
-            type: getTypeLabel(t, normalizedFilter),
+            type: getTypeLabel(t, normalizedFilter, pluginBranding),
           });
     }
     return normalizedFilter === 'all'
       ? t('auth_files.delete_all_button')
-      : `${t('common.delete')} ${getTypeLabel(t, normalizedFilter)}`;
+      : `${t('common.delete')} ${getTypeLabel(t, normalizedFilter, pluginBranding)}`;
   })();
 
   const oauthSectionRef = useRevealOnScroll<HTMLDivElement>();
@@ -597,6 +603,7 @@ export function AuthFilesPage() {
           counts={typeCounts}
           active={normalizedFilter}
           resolvedTheme={resolvedTheme}
+          pluginBranding={pluginBranding}
           onChange={(type) => {
             setFilter(type);
             setPage(1);
@@ -687,6 +694,7 @@ export function AuthFilesPage() {
                 compact={compactMode}
                 selected={selectedFiles.has(file.name)}
                 resolvedTheme={resolvedTheme}
+                pluginBranding={pluginBranding}
                 disableControls={disableControls}
                 deleting={deleting}
                 statusUpdating={statusUpdating}

--- a/src/features/authFiles/components/AuthFileCard.tsx
+++ b/src/features/authFiles/components/AuthFileCard.tsx
@@ -1,6 +1,7 @@
 import { useState, type CSSProperties } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/Button';
+import { FallbackImage } from '@/components/ui/FallbackImage';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import { SelectionCheckbox } from '@/components/ui/SelectionCheckbox';
 import { ToggleSwitch } from '@/components/ui/ToggleSwitch';
@@ -13,6 +14,7 @@ import {
   IconTrash2,
 } from '@/components/ui/icons';
 import { ProviderStatusBar } from '@/components/providers/ProviderStatusBar';
+import type { PluginProviderBrandingMap } from '@/stores/usePluginProviderBrandingStore';
 import type { AuthFileItem } from '@/types';
 import { resolveAuthProvider } from '@/utils/quota';
 import { statusBarDataFromRecentRequests } from '@/utils/recentRequests';
@@ -43,6 +45,8 @@ export type AuthFileCardProps = {
   compact: boolean;
   selected: boolean;
   resolvedTheme: ResolvedTheme;
+  /** Label/logo fallback for provider keys owned by plugin OAuth providers. */
+  pluginBranding?: PluginProviderBrandingMap;
   disableControls: boolean;
   deleting: string | null;
   statusUpdating: Record<string, boolean>;
@@ -73,6 +77,7 @@ export function AuthFileCard(props: AuthFileCardProps) {
     compact,
     selected,
     resolvedTheme,
+    pluginBranding,
     disableControls,
     deleting,
     statusUpdating,
@@ -96,8 +101,8 @@ export function AuthFileCard(props: AuthFileCardProps) {
   const showManualRefreshButton = !isRuntimeOnly && supportsAuthFileManualRefresh(providerKey);
   const isManualRefreshing = manualRefreshing[file.name] === true;
   const typeColor = getTypeColor(providerKey, resolvedTheme);
-  const typeLabel = getTypeLabel(t, providerKey);
-  const providerIcon = getAuthFileIcon(providerKey, resolvedTheme);
+  const typeLabel = getTypeLabel(t, providerKey, pluginBranding);
+  const providerIcon = getAuthFileIcon(providerKey, resolvedTheme, pluginBranding);
   // 与 AI 提供商界面一致：Kimi 图标底座随主题切换颜色
   const useThemeSurfaceIcon = isThemeSurfaceIconProvider(providerKey);
 
@@ -183,11 +188,13 @@ export function AuthFileCard(props: AuthFileCardProps) {
                 }
           }
         >
-          {providerIcon ? (
-            <img src={providerIcon} alt="" className={styles.avatarImage} />
-          ) : (
-            <span className={styles.avatarFallback}>{typeLabel.slice(0, 1).toUpperCase()}</span>
-          )}
+          <FallbackImage
+            src={providerIcon}
+            className={styles.avatarImage}
+            fallback={
+              <span className={styles.avatarFallback}>{typeLabel.slice(0, 1).toUpperCase()}</span>
+            }
+          />
         </div>
         <div className={styles.identity}>
           <div className={styles.badgeRow}>

--- a/src/features/authFiles/components/OAuthEditorProviderCard.tsx
+++ b/src/features/authFiles/components/OAuthEditorProviderCard.tsx
@@ -2,8 +2,9 @@ import { useId } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AutocompleteInput } from '@/components/ui/AutocompleteInput';
 import { Card } from '@/components/ui/Card';
+import { FallbackImage } from '@/components/ui/FallbackImage';
 import { IconCheck, IconNetwork } from '@/components/ui/icons';
-import { useThemeStore } from '@/stores';
+import { usePluginProviderBrandingStore, useThemeStore } from '@/stores';
 import { getAuthFileIcon, getTypeLabel, normalizeProviderKey } from '../constants';
 import styles from './OAuthEditor.module.scss';
 
@@ -25,6 +26,7 @@ export function OAuthEditorProviderCard({
   const { t } = useTranslation();
   const id = useId();
   const resolvedTheme = useThemeStore((state) => state.resolvedTheme);
+  const pluginBranding = usePluginProviderBrandingStore((state) => state.branding);
 
   return (
     <Card className={styles.settingsCard}>
@@ -59,7 +61,7 @@ export function OAuthEditorProviderCard({
           >
             {options.map((option) => {
               const active = normalizeProviderKey(provider) === normalizeProviderKey(option);
-              const icon = getAuthFileIcon(option, resolvedTheme);
+              const icon = getAuthFileIcon(option, resolvedTheme, pluginBranding);
               return (
                 <button
                   key={option}
@@ -69,8 +71,11 @@ export function OAuthEditorProviderCard({
                   onClick={() => onChange(option)}
                   disabled={disabled}
                 >
-                  {icon ? <img src={icon} alt="" /> : <IconNetwork size={16} aria-hidden="true" />}
-                  <span>{getTypeLabel(t, option)}</span>
+                  <FallbackImage
+                    src={icon}
+                    fallback={<IconNetwork size={16} aria-hidden="true" />}
+                  />
+                  <span>{getTypeLabel(t, option, pluginBranding)}</span>
                   <IconCheck size={14} className={styles.providerCheck} aria-hidden="true" />
                 </button>
               );

--- a/src/features/authFiles/components/ProviderTabs.tsx
+++ b/src/features/authFiles/components/ProviderTabs.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from 'react-i18next';
+import { FallbackImage } from '@/components/ui/FallbackImage';
 import { IconFilterAll } from '@/components/ui/icons';
 import {
   getAuthFileIcon,
@@ -7,6 +8,7 @@ import {
   isThemeSurfaceIconProvider,
   type ResolvedTheme,
 } from '@/features/authFiles/constants';
+import type { PluginProviderBrandingMap } from '@/stores/usePluginProviderBrandingStore';
 import styles from './ProviderTabs.module.scss';
 
 export type ProviderTabsProps = {
@@ -14,6 +16,8 @@ export type ProviderTabsProps = {
   counts: Record<string, number>;
   active: string;
   resolvedTheme: ResolvedTheme;
+  /** Label/logo fallback for provider keys owned by plugin OAuth providers. */
+  pluginBranding?: PluginProviderBrandingMap;
   onChange: (type: string) => void;
 };
 
@@ -21,15 +25,23 @@ export type ProviderTabsProps = {
  * 提供商过滤 tabs：水平排布、移动端横向滚动。
  * 品牌色只出现在图标上，激活态是文字 + 2px 墨色下划线。
  */
-export function ProviderTabs({ types, counts, active, resolvedTheme, onChange }: ProviderTabsProps) {
+export function ProviderTabs({
+  types,
+  counts,
+  active,
+  resolvedTheme,
+  pluginBranding,
+  onChange,
+}: ProviderTabsProps) {
   const { t } = useTranslation();
 
   return (
     <div className={styles.tabs} role="group" aria-label={t('auth_files.filter_all')}>
       {types.map((type) => {
         const isActive = active === type;
-        const label = type === 'all' ? t('auth_files.filter_all') : getTypeLabel(t, type);
-        const iconSrc = type === 'all' ? null : getAuthFileIcon(type, resolvedTheme);
+        const label = type === 'all' ? t('auth_files.filter_all') : getTypeLabel(t, type, pluginBranding);
+        const iconSrc =
+          type === 'all' ? null : getAuthFileIcon(type, resolvedTheme, pluginBranding);
 
         return (
           <button
@@ -51,13 +63,15 @@ export function ProviderTabs({ types, counts, active, resolvedTheme, onChange }:
                     : undefined
                 }
               >
-                {iconSrc ? (
-                  <img src={iconSrc} alt="" className={styles.tabIcon} />
-                ) : (
-                  <span className={styles.tabIconFallback}>
-                    {label.slice(0, 1).toUpperCase()}
-                  </span>
-                )}
+                <FallbackImage
+                  src={iconSrc}
+                  className={styles.tabIcon}
+                  fallback={
+                    <span className={styles.tabIconFallback}>
+                      {label.slice(0, 1).toUpperCase()}
+                    </span>
+                  }
+                />
               </span>
             )}
             <span className={styles.tabLabel}>{label}</span>

--- a/src/features/authFiles/constants.ts
+++ b/src/features/authFiles/constants.ts
@@ -10,6 +10,7 @@ import iconKimiDark from '@/assets/icons/kimi-dark.svg';
 import iconKimiLight from '@/assets/icons/kimi-light.svg';
 import iconQwen from '@/assets/icons/qwen.svg';
 import iconVertex from '@/assets/icons/vertex.svg';
+import type { PluginProviderBrandingMap } from '@/stores/usePluginProviderBrandingStore';
 import type { AuthFileItem, ResolvedTheme, ThemeColors } from '@/types';
 import { normalizeOAuthProviderKey } from '@/utils/providerKeys';
 import { parseTimestamp } from '@/utils/timestamp';
@@ -136,12 +137,19 @@ export const isProblemAuthFile = (file: AuthFileItem): boolean => {
   return file.unavailable === true || status === 'error' || hasAuthFileStatusWarning(file);
 };
 
-export const getTypeLabel = (t: TFunction, type: string): string => {
+// Built-in labels win; plugin OAuth providers fall back to the name they declare.
+export const getTypeLabel = (
+  t: TFunction,
+  type: string,
+  pluginBranding?: PluginProviderBrandingMap
+): string => {
   const providerKey = normalizeProviderKey(type);
   const key = `auth_files.filter_${providerKey}`;
   const translated = t(key);
   if (translated !== key) return translated;
   if (providerKey === 'iflow') return 'iFlow';
+  const pluginLabel = pluginBranding?.[providerKey]?.label;
+  if (pluginLabel) return pluginLabel;
   return type.charAt(0).toUpperCase() + type.slice(1);
 };
 
@@ -150,9 +158,15 @@ export const getTypeColor = (type: string, resolvedTheme: ResolvedTheme): ThemeC
   return resolvedTheme === 'dark' && set.dark ? set.dark : set.light;
 };
 
-export const getAuthFileIcon = (type: string, resolvedTheme: ResolvedTheme): string | null => {
-  const iconEntry = AUTH_FILE_ICONS[normalizeProviderKey(type)];
-  if (!iconEntry) return null;
+// Bundled icons win; plugin OAuth providers fall back to the logo they declare.
+export const getAuthFileIcon = (
+  type: string,
+  resolvedTheme: ResolvedTheme,
+  pluginBranding?: PluginProviderBrandingMap
+): string | null => {
+  const providerKey = normalizeProviderKey(type);
+  const iconEntry = AUTH_FILE_ICONS[providerKey];
+  if (!iconEntry) return pluginBranding?.[providerKey]?.logo || null;
   return typeof iconEntry === 'string'
     ? iconEntry
     : resolvedTheme === 'dark'

--- a/src/features/authFiles/hooks/useAuthFilesData.ts
+++ b/src/features/authFiles/hooks/useAuthFilesData.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState, type ChangeEvent, type RefObj
 import { useTranslation } from 'react-i18next';
 import { authFilesApi } from '@/services/api';
 import { notifyAuthFilesChanged } from '@/features/authFiles/authFilesEvents';
-import { useNotificationStore } from '@/stores';
+import { useNotificationStore, usePluginProviderBrandingStore } from '@/stores';
 import type { AuthFileItem } from '@/types';
 import { formatFileSize } from '@/utils/format';
 import { MAX_AUTH_FILE_SIZE } from '@/utils/constants';
@@ -339,7 +339,9 @@ export function useAuthFilesData(options?: UseAuthFilesDataOptions): UseAuthFile
       const isProblemOnly = problemOnly === true;
       const isDisabledOnly = disabledOnly === true;
       const isEnabledOnly = enabledOnly === true;
-      const typeLabel = isFiltered ? getTypeLabel(t, filter) : t('auth_files.filter_all');
+      const typeLabel = isFiltered
+        ? getTypeLabel(t, filter, usePluginProviderBrandingStore.getState().branding)
+        : t('auth_files.filter_all');
       let confirmMessage = t('auth_files.delete_all_confirm');
       if (isDisabledOnly || isEnabledOnly) {
         confirmMessage = t('auth_files.delete_filtered_result_confirm');

--- a/src/features/plugins/pluginResources.ts
+++ b/src/features/plugins/pluginResources.ts
@@ -1,5 +1,7 @@
+import type { PluginProviderBrandingMap } from '@/stores/usePluginProviderBrandingStore';
 import type { PluginListEntry, PluginMenu, PluginStoreEntry } from '@/types';
 import { normalizeApiBase } from '@/utils/connection';
+import { normalizeOAuthProviderKey } from '@/utils/providerKeys';
 
 export const PLUGIN_RESOURCES_REFRESH_EVENT = 'plugin-resources-refresh';
 
@@ -31,6 +33,24 @@ export const resolvePluginAssetURL = (value: string, apiBase: string) => {
   if (!trimmed.startsWith('/')) return trimmed;
   const base = normalizeApiBase(apiBase);
   return base ? `${base}${trimmed}` : trimmed;
+};
+
+// Label and logo for every provider key owned by an active plugin OAuth provider.
+// The first plugin (backend priority order) wins when several claim one key.
+export const collectPluginProviderBranding = (
+  plugins: PluginListEntry[],
+  apiBase: string
+): PluginProviderBrandingMap => {
+  const branding: PluginProviderBrandingMap = {};
+  plugins.forEach((plugin) => {
+    const key = normalizeOAuthProviderKey(plugin.oauthProvider ?? '');
+    if (!plugin.supportsOAuth || !plugin.effectiveEnabled || !key || branding[key]) return;
+    branding[key] = {
+      label: getPluginTitle(plugin),
+      logo: resolvePluginAssetURL(plugin.logo || plugin.metadata?.logo || '', apiBase),
+    };
+  });
+  return branding;
 };
 
 // Registry entries usually carry an "owner/repo" slug rather than a full URL.

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -8,6 +8,7 @@ export { useLanguageStore } from './useLanguageStore';
 export { useAuthStore } from './useAuthStore';
 export { useConfigStore } from './useConfigStore';
 export { useModelsStore } from './useModelsStore';
+export { usePluginProviderBrandingStore } from './usePluginProviderBrandingStore';
 export {
   captureQuotaCacheGeneration,
   commitIfQuotaCacheCurrent,

--- a/src/stores/usePluginProviderBrandingStore.ts
+++ b/src/stores/usePluginProviderBrandingStore.ts
@@ -1,0 +1,25 @@
+/**
+ * Display branding (label + logo) declared by plugin OAuth providers.
+ *
+ * Built-in providers keep their bundled labels and icons; this map only fills
+ * the gap for provider keys owned by plugins.
+ */
+
+import { create } from 'zustand';
+
+export interface PluginProviderBranding {
+  label: string;
+  logo: string;
+}
+
+export type PluginProviderBrandingMap = Record<string, PluginProviderBranding>;
+
+interface PluginProviderBrandingState {
+  branding: PluginProviderBrandingMap;
+  setBranding: (branding: PluginProviderBrandingMap) => void;
+}
+
+export const usePluginProviderBrandingStore = create<PluginProviderBrandingState>((set) => ({
+  branding: {},
+  setBranding: (branding) => set({ branding }),
+}));

--- a/tests/pluginProviderBranding.test.ts
+++ b/tests/pluginProviderBranding.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from 'bun:test';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { I18nextProvider } from 'react-i18next';
+import { createInstance } from 'i18next';
+import { ProviderTabs } from '../src/features/authFiles/components/ProviderTabs';
+import { getAuthFileIcon, getTypeLabel } from '../src/features/authFiles/constants';
+import { collectPluginProviderBranding } from '../src/features/plugins/pluginResources';
+import type { PluginListEntry } from '../src/types';
+import en from '../src/i18n/locales/en.json';
+
+const i18n = createInstance();
+await i18n.init({ lng: 'en', resources: { en: { translation: en } } });
+const t = i18n.t.bind(i18n);
+
+const META_LOGO = 'https://cdn.example.com/meta.svg';
+
+const plugin = (overrides: Partial<PluginListEntry>): PluginListEntry => ({
+  id: 'muse-code',
+  path: '/plugins/muse-code.so',
+  configured: true,
+  registered: true,
+  enabled: true,
+  effectiveEnabled: true,
+  supportsOAuth: true,
+  oauthProvider: 'muse-code',
+  logo: META_LOGO,
+  configFields: [],
+  menus: [],
+  metadata: {
+    name: 'Muse Code',
+    version: '0.1.1',
+    author: 'someone',
+    githubRepository: 'https://github.com/someone/muse-code',
+    logo: META_LOGO,
+    configFields: [],
+  },
+  ...overrides,
+});
+
+describe('plugin provider branding', () => {
+  test('collects label and logo from active OAuth plugins only', () => {
+    const branding = collectPluginProviderBranding(
+      [
+        plugin({}),
+        plugin({ id: 'shadow', oauthProvider: 'muse-code', metadata: null, logo: '/other.svg' }),
+        plugin({ id: 'off', oauthProvider: 'off-provider', effectiveEnabled: false }),
+        plugin({ id: 'no-oauth', oauthProvider: 'plain', supportsOAuth: false }),
+        plugin({
+          id: 'relative',
+          oauthProvider: 'Relative_Provider',
+          logo: '',
+          metadata: null,
+        }),
+      ],
+      'https://proxy.example.com'
+    );
+
+    expect(branding).toEqual({
+      'muse-code': { label: 'Muse Code', logo: META_LOGO },
+      'relative-provider': { label: 'relative', logo: '' },
+    });
+  });
+
+  test('falls back to plugin branding only for non built-in providers', () => {
+    const branding = { 'muse-code': { label: 'Muse Code', logo: META_LOGO } };
+
+    expect(getTypeLabel(t, 'muse-code', branding)).toBe('Muse Code');
+    expect(getAuthFileIcon('muse-code', 'dark', branding)).toBe(META_LOGO);
+
+    expect(getTypeLabel(t, 'muse-code')).toBe('Muse-code');
+    expect(getAuthFileIcon('muse-code', 'dark')).toBeNull();
+
+    const shadowing = { codex: { label: 'Fake Codex', logo: META_LOGO } };
+    expect(getTypeLabel(t, 'codex', shadowing)).toBe(getTypeLabel(t, 'codex'));
+    expect(getAuthFileIcon('codex', 'light', shadowing)).not.toBe(META_LOGO);
+  });
+
+  test('renders the plugin logo and name in the provider tabs', () => {
+    const markup = renderToStaticMarkup(
+      createElement(
+        I18nextProvider,
+        { i18n },
+        createElement(ProviderTabs, {
+          types: ['all', 'muse-code'],
+          counts: { all: 1, 'muse-code': 1 },
+          active: 'muse-code',
+          resolvedTheme: 'dark',
+          pluginBranding: { 'muse-code': { label: 'Muse Code', logo: META_LOGO } },
+          onChange: () => {},
+        })
+      )
+    );
+
+    expect(markup).toContain(`src="${META_LOGO}"`);
+    expect(markup).toContain('Muse Code');
+    expect(markup).not.toContain('Muse-code');
+  });
+});


### PR DESCRIPTION
## Summary

Plugin OAuth providers declare a display name and logo (`metadata.name`, `logo` in `GET /v0/management/plugins`), but only the **OAuth Login** cards used them. Everywhere else the credential's provider key fell back to a capitalized key and a letter placeholder — e.g. a plugin provider `muse-code` showed as **"Muse-code"** with an **"M"** avatar in Auth Files.

This PR reuses the branding the backend already reports:

- `MainLayout` (which already loads `GET /plugins` on connect and on `plugin-resources-refresh`) now also derives a `{ providerKey → { label, logo } }` map for active plugin OAuth providers and keeps it in a small Zustand store (`usePluginProviderBrandingStore`). The map is cleared when disconnected or when plugins are unsupported.
- `getTypeLabel` / `getAuthFileIcon` accept an optional branding map and use it **only as a fallback**: built-in translations and bundled icons always win, so a plugin cannot restyle `codex`, `claude`, etc.
- Auth Files tabs, auth-file cards, the "Delete <provider>" action/confirmation and the OAuth editor provider picker pass the branding. `ProviderTabs` / `AuthFileCard` take it as an optional prop, like `resolvedTheme`.
- Provider icons render through a new `FallbackImage` so an unreachable remote logo degrades to the existing placeholder instead of a broken image.

The provider key normalization and the "first plugin wins" rule match `buildPluginOAuthProviderCards` in `OAuthPage`.

## Verification

- `bun run verify`: 444 tests pass (3 new in `tests/pluginProviderBranding.test.ts`), lint clean for the touched files, single-file build OK.
- New tests cover branding collection (inactive/non-OAuth plugins skipped, first plugin wins, key normalization), the built-in precedence in `getTypeLabel`/`getAuthFileIcon`, and static rendering of `ProviderTabs` with a plugin logo.
- Browser: built panel served locally and connected to a CLIProxyAPI **v7.2.157** instance running a plugin OAuth provider (`muse-code`, logo `https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/meta.svg`). Auth Files now shows the tab "Muse Code" with the logo, the card avatar with the logo, the badge "MUSE CODE" and "Delete Muse Code". Built-in providers (Antigravity, Claude, Codex, xAI) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Z5Lm84JzzZ8QtcWeenkL1
